### PR TITLE
Fix drawing blocked tiles and grid in city mode

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -852,23 +852,22 @@ struct unit *find_visible_unit(struct tile *ptile)
        3: any transporter
        4: any unit
      (always return first in stack). */
-  unit_list_iterate(ptile->units,
-                    punit) if (unit_owner(punit) == client.conn.playing)
+  unit_list_iterate(ptile->units, punit)
   {
-    if (!unit_transported(punit)) {
-      if (get_transporter_capacity(punit) > 0) {
-        return punit;
-      } else if (!panyowned) {
-        panyowned = punit;
+    if (unit_owner(punit) == client.conn.playing) {
+      if (!unit_transported(punit)) {
+        if (get_transporter_capacity(punit) > 0) {
+          return punit;
+        } else if (!panyowned) {
+          panyowned = punit;
+        }
       }
-    }
-  }
-  else if (!ptptother && !unit_transported(punit))
-  {
-    if (get_transporter_capacity(punit) > 0) {
-      ptptother = punit;
-    } else if (!panyother) {
-      panyother = punit;
+    } else if (!ptptother && !unit_transported(punit)) {
+      if (get_transporter_capacity(punit) > 0) {
+        ptptother = punit;
+      } else if (!panyother) {
+        panyother = punit;
+      }
     }
   }
   unit_list_iterate_end;

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -980,7 +980,7 @@ void put_one_element(QPixmap *pcanvas, enum mapview_layer layer,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
                      const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y, const struct city *citymode,
+                     int canvas_x, int canvas_y,
                      const struct unit_type *putype)
 {
   struct drawn_sprite tile_sprs[80];
@@ -988,7 +988,7 @@ void put_one_element(QPixmap *pcanvas, enum mapview_layer layer,
   bool city_unit = false;
   int dummy_x, dummy_y;
   int count = fill_sprite_array(tileset, tile_sprs, layer, ptile, pedge,
-                                pcorner, punit, pcity, citymode, putype);
+                                pcorner, punit, pcity, putype);
   bool fog = (ptile && gui_options.draw_fog_of_war
               && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile));
   if (ptile) {
@@ -1023,7 +1023,7 @@ void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
   mapview_layer_iterate(layer)
   {
     put_one_element(pcanvas, layer, NULL, NULL, NULL, punit, NULL, canvas_x,
-                    canvas_y, NULL, NULL);
+                    canvas_y, NULL);
   }
   mapview_layer_iterate_end;
 }
@@ -1039,7 +1039,7 @@ void put_unittype(const struct unit_type *putype, QPixmap *pcanvas,
   mapview_layer_iterate(layer)
   {
     put_one_element(pcanvas, layer, NULL, NULL, NULL, NULL, NULL, canvas_x,
-                    canvas_y, NULL, putype);
+                    canvas_y, putype);
   }
   mapview_layer_iterate_end;
 }
@@ -1057,7 +1057,7 @@ void put_city(struct city *pcity, QPixmap *pcanvas, int canvas_x,
   mapview_layer_iterate(layer)
   {
     put_one_element(pcanvas, layer, NULL, NULL, NULL, NULL, pcity, canvas_x,
-                    canvas_y, NULL, NULL);
+                    canvas_y, NULL);
   }
   mapview_layer_iterate_end;
 }
@@ -1077,7 +1077,7 @@ void put_terrain(struct tile *ptile, QPixmap *pcanvas, int canvas_x,
   mapview_layer_iterate(layer)
   {
     put_one_element(pcanvas, layer, ptile, NULL, NULL, NULL, NULL, canvas_x,
-                    canvas_y, NULL, NULL);
+                    canvas_y, NULL);
   }
   mapview_layer_iterate_end;
 }
