### PR TITLE
Always use the forward slash (/) as dir separator

### DIFF
--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -241,8 +241,8 @@ bool client_start_server()
 
   // Set up the command-line parameters.
   port_buf = QString::number(internal_server_port);
-  savesdir = QStringLiteral("%1%2saves").arg(storage, DIR_SEPARATOR);
-  scensdir = QStringLiteral("%1%2scenarios").arg(storage, DIR_SEPARATOR);
+  savesdir = QStringLiteral("%1/saves").arg(storage);
+  scensdir = QStringLiteral("%1/scenarios").arg(storage);
 
   arguments << QStringLiteral("-p") << port_buf << QStringLiteral("--bind")
             << QStringLiteral("localhost") << QStringLiteral("-q")
@@ -401,8 +401,8 @@ void send_client_wants_hack(const char *filename)
 
     make_dir(sdir);
 
-    fc_snprintf(challenge_fullname, sizeof(challenge_fullname), "%s%c%s",
-                sdir, DIR_SEPARATOR_CHAR, filename);
+    fc_snprintf(challenge_fullname, sizeof(challenge_fullname), "%s/%s",
+                sdir, filename);
 
     // generate an authentication token
     randomize_string(req.token, sizeof(req.token));

--- a/client/gui-qt/icons.cpp
+++ b/client/gui-qt/icons.cpp
@@ -49,14 +49,14 @@ QIcon fcIcons::getIcon(const QString &id)
   QByteArray pn_bytes;
   QByteArray png_bytes;
 
-  str = QStringLiteral("themes") + DIR_SEPARATOR + "gui-qt" + DIR_SEPARATOR;
+  str = QStringLiteral("themes/gui-qt/");
   // Try custom icon from theme
   pn_bytes = str.toLocal8Bit();
   png_bytes =
-      QString(pn_bytes.data() + current_theme + DIR_SEPARATOR + id + ".png")
+      QString(pn_bytes.data() + current_theme + "/" + id + ".png")
           .toLocal8Bit();
   icon.addFile(fileinfoname(get_data_dirs(), png_bytes.data()));
