### PR TITLE
Remove last traces of libcurl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
         - ninja-build
         - python3
         - gettext
-        - libcurl4-openssl-dev
         - libicu-dev
         - qt5-default
         - libsqlite3-dev
@@ -26,7 +25,6 @@ jobs:
         - ninja-build
         - python3
         - gettext
-        - libcurl4-openssl-dev
         - libicu-dev
         - qt5-default
         - libsqlite3-dev
@@ -45,7 +43,6 @@ jobs:
           - ninja
           - python3
           - gettext
-          - curl
           - icu4c
           - qt
           - readline

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -56,10 +56,6 @@ set(FREECIV_C11_THR FALSE)
 set(FREECIV_HAVE_TINYCTHR FALSE)
 
 # Required for utility
-if (NOT EMSCRIPTEN)
-  find_package(CURL REQUIRED)
-  set(HAVE_CURL TRUE)
-endif()
 find_package(ICU COMPONENTS uc REQUIRED)
 find_package(Iconv)
 if(Iconv_FOUND)

--- a/tools/fcmp/download.h
+++ b/tools/fcmp/download.h
@@ -15,6 +15,11 @@
 
 #include <functional>
 
+// Qt
+#include <QObject>
+
+#include "netfile.h"
+
 /* modinst */
 #include "modinst.h"
 
@@ -25,23 +30,20 @@
 
 #define FCMP_CONTROLD ".control"
 
-using dl_msg_callback = std::function<void(const char *msg)>;
+using dl_msg_callback = nf_errmsg;
 using dl_pb_callback = std::function<void(int downloaded, int max)>;
 
 const char *download_modpack(const char *URL, const struct fcmp_params *fcmp,
-                             const dl_msg_callback& mcb, const dl_pb_callback& pbcb);
+                             const dl_msg_callback &mcb,
+                             const dl_pb_callback &pbcb);
 
-using modpack_list_setup_cb = std::function<void(const char *name, const char *URL,
-                                      const char *version,
-                                      const char *license,
-                                      enum modpack_type type,
-                                      const char *subtype,
-                                      const char *notes)>;
+using modpack_list_setup_cb = std::function<void(
+    const char *name, const char *URL, const char *version,
+    const char *license, enum modpack_type type, const char *subtype,
+    const char *notes)>;
 
 const char *download_modpack_list(const struct fcmp_params *fcmp,
-                                  const modpack_list_setup_cb& cb,
-                                  const dl_msg_callback& mcb);
-
-
+                                  const modpack_list_setup_cb &cb,
+                                  const dl_msg_callback &mcb);
 
 #endif /* FC__MODPACK_DOWNLOAD_H */

--- a/tools/fcmp/mpcli.cpp
+++ b/tools/fcmp/mpcli.cpp
@@ -17,6 +17,10 @@
 
 #include <stdlib.h>
 
+// Qt
+#include <QCoreApplication>
+#include <QString>
+
 /* utility */
 #include "fc_cmdline.h"
 #include "fciconv.h"