@@ -1197,15 +1197,14 @@ void put_nuke_mushroom_pixmaps(struct tile *ptile)
    Draw some or all of a tile onto the canvas.
  ****************************************************************************/
 static void put_one_tile(QPixmap *pcanvas, enum mapview_layer layer,
-                         struct tile *ptile, int canvas_x, int canvas_y,
-                         const struct city *citymode)
+                         struct tile *ptile, int canvas_x, int canvas_y)
 {
   if (client_tile_get_known(ptile) != TILE_UNKNOWN
       || (editor_is_active() && editor_tile_is_selected(ptile))) {
-    struct unit *punit = get_drawable_unit(tileset, ptile, citymode);
+    struct unit *punit = get_drawable_unit(tileset, ptile);
 
     put_one_element(pcanvas, layer, ptile, NULL, NULL, punit,
-                    tile_city(ptile), canvas_x, canvas_y, citymode, NULL);
+                    tile_city(ptile), canvas_x, canvas_y, NULL);
   }
 }
 
@@ -1402,13 +1401,13 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
       const int cx = gui_x - mapview.gui_x0, cy = gui_y - mapview.gui_y0;
 
       if (ptile) {
-        put_one_tile(mapview.store, layer, ptile, cx, cy, NULL);
+        put_one_tile(mapview.store, layer, ptile, cx, cy);
       } else if (pedge) {
         put_one_element(mapview.store, layer, NULL, pedge, NULL, NULL, NULL,
-                        cx, cy, NULL, NULL);
+                        cx, cy, NULL);
       } else if (pcorner) {
         put_one_element(mapview.store, layer, NULL, NULL, pcorner, NULL,
-                        NULL, cx, cy, NULL, NULL);
+                        NULL, cx, cy, NULL);
       } else {
         /* This can happen, for instance for unreal tiles. */
       }

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -273,7 +273,7 @@ void put_one_element(QPixmap *pcanvas, enum mapview_layer layer,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
                      const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y, const struct city *citymode,
+                     int canvas_x, int canvas_y,
                      const struct unit_type *putype);
 
 void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -5163,11 +5163,11 @@ bool unit_drawn_with_city_outline(const struct unit *punit, bool check_focus)
 /************************************************************************/ /**
    Fill in the grid sprites for the given tile, city, and unit.
  ****************************************************************************/