-  str = str + "icons" + DIR_SEPARATOR;
+  str = str + "icons/";
   // Try icon from icons dir
   if (icon.isNull()) {
     pn_bytes = str.toLocal8Bit();
@@ -81,13 +81,13 @@ QPixmap *fcIcons::getPixmap(const QString &id)
   if (QPixmapCache::find(id, pm)) {
     return pm;
   }
-  str = QStringLiteral("themes") + DIR_SEPARATOR + "gui-qt" + DIR_SEPARATOR;
-  png_bytes = QString(str + current_theme + DIR_SEPARATOR + id + ".png")
+  str = QStringLiteral("themes/gui-qt/");
+  png_bytes = QString(str + current_theme + "/" + id + ".png")
                   .toLocal8Bit();
   status = pm->load(fileinfoname(get_data_dirs(), png_bytes.data()));
 
   if (!status) {
-    str = str + "icons" + DIR_SEPARATOR;
+    str = str + "icons/";
     png_bytes = QString(str + id + ".png").toLocal8Bit();
     pm->load(fileinfoname(get_data_dirs(), png_bytes.data()));
   }
@@ -104,8 +104,7 @@ QString fcIcons::getPath(const QString &id)
   QString str;
   QByteArray png_bytes;
 
-  str = QStringLiteral("themes") + DIR_SEPARATOR + "gui-qt" + DIR_SEPARATOR
-        + "icons" + DIR_SEPARATOR;
+  str = QStringLiteral("themes/gui-qt/icons/");
   png_bytes = QString(str + id + ".png").toLocal8Bit();
 
   return fileinfoname(get_data_dirs(), png_bytes.data());

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -2926,12 +2926,12 @@ void mr_menu::save_image()
   storage_path = freeciv_storage_dir();
   path = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
   if (!storage_path.isEmpty() && QDir(storage_path).isReadable()) {
-    img_name = storage_path + DIR_SEPARATOR + img_name;
+    img_name = storage_path + "/" + img_name;
   } else if (!path.isEmpty()) {
-    img_name = path + DIR_SEPARATOR + img_name;
+    img_name = path + "/" + img_name;
   } else {
     img_name = QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-               + DIR_SEPARATOR + img_name;
+               + "/" + img_name;
   }
   map_saved = mapview.store->save(img_name, "png");
   map_canvas_resized(current_width, current_height);

--- a/client/gui-qt/themes.cpp
+++ b/client/gui-qt/themes.cpp
@@ -35,8 +35,6 @@ Q_GLOBAL_STATIC(QString, stylestring)
  */
 void qtg_gui_load_theme(QString &directory, QString &theme_name)
 {
-  QString name;
-  QString path;
   QString fake_dir;
   QString data_dir;
   QFile f;
@@ -49,9 +47,7 @@ void qtg_gui_load_theme(QString &directory, QString &theme_name)
 
   data_dir = QString(directory);
 
-  path = data_dir + DIR_SEPARATOR + theme_name + DIR_SEPARATOR;
-  name = path + "resource.qss";
-  f.setFileName(name);
+  f.setFileName(data_dir + "/" + theme_name + "/resource.qss");
 
   if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
     if (QString(theme_name) != QStringLiteral(FC_QT_DEFAULT_THEME_NAME)) {
@@ -61,7 +57,6 @@ void qtg_gui_load_theme(QString &directory, QString &theme_name)
   }
   // Stylesheet uses UNIX separators
   fake_dir = data_dir;
-  fake_dir.replace(DIR_SEPARATOR_CHAR, QLatin1String("/"));
   QTextStream in(&f);
   *stylestring = in.readAll();
   stylestring->replace(lnb, fake_dir + "/" + theme_name + "/");
@@ -143,8 +138,7 @@ QStringList qtg_get_useable_themes_in_directory(QString &directory,
   name = QString(directory);
 
   for (auto const &str : qAsConst(sl)) {
-    f.setFileName(name + DIR_SEPARATOR + str + DIR_SEPARATOR
-                  + "resource.qss");
+    f.setFileName(name + "/" + str + "/resource.qss");
     if (!f.exists()) {
       continue;
     }

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -3955,7 +3955,7 @@ static const char *get_current_option_file_name()
       return NULL;
     }
     fc_snprintf(name_buffer, sizeof(name_buffer),
-                "%s%cfreeciv-client-rc-%d.%d", name, DIR_SEPARATOR_CHAR,
+                "%s/freeciv-client-rc-%d.%d", name,
                 MAJOR_NEW_OPTION_FILE_NAME, MINOR_NEW_OPTION_FILE_NAME);
 #endif // OPTION_FILE_NAME
   }
@@ -4015,8 +4015,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
                   : minor >= 0);
            minor--) {
         fc_snprintf(name_buffer, sizeof(name_buffer),
-                    "%s%cfreeciv-client-rc-%d.%d", name, DIR_SEPARATOR_CHAR,
-                    major, minor);
+                    "%s/freeciv-client-rc-%d.%d", name, major, minor);
         if (0 == fc_stat(name_buffer, &buf)) {
           if (MAJOR_NEW_OPTION_FILE_NAME != major
               || MINOR_NEW_OPTION_FILE_NAME != minor) {
@@ -4040,9 +4039,8 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
         minor = FIRST_MINOR_NEW_OPTION_FILE_NAME;
          minor >= FIRST_MINOR_MID_OPTION_FILE_NAME; minor--) {
       fc_snprintf(name_buffer, sizeof(name_buffer),
-                  "%s%c.freeciv-client-rc-%d.%d",
-                  qUtf8Printable(QDir::homePath()), DIR_SEPARATOR_CHAR,
-                  major, minor);
+                  "%s/.freeciv-client-rc-%d.%d",
+                  qUtf8Printable(QDir::homePath()), major, minor);
       if (0 == fc_stat(name_buffer, &buf)) {
         qInfo(_("Didn't find '%s' option file, "
                 "loading from '%s' instead."),
@@ -4057,8 +4055,8 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
     }
 
     // Try with the old one.
-    fc_snprintf(name_buffer, sizeof(name_buffer), "%s%c%s", name,
-                DIR_SEPARATOR_CHAR, OLD_OPTION_FILE_NAME);
+    fc_snprintf(name_buffer, sizeof(name_buffer), "%s/%s", name,
+                OLD_OPTION_FILE_NAME);
     if (0 == fc_stat(name_buffer, &buf)) {
       qInfo(_("Didn't find '%s' option file, "
               "loading from '%s' instead."),
@@ -4679,7 +4677,7 @@ void options_save(option_save_log_callback log_cb)
   // Directory name
   sz_strlcpy(dir_name, name);
   for (i = qstrlen(dir_name) - 1;
-       i >= 0 && dir_name[i] != DIR_SEPARATOR_CHAR; i--) {
+       i >= 0 && dir_name[i] != '/'; i--) {
     // Nothing
   }
   if (i > 0) {

--- a/server/gamehand.cpp
+++ b/server/gamehand.cpp
@@ -1093,8 +1093,7 @@ static const char *get_challenge_fullname(struct connection *pc)
     return NULL;
   }
 
-  fc_snprintf(fullname, sizeof(fullname), "%s%c%s", sdir, DIR_SEPARATOR_CHAR,
-              cname);
+  fc_snprintf(fullname, sizeof(fullname), "%s/%s", sdir, cname);
 
   return fullname;
 }

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -207,16 +207,16 @@ static QString valid_ruleset_filename(const char *subdir, const char *name,
 
   fc_assert_ret_val(subdir && name && extension, NULL);
 
-  fc_snprintf(filename, sizeof(filename), "%s%c%s.%s", subdir,
-              DIR_SEPARATOR_CHAR, name, extension);
+  fc_snprintf(filename, sizeof(filename), "%s/%s.%s", subdir, name, 
+              extension);
   qCDebug(ruleset_category, "Trying \"%s\".", filename);
   dfilename = fileinfoname(get_data_dirs(), filename);
   if (!dfilename.isEmpty()) {
     return dfilename;
   }
 
-  fc_snprintf(filename, sizeof(filename), "default%c%s.%s",
-              DIR_SEPARATOR_CHAR, name, extension);
+  fc_snprintf(filename, sizeof(filename), "default/%s.%s", name, 
+              extension);
   qCDebug(ruleset_category, "Trying \"%s\": default ruleset directory.",
           filename);
   dfilename = fileinfoname(get_data_dirs(), filename);

--- a/tools/fcmp/download.cpp
+++ b/tools/fcmp/download.cpp
@@ -152,11 +152,11 @@ static const char *download_modpack_recursive(const char *URL,
   }
 
   if (type == MPT_SCENARIO) {
-    fc_snprintf(local_dir, sizeof(local_dir), "%s%cscenarios",
-                qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR);
+    fc_snprintf(local_dir, sizeof(local_dir), "%s/scenarios",
+                qPrintable(fcmp->inst_prefix));
   } else {
-    fc_snprintf(local_dir, sizeof(local_dir), "%s%c" DATASUBDIR,
-                qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR);
+    fc_snprintf(local_dir, sizeof(local_dir), "%s/" DATASUBDIR,
+                qPrintable(fcmp->inst_prefix));
   }
 
   baseURLpart = secfile_lookup_str(control, "info.baseURL");
@@ -262,12 +262,6 @@ static const char *download_modpack_recursive(const char *URL,
   for (filenbr = 0; filenbr < total_files; filenbr++) {
     const char *dest_name;
 
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-    char *dest_name_copy;
-#else // DIR_SEPARATOR_IS_DEFAULT
-#define dest_name_copy dest_name
-#endif // DIR_SEPARATOR_IS_DEFAULT
-
     int i;
     bool illegal_filename = false;
 
@@ -282,10 +276,6 @@ static const char *download_modpack_recursive(const char *URL,
       dest_name = src_name;
     }
 
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-    dest_name_copy = new char[strlen(dest_name) + 1];
-#endif // DIR_SEPARATOR_IS_DEFAULT
-
     for (i = 0; dest_name[i] != '\0'; i++) {
       if (dest_name[i] == '.' && dest_name[i + 1] == '.') {
         if (mcb != NULL) {
@@ -297,30 +287,13 @@ static const char *download_modpack_recursive(const char *URL,
         partial_failure = true;
         illegal_filename = true;
       }
-
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-      if (dest_name[i] == '/') {
-        dest_name_copy[i] = DIR_SEPARATOR_CHAR;
-      } else {
-        dest_name_copy[i] = dest_name[i];
-      }
-#endif // DIR_SEPARATOR_IS_DEFAULT
     }
 
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-    dest_name_copy[i] = '\0';
-#endif // DIR_SEPARATOR_IS_DEFAULT
-
     if (!illegal_filename) {
-      fc_snprintf(local_name, sizeof(local_name), "%s%c%s", local_dir,
-                  DIR_SEPARATOR_CHAR, dest_name_copy);
+      fc_snprintf(local_name, sizeof(local_name), "%s/%s", local_dir,
+                  dest_name);
 
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-      free(dest_name_copy);
-#endif // DIR_SEPARATOR_IS_DEFAULT
-
-      for (i = qstrlen(local_name) - 1; local_name[i] != DIR_SEPARATOR_CHAR;
-           i--) {
+      for (i = qstrlen(local_name) - 1; local_name[i] != '/'; i--) {
         // Nothing
       }
       local_name[i] = '\0';
@@ -329,7 +302,7 @@ static const char *download_modpack_recursive(const char *URL,
         secfile_destroy(control);
         return _("Cannot create required directories");
       }
-      local_name[i] = DIR_SEPARATOR_CHAR;
+      local_name[i] = '/';
 
       if (mcb != NULL) {
         char buf[2048];
@@ -352,10 +325,6 @@ static const char *download_modpack_recursive(const char *URL,
         }
         partial_failure = true;
       }
-    } else {
-#ifndef DIR_SEPARATOR_IS_DEFAULT
-      free(dest_name_copy);
-#endif // DIR_SEPARATOR_IS_DEFAULT
     }
 
     if (pbcb != NULL) {

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -47,24 +47,18 @@ void load_install_info_lists(struct fcmp_params *fcmp)
   struct stat buf;
 
   fc_snprintf(main_db_filename, sizeof(main_db_filename),
-              "%s%c" DATASUBDIR "%c" FCMP_CONTROLD "%cmp.db",
-              qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR,
-              DIR_SEPARATOR_CHAR, DIR_SEPARATOR_CHAR);
+              "%s/" DATASUBDIR "/" FCMP_CONTROLD "/mp.db",
+              qPrintable(fcmp->inst_prefix));
   fc_snprintf(scenario_db_filename, sizeof(scenario_db_filename),
-              "%s%c"
-              "scenarios%c" FCMP_CONTROLD "%cmp.db",
-              qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR,
-              DIR_SEPARATOR_CHAR, DIR_SEPARATOR_CHAR);
+              "%s/scenarios/" FCMP_CONTROLD "/mp.db",
+              qPrintable(fcmp->inst_prefix));
 
   fc_snprintf(main_ii_filename, sizeof(main_ii_filename),
-              "%s%c" DATASUBDIR "%c" FCMP_CONTROLD "%cmodpacks.db",
-              qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR,
-              DIR_SEPARATOR_CHAR, DIR_SEPARATOR_CHAR);
+              "%s/" DATASUBDIR "/" FCMP_CONTROLD "/modpacks.db",
+              qPrintable(fcmp->inst_prefix));
   fc_snprintf(scenario_ii_filename, sizeof(scenario_ii_filename),
-              "%s%c"
-              "scenarios%c" FCMP_CONTROLD "%cmodpacks.db",
-              qPrintable(fcmp->inst_prefix), DIR_SEPARATOR_CHAR,
-              DIR_SEPARATOR_CHAR, DIR_SEPARATOR_CHAR);
+              "%s/scenarios/" FCMP_CONTROLD "/modpacks.db",
+              qPrintable(fcmp->inst_prefix));
 
   if (fc_stat(main_db_filename, &buf)) {
     create_mpdb(main_db_filename, false);

--- a/tools/fcmp/mpdb.cpp
+++ b/tools/fcmp/mpdb.cpp
@@ -140,7 +140,7 @@ void create_mpdb(const char *filename, bool scenario_db)
   int i;
 
   qstrncpy(local_name, filename, llen);
-  for (i = llen - 1; local_name[i] != DIR_SEPARATOR_CHAR; i--) {
+  for (i = llen - 1; local_name[i] != '/'; i--) {
     // Nothing
   }
   local_name[i] = '\0';

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -100,13 +100,6 @@ enum fc_tristate fc_tristate_and(enum fc_tristate one, enum fc_tristate two);
     }                                                                       \
   }
 
-#define DIR_SEPARATOR qUtf8Printable(QDir::separator())
-#define DIR_SEPARATOR_CHAR QDir::separator().toLatin1()
-
-#ifndef FREECIV_MSWINDOWS
-#define DIR_SEPARATOR_IS_DEFAULT
-#endif
-
 #define PARENT_DIR_OPERATOR ".."
 
 const char *big_int_to_text(unsigned int mantissa, unsigned int exponent);


### PR DESCRIPTION
Qt abstracts it away so we don't need to worry about it.

Fixes #279 