### PR TITLE
Reconfigure fonts if freeciv settings are lost

### DIFF
--- a/client/gui-qt/fc_client.cpp
+++ b/client/gui-qt/fc_client.cpp
@@ -373,9 +373,6 @@ void fc_client::read_settings()
 {
   QSettings s(QSettings::IniFormat, QSettings::UserScope,
               QStringLiteral("freeciv-qt-client"));
-  if (!s.contains(QStringLiteral("Fonts-set"))) {
-    configure_fonts();
-  }
   if (s.contains(QStringLiteral("Chat-fx-size"))) {
     qt_settings.chat_fwidth =
         s.value(QStringLiteral("Chat-fx-size")).toFloat();

--- a/client/gui-qt/gui_main.cpp
+++ b/client/gui-qt/gui_main.cpp
@@ -104,6 +104,7 @@ void qtg_ui_main()
       /* We're using fresh defaults for this version of this client,
        * so prevent any future migrations from other versions */
       gui_options.gui_qt_migrated_from_2_5 = true;
+      configure_fonts();
     } else if (!gui_options.gui_qt_migrated_from_2_5) {
       migrate_options_from_2_5();
     }


### PR DESCRIPTION
Use configure_fonts() to pick fonts when freeciv settings were lost or jsut need to be created.