### PR TITLE
Reinterpret cast ->dynamic cast to avoid crash due to debian compile …

### DIFF
--- a/utility/inputfile.cpp
+++ b/utility/inputfile.cpp
@@ -257,8 +257,8 @@ static void inf_close_partial(struct inputfile *inf)
 
   bool error = !inf->fp->errorString().isEmpty();
   // KFilterDev returns "Unknown error" even when there's no error
-  if (reinterpret_cast<KFilterDev *>(inf->fp)) {
-    error = reinterpret_cast<KFilterDev *>(inf->fp)->error() != 0;
+  if (dynamic_cast<KFilterDev *>(inf->fp)) {
+    error = dynamic_cast<KFilterDev *>(inf->fp)->error() != 0;
   }
   if (error) {
     qCCritical(inf_category) << "Error before closing" << inf_filename(inf)

--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -835,8 +835,8 @@ bool secfile_save(const struct section_file *secfile, QString filename)
 
   bool error = !fs->errorString().isEmpty();
   // KFilterDev returns "Unknown error" even when there's no error
-  if (reinterpret_cast<KFilterDev *>(fs)) {
-    error = reinterpret_cast<KFilterDev *>(fs)->error() != 0;
+  if (dynamic_cast<KFilterDev *>(fs)) {
+    error = dynamic_cast<KFilterDev *>(fs)->error() != 0;
   }
   if (error) {
     SECFILE_LOG(secfile, NULL, "Error before closing %s: %s", real_filename,


### PR DESCRIPTION
…fail

Works on debian and doesnt crash on other distros.