### PR TITLE
Unset asprintf/vasprintf if libintl.h defines them

### DIFF
--- a/utility/fcintl.h
+++ b/utility/fcintl.h
@@ -24,6 +24,17 @@
  * we don't want defined when nls is disabled. */
 #ifdef FREECIV_HAVE_LIBINTL_H
 #include <libintl.h>
+
+// MSYS libintl redefines asprintf/vasprintf as macros, and this clashes with
+// QString::asprintf and QString::vasprintf.
+#ifdef asprintf
+#undef asprintf
+#endif
+
+#ifdef vasprintf
+#undef vasprintf
+#endif
+
 #endif
 
 // Core freeciv


### PR DESCRIPTION
Resetting asprintf/vasprintf as macros is probably non-conformant but it
is the case on MSYS. It conflicts with QString methods of the same name.
Unset the macros.

Closes issue #273