### PR TITLE
Fix server startup on Windows

### DIFF
--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -3056,7 +3056,7 @@ struct entry *section_entry_str_new(struct section *psection,
 
   if (NULL != pentry) {
     pentry->type = ENTRY_STR;
-    pentry->string.value = qstrdup(qPrintable(value));
+    pentry->string.value = qstrdup(qUtf8Printable(value));
     pentry->string.escaped = escaped;
     pentry->string.raw = false;
     pentry->string.gt_marking = false;


### PR DESCRIPTION
Ruleset encoding issues (#280) prevented the server from even starting up. Fix by using `qUtf8Printable()` instead of `qPrintable()` for the relevant string conversion.