### PR TITLE
Reduced packet diplstate

### DIFF
--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -24,7 +24,7 @@ Syntax:
 
  Typedef lines:
  ==============
- 
+
   Start with "type" and have the format "type <alias> = <src>". You
   can now use <alias> at every place a type is expected. Nested type
   defs are possible.
@@ -37,7 +37,7 @@ Syntax:
   A packet definition starts with a header line, contains variable
   field declarations, and ends with a single line containing the word
   "end".
-   
+
    PACKET_<PACKET_NAME>=<packet num>; [<packet flags>]
      <type1> <field1>; [<field flags>]
      <type2> <field2>; [<field flags>]
@@ -65,7 +65,7 @@ Syntax:
     PACKET_PROCESSING_FINISHED, PACKET_SERVER_JOIN_REQ and
     PACKET_SERVER_JOIN_REPLY are excluded here. These packets should
     never change their number. The packet number can be freely chosen
-    as long as it is below 65536 and unique. For backward compatibility  
+    as long as it is below 65536 and unique. For backward compatibility
     reasons, packets used for the initial protocol (notably before
     checking the capabilities) must be in range 0-255.
 
@@ -129,7 +129,7 @@ Syntax:
      as a parameter, it takes the fields of the packet as parameters.
 
      lsend: request the creation of a lsend_packet_* function.  This
-     function sends to list of connections instead of just one 
+     function sends to list of connections instead of just one
      connection, which is the case for the other send functions.
 
      cs: a packet which is sent from the client to the server
@@ -967,7 +967,7 @@ PACKET_PLAYER_ATTRIBUTE_CHUNK = 58; pre-send, sc, cs, handle-via-packet
   MEMORY data[ATTRIBUTE_CHUNK_SIZE:chunk_length];
 end
 
-PACKET_PLAYER_DIPLSTATE = 59; sc
+PACKET_PLAYER_DIPLSTATE = 59; sc, is-game-info
   UINT32 diplstate_id; key
   PLAYER plr1;
   PLAYER plr2;
@@ -1323,7 +1323,7 @@ PACKET_SPACESHIP_PLACE = 136; cs, dsend
   PLACE_TYPE type;
 
   # Meaning of num:
-  #  - if type == SSHIP_ACT_PLACE_STRUCTURAL: 
+  #  - if type == SSHIP_ACT_PLACE_STRUCTURAL:
   #      index to sship->structure[]
   #  - if type != SSHIP_ACT_PLACE_STRUCTURAL:
   #      new value for sship->fuel etc; should be just one more than
@@ -1574,7 +1574,7 @@ PACKET_RULESET_NATION = 148; sc, lsend
 
   BOOL is_playable;
   BARBARIAN_TYPE barbarian_type;
-  
+
   UINT8 nsets;
   UINT8 sets[MAX_NUM_NATION_SETS:nsets];
 
@@ -1605,7 +1605,7 @@ PACKET_RULESET_STYLE = 239; sc, lsend
 end
 
 PACKET_RULESET_CITY = 149; sc, lsend
-  UINT8 style_id; 
+  UINT8 style_id;
   STRING name[MAX_LEN_NAME];
   STRING rule_name[MAX_LEN_NAME];
   STRING citizens_graphic[MAX_LEN_NAME];
@@ -1854,7 +1854,7 @@ PACKET_RULESET_ACTION_AUTO = 252; sc, lsend
 end
 
 PACKET_RULESET_MUSIC = 240; sc, lsend
-  UINT8  id; 
+  UINT8  id;
   STRING music_peaceful[MAX_LEN_NAME];
   STRING music_combat[MAX_LEN_NAME];
   UINT8 reqs_count;
@@ -1933,7 +1933,7 @@ PACKET_RULESET_DESCRIPTION_PART = 247; sc, lsend
 end
 
 /*********************************************************
- Below are the packets that control single-player mode.  
+ Below are the packets that control single-player mode.
 *********************************************************/
 PACKET_SINGLE_WANT_HACK_REQ = 160; cs, handle-per-conn, handle-via-packet
  STRING token[MAX_LEN_NAME];
@@ -2262,7 +2262,7 @@ PACKET_EDIT_PLAYER_REMOVE = 215; cs, handle-per-conn, dsend
 end
 
 PACKET_EDIT_PLAYER = 216; cs, handle-per-conn, lsend
-  PLAYER id; key 
+  PLAYER id; key
   STRING name[MAX_LEN_NAME];
   STRING username[MAX_LEN_NAME];
   STRING ranked_username[MAX_LEN_NAME];


### PR DESCRIPTION
fixed compilation of packet statistics - it must be set in source file ( it wasnt updated for ages, replaced log_debugs with printfs there)
enable is-game-info for packet diplstate