-static int fill_grid_sprite_array(
-    const struct tileset *t, struct drawn_sprite *sprs,
-    const struct tile *ptile, const struct tile_edge *pedge,
-    const struct tile_corner *pcorner, const struct unit *punit,
-    const struct city *pcity, const struct city *citymode)
+static int fill_grid_sprite_array(const struct tileset *t,
+                                  struct drawn_sprite *sprs,
+                                  const struct tile *ptile,
+                                  const struct tile_edge *pedge,
+                                  const struct city *citymode)
 {
   struct drawn_sprite *saved_sprs = sprs;
 
@@ -5669,8 +5669,7 @@ int fill_sprite_array(struct tileset *t, struct drawn_sprite *sprs,
 
   case LAYER_GRID1:
     if (t->type == TS_ISOMETRIC) {
-      sprs += fill_grid_sprite_array(t, sprs, ptile, pedge, pcorner, punit,
-                                     pcity, citymode);
+      sprs += fill_grid_sprite_array(t, sprs, ptile, pedge, citymode);
     }
     break;
 
@@ -5930,8 +5929,7 @@ int fill_sprite_array(struct tileset *t, struct drawn_sprite *sprs,
 
   case LAYER_GRID2:
     if (t->type == TS_OVERHEAD) {
-      sprs += fill_grid_sprite_array(t, sprs, ptile, pedge, pcorner, punit,
-                                     pcity, citymode);
+      sprs += fill_grid_sprite_array(t, sprs, ptile, pedge, citymode);
     }
     break;
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -5170,7 +5170,6 @@ static int fill_grid_sprite_array(
     const struct city *pcity, const struct city *citymode)
 {
   struct drawn_sprite *saved_sprs = sprs;
-  struct city *xcity;
 
   if (pedge) {
     bool known[NUM_EDGE_TILES], city[NUM_EDGE_TILES];
@@ -5220,14 +5219,10 @@ static int fill_grid_sprite_array(
           worked[i] = (NULL != tile_worked(tile));
         }
       }
-      if (tile && is_any_city_dialog_open()) {
-        { // Draw city grid for main citymap
-          xcity = find_city_near_tile(tile);
-          if (xcity && xcity->client.city_opened
-              && city_base_to_city_map(&dummy_x, &dummy_y, xcity, tile)) {
-            ADD_SPRITE_SIMPLE(t->sprites.grid.selected[pedge->type]);
-          }
-        }
+      // Draw city grid for main citymap
+      if (citymode
+          && city_base_to_city_map(&dummy_x, &dummy_y, citymode, tile)) {
+        ADD_SPRITE_SIMPLE(t->sprites.grid.selected[pedge->type]);
       }
     }
     if (mapdeco_is_highlight_set(pedge->tile[0])
@@ -5446,16 +5441,12 @@ static bool is_extra_drawing_enabled(struct extra_type *pextra)
 
    pcity, if specified, gives the city.  For tile drawing this should
    generally be tile_city(ptile); otherwise it can be any city.
-
-   citymode specifies whether this is part of a citydlg.  If so some
- drawing is done differently.
  ****************************************************************************/
 int fill_sprite_array(struct tileset *t, struct drawn_sprite *sprs,
                       enum mapview_layer layer, const struct tile *ptile,
                       const struct tile_edge *pedge,
                       const struct tile_corner *pcorner,
                       const struct unit *punit, const struct city *pcity,
-                      const struct city *citymode,
                       const struct unit_type *putype)
 {
   int tileno, dir;
@@ -5475,32 +5466,7 @@ int fill_sprite_array(struct tileset *t, struct drawn_sprite *sprs,
                    && (do_draw_unit || (pcity && gui_options.draw_cities)
                        || (ptile && !gui_options.draw_terrain)));
 
-  if (citymode) {
-    int count = 0, i, cx, cy;
-    const struct tile *const *tiles = NULL;
-    bool valid = false;
-
-    if (ptile) {
-      tiles = &ptile;
-      count = 1;
-    } else if (pcorner) {
-      tiles = pcorner->tile;
-      count = NUM_CORNER_TILES;
-    } else if (pedge) {
-      tiles = pedge->tile;
-      count = NUM_EDGE_TILES;
-    }
-
-    for (i = 0; i < count; i++) {
-      if (tiles[i] && city_base_to_city_map(&cx, &cy, citymode, tiles[i])) {
-        valid = true;
-        break;
-      }
-    }
-    if (!valid) {
-      return 0;
-    }
-  }
+  const city *citymode = is_any_city_dialog_open();
 
   if (ptile && client_tile_get_known(ptile) != TILE_UNKNOWN) {
     textras = *tile_extras(ptile);
@@ -6180,16 +6146,11 @@ void toggle_focus_unit_state(struct tileset *t)
 /************************************************************************/ /**
    Find unit that we can display from given tile.
  ****************************************************************************/
-struct unit *get_drawable_unit(const struct tileset *t, struct tile *ptile,
-                               const struct city *citymode)
+struct unit *get_drawable_unit(const struct tileset *t, struct tile *ptile)
 {
   struct unit *punit = find_visible_unit(ptile);
 
   if (punit == NULL) {
-    return NULL;
-  }
-
-  if (citymode && unit_owner(punit) == city_owner(citymode)) {
     return NULL;
   }
 

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -242,7 +242,6 @@ int fill_sprite_array(struct tileset *t, struct drawn_sprite *sprs,
                       const struct tile_edge *pedge,
                       const struct tile_corner *pcorner,
                       const struct unit *punit, const struct city *pcity,
-                      const struct city *citymode,
                       const struct unit_type *putype);
 int fill_basic_terrain_layer_sprite_array(struct tileset *t,
                                           struct drawn_sprite *sprs,
@@ -253,8 +252,7 @@ int get_focus_unit_toggle_timeout(const struct tileset *t);
 void reset_focus_unit_state(struct tileset *t);
 void focus_unit_in_combat(struct tileset *t);
 void toggle_focus_unit_state(struct tileset *t);
-struct unit *get_drawable_unit(const struct tileset *t, struct tile *ptile,
-                               const struct city *citymode);
+struct unit *get_drawable_unit(const struct tileset *t, struct tile *ptile);
 bool unit_drawn_with_city_outline(const struct unit *punit,
                                   bool check_focus);
 


### PR DESCRIPTION
This always selects the correct tiles when in the city screen.