### PR TITLE
Speed up tileset loading on Windows (3x)

### DIFF
--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -1388,7 +1388,13 @@ static QPixmap *load_gfx_file(const char *gfx_filename)
   QPixmap *s;
 
   // Try out all supported file extensions to find one that works.
-  for (auto gfx_fileext : QImageReader::supportedImageFormats()) {
+  auto supported = QImageReader::supportedImageFormats();
+
+  // Make sure we try png first (it's the most common and Qt always supports
+  // it). This dramatically improves tileset loading performance on Windows.
+  supported.prepend("png");
+
+  for (auto gfx_fileext : qAsConst(supported)) {
     QString real_full_name;
     QString full_name =
         QStringLiteral("%1.%2").arg(gfx_filename, gfx_fileext.data());


### PR DESCRIPTION
When loading a tileset, the client tries every possible format for every graphics file. This is very inefficient on Windows. Make sure that png is always tried out first, to match what all shipped files use. A rough estimate of the speedup is 3x for hexamplio (from ~15s to ~5s in my VM).