### PR TITLE
Added CMakePresets CMake 3.19 is required to use them

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,49 @@
+
+{
+    "version": 1,
+    "configurePresets": [
+        {
+            "name": "fullrelease",
+            "displayName": "Build Everythign in Release Mode",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-rel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "FREECIV_ENABLE_TOOLS": "ON",
+                "FREECIV_ENABLE_SERVER" : "ON",
+                "FREECIV_ENABLE_CLIENT" : "ON",
+                "FREECIV_ENABLE_NLS" : "ON"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Build Server and Client only in Debug Mode",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "FREECIV_ENABLE_TOOLS": "OFF",
+                "FREECIV_ENABLE_SERVER" : "ON",
+                "FREECIV_ENABLE_CLIENT" : "ON",
+                "FREECIV_ENABLE_NLS" : "OFF"
+            }
+        },
+        {
+            "name": "clazy",
+            "displayName": "Check for clazy warnings",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-clazy",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "FREECIV_ENABLE_TOOLS": "ON",
+                "FREECIV_ENABLE_SERVER" : "ON",
+                "FREECIV_ENABLE_CLIENT" : "ON",
+                "FREECIV_ENABLE_NLS" : "OFF"
+            },
+            "environment": {
+                "CXX": "clazy",
+                "CLAZY_CHECKS": "level2,no-qstring-allocations,no-ctor-missing-parent-argument,no-missing-qobject-macro"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added 3 simple example presets
use:
cmake --preset=clazy
cmake --build build-clazy -j10000