### PR TITLE
Fixed governor crash and assert fail

### DIFF
--- a/client/global_worklist.cpp
+++ b/client/global_worklist.cpp
@@ -228,8 +228,7 @@ void global_worklist_destroy(struct global_worklist *pgwl)
     int i;
 
     for (i = 0; i < pgwl->unbuilt.length; i++) {
-      // sveinung
-      // puni_name = pgwl->unbuilt.entries + i;
+      puni_name = pgwl->unbuilt.entries + i;
       puni_name->kind = pgwl->unbuilt.entries[i].kind;
       puni_name->name = pgwl->unbuilt.entries[i].name;
       free(puni_name->kind);

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -826,7 +826,7 @@ int get_unittype_bonus(const struct player *pplayer,
     return 0;
   }
 
-  fc_assert_ret_val(pplayer != NULL && punittype != NULL, 0);
+  fc_assert_ret_val(punittype != NULL, 0);
 
   if (ptile != NULL) {
     pcity = tile_city(ptile);


### PR DESCRIPTION
It fixes governor crash
and assert fail - it removess assert but it was introduced with 6f5d4f4 when adding "utype_build_shield_cost" which has only those arguments(const struct city *pcity, const struct unit_type *punittype) and homeless units have no way to find pplayer by pcity.