### PR TITLE
Allow multi pick players in pregame

### DIFF
--- a/client/gui-qt/page_pregame.ui
+++ b/client/gui-qt/page_pregame.ui
@@ -56,6 +56,18 @@
     </item>
     <item row="0" column="0" colspan="3">
      <widget class="QTreeWidget" name="start_players_tree">
+      <property name="contextMenuPolicy">
+       <enum>Qt::CustomContextMenu</enum>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
+      </property>
+      <property name="rootIsDecorated">
+       <bool>false</bool>
+      </property>
       <column>
        <property name="text">
         <string notr="true">1</string>


### PR DESCRIPTION
Mutlimenu pick in pregame:
Allows selecting many players at once and moving to 1 team or setting their difficulty with single click.