@@ -40,7 +44,10 @@ struct fcmp_params fcmp = {
 /**********************************************************************/ /**
    Progress indications from downloader
  **************************************************************************/
-static void msg_callback(const char *msg) { log_normal("%s", msg); }
+static void msg_callback(const QString &msg)
+{
+  log_normal("%s", msg.toLocal8Bit().data());
+}
 
 /**********************************************************************/ /**
    Build main modpack list view
@@ -90,6 +97,8 @@ static void setup_modpack_list(const char *name, const char *URL,
  **************************************************************************/
 int main(int argc, char *argv[])
 {
+  QCoreApplication app(argc, argv);
+
   int ui_options;
 
   fcmp_init();

--- a/tools/fcmp/mpgui_qt.cpp
+++ b/tools/fcmp/mpgui_qt.cpp
@@ -71,11 +71,11 @@ static void setup_modpack_list(const char *name, const char *URL,
                                const char *version, const char *license,
                                enum modpack_type type, const char *subtype,
                                const char *notes);
-static void msg_callback(const char *msg);
-static void msg_callback_thr(const char *msg);
+static void msg_callback(const QString &msg);
+static void msg_callback_thr(const QString &msg);
 static void progress_callback_thr(int downloaded, int max);
 
-static void gui_download_modpack(QString URL);
+static void gui_download_modpack(const QString &url);
 
 /**********************************************************************/ /**
    Entry point for whole freeciv-mp-qt program.
@@ -158,12 +158,15 @@ int main(int argc, char **argv)
 /**********************************************************************/ /**
    Progress indications from downloader
  **************************************************************************/
-static void msg_callback(const char *msg) { gui->display_msg(msg); }
+static void msg_callback(const QString &msg) { gui->display_msg(msg); }
 
 /**********************************************************************/ /**
    Progress indications from downloader thread
  **************************************************************************/
-static void msg_callback_thr(const char *msg) { gui->display_msg_thr(msg); }
+static void msg_callback_thr(const QString &msg)
+{
+  gui->display_msg_thr(msg);
+}
 
 /**********************************************************************/ /**
    Progress indications from downloader
@@ -270,7 +273,7 @@ void mpgui::setup(QWidget *central, struct fcmp_params *params)
 /**********************************************************************/ /**
    Display status message
  **************************************************************************/
-void mpgui::display_msg(QString msg)
+void mpgui::display_msg(const QString &msg)
 {
   QByteArray msg_bytes = msg.toLocal8Bit();
 
@@ -281,9 +284,9 @@ void mpgui::display_msg(QString msg)
 /**********************************************************************/ /**
    Display status message from another thread
  **************************************************************************/
-void mpgui::display_msg_thr(const char *msg)
+void mpgui::display_msg_thr(const QString &msg)
 {
-  emit display_msg_thr_signal(QString::fromUtf8(msg));
+  emit display_msg_thr_signal(msg);
 }
 
 /**********************************************************************/ /**
@@ -306,7 +309,7 @@ void mpgui::progress_thr(int downloaded, int max)
 /**********************************************************************/ /**
    Download modpack from given URL
  **************************************************************************/
-static void gui_download_modpack(QString URL)
+static void gui_download_modpack(const QString &URL)
 {
   if (worker != nullptr) {
     if (worker->isRunning()) {
@@ -317,7 +320,8 @@ static void gui_download_modpack(QString URL)
     worker = new mpqt_worker;
   }
 
-  worker->download(URL, gui, &fcmp, msg_callback_thr, progress_callback_thr);
+  worker->download(QUrl::fromUserInput(URL), gui, &fcmp, msg_callback_thr,
+                   progress_callback_thr);
 }
 
 /**********************************************************************/ /**

--- a/tools/fcmp/mpgui_qt.h
+++ b/tools/fcmp/mpgui_qt.h
@@ -50,7 +50,7 @@ class mpgui : public QObject {
 
 public:
   void setup(QWidget *central, struct fcmp_params *fcmp);
-  void display_msg_thr(const char *msg);
+  void display_msg_thr(const QString &msg);
   void progress_thr(int downloaded, int max);
   void setup_list(const char *name, const char *URL, const char *version,
                   const char *license, enum modpack_type type,
@@ -63,7 +63,7 @@ signals:
   void refresh_list_versions_thr_signal();
 
 public slots:
-  void display_msg(QString msg);
+  void display_msg(const QString &msg);
   void progress(int downloaded, int max);
   void refresh_list_versions();
 

--- a/tools/fcmp/mpgui_qt_worker.cpp
+++ b/tools/fcmp/mpgui_qt_worker.cpp
@@ -41,35 +41,32 @@
  **************************************************************************/
 void mpqt_worker::run()
 {
-  const char *errmsg;
-  QByteArray url_bytes;
-
-  url_bytes = URL.toUtf8();
-  errmsg =
-      download_modpack(url_bytes.data(), fcmp, msg_callback, pb_callback);
+  auto url_bytes = m_url.toEncoded();
+  const char *errmsg = download_modpack(url_bytes.data(), m_fcmp,
+                                        m_msg_callback, m_pb_callback);
 
   if (errmsg != nullptr) {
-    msg_callback(errmsg);
+    m_msg_callback(errmsg);
   } else {
-    msg_callback(_("Ready"));
+    m_msg_callback(_("Ready"));
   }
 
-  gui->refresh_list_versions_thr();
+  m_gui->refresh_list_versions_thr();
 }
 
 /**********************************************************************/ /**
    Start thread to download and install given modpack.
  **************************************************************************/
-void mpqt_worker::download(QString URL_in, class mpgui *gui_in,
-                           struct fcmp_params *fcmp_in,
-                           dl_msg_callback msg_callback_in,
-                           dl_pb_callback pb_callback_in)
+void mpqt_worker::download(const QUrl &url, class mpgui *gui,
+                           struct fcmp_params *fcmp,
+                           const dl_msg_callback &msg_callback,
+                           const dl_pb_callback &pb_callback)
 {
-  URL = URL_in;
-  gui = gui_in;
-  fcmp = fcmp_in;
-  msg_callback = msg_callback_in;
-  pb_callback = pb_callback_in;
+  m_url = url;
+  m_gui = gui;
+  m_fcmp = fcmp;
+  m_msg_callback = msg_callback;
+  m_pb_callback = pb_callback;
 
   start();
 }

--- a/tools/fcmp/mpgui_qt_worker.h
+++ b/tools/fcmp/mpgui_qt_worker.h
@@ -21,6 +21,7 @@
 // Qt
 #include <QString>
 #include <QThread>
+#include <QUrl>
 
 // tools
 #include "download.h"
@@ -33,16 +34,16 @@ class mpqt_worker : public QThread {
 
 public:
   void run();
-  void download(QString URL_in, class mpgui *gui_in,
-                struct fcmp_params *fcmp_in, dl_msg_callback msg_callback_in,
-                dl_pb_callback pb_callback_in);
+  void download(const QUrl &url, mpgui *gui, fcmp_params *fcmp,
+                const dl_msg_callback &msg_callback,
+                const dl_pb_callback &pb_callback);
 
 private:
-  QString URL;
-  class mpgui *gui;
-  struct fcmp_params *fcmp;
-  dl_msg_callback msg_callback;
-  dl_pb_callback pb_callback;
+  QUrl m_url;
+  mpgui *m_gui;
+  fcmp_params *m_fcmp;
+  dl_msg_callback m_msg_callback;
+  dl_pb_callback m_pb_callback;
 };
 
 #endif // FC__MPGUI_QT_WORKER_H

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(
   log.cpp
   mem.cpp
   netintf.cpp
+  netfile.cpp
   rand.cpp
   registry.cpp
   registry_ini.cpp
@@ -68,17 +69,12 @@ add_library(
   ${CMAKE_CURRENT_BINARY_DIR}/specenum_gen.h
   ${CMAKE_CURRENT_BINARY_DIR}/version_gen.h
 )
-if (HAVE_CURL)
-  target_sources(utility PRIVATE netfile.cpp)
-endif()
 
 target_include_directories(utility PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(utility PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(utility PRIVATE ${CURL_INCLUDE_DIRS})
 
-target_link_libraries(utility PUBLIC Qt5::Core)
+target_link_libraries(utility PUBLIC Qt5::Core Qt5::Network)
 target_link_libraries(utility PUBLIC Threads::Threads)
-target_link_libraries(utility PRIVATE ${CURL_LIBRARIES})
 target_link_libraries(utility PRIVATE ICU::uc)
 if (WIN32 OR MSYS OR MINGW)
   target_link_libraries(utility PRIVATE ws2_32 wsock32)

--- a/utility/netfile.cpp
+++ b/utility/netfile.cpp
@@ -15,174 +15,115 @@
 #include <fc_config.h>
 #endif
 
-#ifndef __EMSCRIPTEN__
-
-#include <curl/curl.h>
-
-#ifdef FREECIV_MSWINDOWS
-#include <windows.h>
-#endif
+#include <memory>
 
 // Qt
-#include <QByteArray>
+#include <QBuffer>
+#include <QEventLoop>
+#include <QFile>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 
 /* utility */
 #include "fcintl.h"
 #include "ioz.h"
-#include "mem.h"
-#include "rand.h"
 #include "registry.h"
 
 #include "netfile.h"
-
-static char error_buf_curl[CURL_ERROR_SIZE];
-
-/*******************************************************************/ /**
-   Set handle to usable state.
- ***********************************************************************/
-static CURL *netfile_init_handle(void)
-{
-  /* Consecutive transfers can use same handle for better performance */
-  static CURL *handle = NULL;
-
-  if (handle == NULL) {
-    handle = curl_easy_init();
-  } else {
-    curl_easy_reset(handle);
-  }
-
-  error_buf_curl[0] = '\0';
-  curl_easy_setopt(handle, CURLOPT_ERRORBUFFER, error_buf_curl);
-
-#ifdef CUSTOM_CACERT_PATH
-  curl_easy_setopt(handle, CURLOPT_CAINFO, CUSTOM_CACERT_PATH);
-#endif /* CUSTOM_CERT_PATH */
-
-  return handle;
-}
-
-/*******************************************************************/ /**
-   Curl write callback to store received file to memory.
- ***********************************************************************/
-static size_t netfile_memwrite_cb(char *ptr, size_t size, size_t nmemb,
-                                  const void *userdata)
-{
-  struct netfile_write_cb_data *data =
-      (struct netfile_write_cb_data *) userdata;
-
-  if (size > 0) {
-    data->mem = static_cast<char *>(
-        fc_realloc(data->mem, data->size + size * nmemb));
-    memcpy(data->mem + data->size, ptr, size * nmemb);
-    data->size += size * nmemb;
-  }
-
-  return size * nmemb;
-}
 
 /*******************************************************************/ /**
    Fetch file from given URL to given file stream. This is core
    function of netfile module.
  ***********************************************************************/
-static bool
-netfile_download_file_core(const char *URL, FILE *fp,
-                           struct netfile_write_cb_data *mem_data,
-                           nf_errmsg cb, const void *data)
+static bool netfile_download_file_core(const QUrl &url, QIODevice *out,
+                                       const nf_errmsg &cb)
 {
-  CURLcode curlret;
-  struct curl_slist *headers = NULL;
-  static CURL *handle;
-  bool ret = TRUE;
+  fc_assert_ret_val(out != nullptr, false);
 
-  handle = netfile_init_handle();
+  // Create a network manager
+  auto manager = std::make_unique<QNetworkAccessManager>();
 
-  headers =
-      curl_slist_append(headers, "User-Agent: Freeciv/" VERSION_STRING);
+  // Initiate the request
+  auto request = QNetworkRequest(url);
+  request.setHeader(QNetworkRequest::UserAgentHeader,
+                    QLatin1String("Freeciv/" VERSION_STRING));
 
-  curl_easy_setopt(handle, CURLOPT_URL, URL);
-  if (mem_data != NULL) {
-    mem_data->mem = NULL;
-    mem_data->size = 0;
-    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, netfile_memwrite_cb);
-    curl_easy_setopt(handle, CURLOPT_WRITEDATA, mem_data);
-  } else {
-    curl_easy_setopt(handle, CURLOPT_WRITEDATA, fp);
-  }
-  curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
-  curl_easy_setopt(handle, CURLOPT_FAILONERROR, 1);
+  auto reply = manager->get(request);
+  bool retval = true;
 
-  curlret = curl_easy_perform(handle);
+  QEventLoop loop; // Need an event loop for QNetworkReply to work
 
-  curl_slist_free_all(headers);
+  // Data are available
+  QObject::connect(reply, &QNetworkReply::readyRead, [&]() {
+    while (reply->bytesAvailable() > 0) {
+      out->write(reply->read(1 << 20)); // Read max 1MB at a time
+    }
+  });
 
-  if (curlret != CURLE_OK) {
-    if (cb != NULL) {
-      char buf[2048 + CURL_ERROR_SIZE];
+  // It's over -- for good or bad reasons
+  QObject::connect(reply, &QNetworkReply::finished, [&] {
+    if (reply->error() != QNetworkReply::NoError) {
+      // Error
+      retval = false;
 
-      fc_snprintf(buf, sizeof(buf),
-                  /* TRANS: first %s is URL, second is Curl error message
-                   * (not in Freeciv translation domain) */
-                  _("Failed to fetch %s: %s"), URL,
-                  error_buf_curl[0] != '\0' ? error_buf_curl
-                                            : curl_easy_strerror(curlret));
-      cb(buf, data);
+      if (cb != nullptr) {
+
+        // TRANS: %1 is URL, %2 is Curl error message (not in Freeciv
+        // translation domain)
+        auto msg = QString::fromUtf8(_("Failed to fetch %1: %2"))
+                       .arg(url.toDisplayString())
+                       .arg(reply->errorString());
+        cb(msg);
+      }
     }
 
-    ret = FALSE;
-  }
+    // Clean up
+    reply->deleteLater();
+    manager->deleteLater();
 
-  return ret;
+    loop.quit();
+  });
+
+  // Perform the request
+  loop.exec();
+
+  return retval;
 }
 
 /*******************************************************************/ /**
    Fetch section file from net
  ***********************************************************************/
-struct section_file *netfile_get_section_file(const char *URL, nf_errmsg cb,
-                                              const void *data)
+section_file *netfile_get_section_file(const QUrl &url, const nf_errmsg &cb)
 {
-  bool success;
-  struct section_file *out = NULL;
-  struct netfile_write_cb_data mem_data;
-  fz_FILE *file;
+  QBuffer buffer;
+  buffer.open(QIODevice::WriteOnly);
 
-  success = netfile_download_file_core(URL, NULL, &mem_data, cb, data);
-
-  if (success) {
-    file = fz_from_memory(QByteArray(mem_data.mem, mem_data.size));
-
-    out = secfile_from_stream(file, TRUE);
+  // Try to download into the buffer
+  if (netfile_download_file_core(url, &buffer, cb)) {
+    auto file = fz_from_memory(buffer.buffer());
+    // Parse
+    return secfile_from_stream(file, TRUE);
   }
 
-  return out;
+  return nullptr;
 }
 
 /*******************************************************************/ /**
    Fetch file from given URL and save as given filename.
  ***********************************************************************/
-bool netfile_download_file(const char *URL, const char *filename,
-                           nf_errmsg cb, const void *data)
+bool netfile_download_file(const QUrl &url, const char *filename,
+                           const nf_errmsg &cb)
 {
-  bool success;
-  FILE *fp;
-
-  fp = fc_fopen(filename, "w+b");
-
-  if (fp == NULL) {
+  QFile out(QString::fromUtf8(filename));
+  if (!out.open(QIODevice::WriteOnly)) {
     if (cb != NULL) {
-      char buf[2048];
-
-      fc_snprintf(buf, sizeof(buf), _("Could not open %s for writing"),
-                  filename);
-      cb(buf, data);
+      auto msg = QString::fromUtf8(_("Could not open %1 for writing"))
+                     .arg(filename);
+      cb(msg);
     }
-    return FALSE;
+    return false;
   }
 
-  success = netfile_download_file_core(URL, fp, NULL, cb, data);
-
-  fclose(fp);
-
-  return success;
+  return netfile_download_file_core(url, &out, cb);
 }
-
-#endif /* __EMSCRIPTEN__ */

--- a/utility/netfile.h
+++ b/utility/netfile.h
@@ -14,17 +14,19 @@
 #ifndef FC__NETFILE_H
 #define FC__NETFILE_H
 
-struct netfile_write_cb_data {
-  char *mem;
-  int size;
-};
+#include <functional>
 
-typedef void (*nf_errmsg)(const char *msg, const void *data);
+// Forward declarations
+class QString;
+class QUrl;
 
-struct section_file *netfile_get_section_file(const char *URL, nf_errmsg cb,
-                                              const void *data);
+struct section_file;
 
-bool netfile_download_file(const char *URL, const char *filename,
-                           nf_errmsg cb, const void *data);
+using nf_errmsg = std::function<void(const QString &message)>;
+
+section_file *netfile_get_section_file(const QUrl &url, const nf_errmsg &cb);
+
+bool netfile_download_file(const QUrl &url, const char *filename,
+                           const nf_errmsg &cb);
 
 #endif /* FC__NETFILE_H */


### PR DESCRIPTION
Use Qt Network instead. This means that downloading modpacks from local files or eg ftp servers doesn't work anymore. Local files are maybe annoying, but nowadays http is ruling the Web.

This ended up mixed with some cleanup of the modpack installer code. It had clearly been written by someone not very familiar with C++.