### PR TITLE
Fix a crash on server exit

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -323,6 +323,7 @@ server::~server()
   if (m_between_turns_timer != nullptr) {
     timer_destroy(m_between_turns_timer);
   }
+  server_quit();
 }
 
 /*************************************************************************/ /**
@@ -845,7 +846,7 @@ bool server::shut_game_down()
 
   if (game.info.timeout == -1 || srvarg.exit_on_end) {
     /* For autogames or if the -e option is specified, exit the server. */
-    server_quit();
+    deleteLater();
     return false;
   }
 
@@ -881,7 +882,7 @@ void server::quit_idle()
 
   if (srvarg.exit_on_end) {
     // No need for anything more; just quit.
-    server_quit();
+    deleteLater();
   } else {
     force_end_of_sniff = true;
     update_game_state();

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -20,6 +20,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// Qt
+#include <QCoreApplication>
+
 #ifdef FREECIV_HAVE_LIBREADLINE
 #include <readline/readline.h>
 #endif
@@ -4333,7 +4336,7 @@ static bool quit_game(struct connection *caller, bool check)
 {
   if (!check) {
     cmd_reply(CMD_QUIT, caller, C_OK, _("Goodbye."));
-    server_quit();
+    QCoreApplication::quit();
   }
   return TRUE;
 }


### PR DESCRIPTION
When quitting with "quit", the server was still reading input after the connections were closed, causing a use-after-free. Move closing the connections to the server destructor, and use `QCoreApplication::quit()` to exit.