### PR TITLE
❤️ Penalize buying without building

### DIFF
--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -776,6 +776,7 @@ void handle_city_info(const struct packet_city_info *packet)
 
   pcity->airlift = packet->airlift;
   pcity->did_buy = packet->did_buy;
+  pcity->did_buy_production =  packet->did_buy_production;
   pcity->did_sell = packet->did_sell;
   pcity->was_happy = packet->was_happy;
 

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -1870,12 +1870,10 @@ int city_change_production_penalty(const struct city *pcity,
     penalized_shields = pcity->before_change_shields;
   }
 
-  // Penalize 50% if you buy last turn but didnt built
-  if ((pcity->did_buy_production && ((target->kind == VUT_UTYPE
-            && target->value.utype != pcity->changed_from.value.utype)
-           || (target->kind == VUT_IMPROVEMENT
-               && target->value.building
-                      != pcity->changed_from.value.building)))) {
+  // Penalize 50% if you buy unit last turn but didnt built
+  if ((pcity->did_buy_production
+       && ((target->kind == VUT_UTYPE
+            && target->value.utype != pcity->changed_from.value.utype)))) {
     unpenalized_shields = 0;
     penalized_shields = pcity->before_change_shields;
   }

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -1870,6 +1870,16 @@ int city_change_production_penalty(const struct city *pcity,
     penalized_shields = pcity->before_change_shields;
   }
 
+  // Penalize 50% if you buy last turn but didnt built
+  if ((pcity->did_buy_production && ((target->kind == VUT_UTYPE
+            && target->value.utype != pcity->changed_from.value.utype)
+           || (target->kind == VUT_IMPROVEMENT
+               && target->value.building
+                      != pcity->changed_from.value.building)))) {
+    unpenalized_shields = 0;
+    penalized_shields = pcity->before_change_shields;
+  }
+
   /* Do not put penalty on these. It shouldn't matter whether you disband
      unit before or after changing production...*/
   unpenalized_shields += pcity->disbanded_shields;
@@ -3361,6 +3371,7 @@ struct city *create_city_virtual(struct player *pplayer, struct tile *ptile,
 
   pcity->turn_plague = -1; // -1 = never
   pcity->did_buy = false;
+  pcity->did_buy_production = false;
   pcity->city_radius_sq = game.info.init_city_radius_sq;
   pcity->turn_founded = game.info.turn;
   pcity->turn_last_built = game.info.turn;

--- a/common/city.h
+++ b/common/city.h
@@ -337,6 +337,7 @@ struct city {
   // turn states
   int airlift;
   bool did_buy;
+  bool did_buy_production;
   bool did_sell;
   bool was_happy;
 

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -731,7 +731,7 @@ PACKET_CITY_INFO = 31; sc, lsend, is-game-info, force, cancel(PACKET_CITY_SHORT_
   UINT16 last_turns_shield_surplus;
 
   UINT8 airlift;
-  BOOL did_buy, did_sell, was_happy;
+  BOOL did_buy, did_buy_production, did_sell, was_happy;
 
   BOOL diplomat_investigate;
   UINT8 walls;
@@ -2239,6 +2239,7 @@ PACKET_EDIT_CITY = 213; cs, handle-per-conn, handle-via-packet
   BOOL airlift;
   BOOL debug;
   BOOL did_buy;
+  BOOL did_buy_production;
   BOOL did_sell;
   BOOL was_happy;
   UINT8 anarchy;

--- a/server/cityhand.cpp
+++ b/server/cityhand.cpp
@@ -348,6 +348,7 @@ void really_handle_city_buy(struct player *pplayer, struct city *pcity)
     pcity->disbanded_shields += total - pcity->shield_stock;
     pcity->shield_stock = total; // AI wants this -- Syela
     pcity->did_buy = true;       // !PS: no need to set buy flag otherwise
+    pcity->did_buy_production = true;
   }
   city_refresh(pcity);
 

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -2582,6 +2582,7 @@ void package_city(struct city *pcity, struct packet_city_info *packet,
 
   packet->airlift = pcity->airlift;
   packet->did_buy = pcity->did_buy;
+  packet->did_buy_production = pcity->did_buy_production;
   packet->did_sell = pcity->did_sell;
   packet->was_happy = pcity->was_happy;
 

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -2305,6 +2305,7 @@ static bool city_build_building(struct player *pplayer, struct city *pcity)
     pcity->before_change_shields -= cost;
     pcity->shield_stock -= cost;
     pcity->turn_last_built = game.info.turn;
+    pcity->did_buy_production = false;
     // to eliminate micromanagement
     if (is_great_wonder(pimprove)) {
       notify_player(NULL, city_tile(pcity), E_WONDER_BUILD, ftc_server,
@@ -2496,7 +2497,7 @@ static bool city_build_unit(struct player *pplayer, struct city *pcity)
 
     // don't update turn_last_built if we returned above
     pcity->turn_last_built = game.info.turn;
-
+    pcity->did_buy_production = false;
     // check if we can build more than one unit (effect City_Build_Slots)
     (void) city_production_build_units(pcity, false, &num_units);
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -4839,6 +4839,10 @@ static bool sg_load_player_city(struct loaddata *loading, struct player *plr,
   sg_warn_ret_val(secfile_lookup_bool(loading->file, &pcity->did_buy,
                                       "%s.did_buy", citystr),
                   false, "%s", secfile_error());
+  sg_warn_ret_val(secfile_lookup_bool(loading->file,
+                                      &pcity->did_buy_production,
+                                      "%s.did_buy_production", citystr),
+                  false, "%s", secfile_error());
   sg_warn_ret_val(secfile_lookup_bool(loading->file, &pcity->did_sell,
                                       "%s.did_sell", citystr),
                   false, "%s", secfile_error());
@@ -5290,6 +5294,8 @@ static void sg_save_player_cities(struct savedata *saving,
     secfile_insert_int(saving->file, pcity->turn_founded, "%s.turn_founded",
                        buf);
     secfile_insert_bool(saving->file, pcity->did_buy, "%s.did_buy", buf);
+    secfile_insert_bool(saving->file, pcity->did_buy_production,
+                        "%s.did_buy_production", buf);
     secfile_insert_bool(saving->file, pcity->did_sell, "%s.did_sell", buf);
     secfile_insert_int(saving->file, pcity->turn_last_built,
                        "%s.turn_last_built", buf);

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -4839,10 +4839,10 @@ static bool sg_load_player_city(struct loaddata *loading, struct player *plr,
   sg_warn_ret_val(secfile_lookup_bool(loading->file, &pcity->did_buy,
                                       "%s.did_buy", citystr),
                   false, "%s", secfile_error());
-  sg_warn_ret_val(secfile_lookup_bool(loading->file,
-                                      &pcity->did_buy_production,
-                                      "%s.did_buy_production", citystr),
-                  false, "%s", secfile_error());
+  sg_warn_ret_val(
+      secfile_lookup_bool_default(loading->file, &pcity->did_buy_production,
+                                  "%s.did_buy_production", citystr),
+      false, "%s", secfile_error());
   sg_warn_ret_val(secfile_lookup_bool(loading->file, &pcity->did_sell,
                                       "%s.did_sell", citystr),
                   false, "%s", secfile_error());

--- a/utility/fc_version.h
+++ b/utility/fc_version.h
@@ -11,7 +11,7 @@
 #define VERSION_STRING "3.0.1337.1-haxx"
 #endif
 
-#define NETWORK_CAPSTRING "+Freeciv21.fok_all"
+#define NETWORK_CAPSTRING "+Freeciv21.21March06"
 
 #ifndef FOLLOWTAG
 #define FOLLOWTAG "S_HAXXOR"


### PR DESCRIPTION
Fix #310 
Set 50% penalty when buying units/improvements and changing to somethign else later.