### PR TITLE
fcmp: initialize logging first

### DIFF
--- a/tools/fcmp/mpcli.cpp
+++ b/tools/fcmp/mpcli.cpp
@@ -100,10 +100,10 @@ int main(int argc, char *argv[])
   QCoreApplication app(argc, argv);
   QCoreApplication::setApplicationVersion(VERSION_STRING);
 
-  fcmp_init();
-
   // Delegate option parsing to the common function.
   fcmp_parse_cmdline(app);
+
+  fcmp_init();
 
   const char *rev_ver;
 

--- a/tools/fcmp/mpgui_qt.cpp
+++ b/tools/fcmp/mpgui_qt.cpp
@@ -86,10 +86,10 @@ int main(int argc, char **argv)
   QApplication app(argc, argv);
   QCoreApplication::setApplicationVersion(VERSION_STRING);
 
-  fcmp_init();
-
   // Delegate option parsing to the common function.
   fcmp_parse_cmdline(app);
+
+  fcmp_init();
 
   // Start
   mpgui_main *main_window;


### PR DESCRIPTION
Initializing the rest may print log messages.

Closes #107.