### PR TITLE
Bump the required C++ version to C++ 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
           - ninja
           - python3
           - gettext
-          - qt
+          - qt@5
           - kde-karchive
           - readline
           - sqlite

--- a/client/citybar.h
+++ b/client/citybar.h
@@ -13,12 +13,14 @@
 
 #include <memory>
 
+// Qt
+#include <QStringList>
+
 // Forward declarations
 class QPainter;
 class QPointF;
 class QRect;
 class QString;
-class QStringList;
 class QTextDocument;
 
 struct city;

--- a/client/gui-qt/fonts.h
+++ b/client/gui-qt/fonts.h
@@ -11,9 +11,9 @@
 
 // Qt
 #include <QMap>
+#include <QStringList>
 
 class QFont;
-class QStringList;
 
 namespace fonts {
 const char *const default_font = "gui_qt_font_default";

--- a/client/themes_common.h
+++ b/client/themes_common.h
@@ -10,8 +10,10 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 ***********************************************************************/
 #pragma once
 
+#include <QString>
+#include <QVector>
+
 void init_themes();
-class QStringList;
 const QVector<QString> *get_themes_list(const struct option *poption);
 bool load_theme(const QString &theme_name);
 void theme_reread_callback(struct option *option);

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -10,7 +10,7 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 # Language support
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 # Should be available in C++11 but not all systems have it

--- a/utility/genlist.cpp
+++ b/utility/genlist.cpp
@@ -20,6 +20,7 @@
 // utility
 #include "fcthread.h"
 #include "log.h"
+#include "rand.h"
 #include "shared.h" // array_shuffle
 
 #include "genlist.h"
@@ -641,7 +642,7 @@ void genlist_shuffle(struct genlist *pgenlist)
   }
 
   // randomize it
-  std::random_shuffle(shuffle.begin(), shuffle.end());
+  std::shuffle(shuffle.begin(), shuffle.end(), freeciv::random_generator());
 
   // create the shuffled list
   myiter = genlist_head(pgenlist);

--- a/utility/rand.h
+++ b/utility/rand.h
@@ -43,3 +43,28 @@ void test_random1(int n);
 RANDOM_TYPE fc_randomly_debug(RANDOM_TYPE seed, RANDOM_TYPE size,
                               const char *called_as, int line,
                               const char *file);
+
+namespace freeciv {
+
+/**
+ * A UniformRandomBitGenerator class usable with STL algorithms and using the
+ * Freeciv RNG under the hood.
+ */
+class random_generator {
+public:
+  using result_type = RANDOM_TYPE;
+
+  static constexpr auto min() { return 0; }
+
+  static constexpr auto max()
+  {
+    return std::numeric_limits<result_type>::max() - 1;
+  }
+
+  auto operator()()
+  {
+    return fc_rand(std::numeric_limits<result_type>::max());
+  }
+};
+
+} // namespace freeciv

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -858,8 +858,7 @@ const QStringList *get_scenario_dirs()
    The suffixes are removed from the filenames before the list is
    returned.
  */
-class QVector<QString> *fileinfolist(const QStringList *dirs,
-                                     const char *suffix) {
+QVector<QString> *fileinfolist(const QStringList *dirs, const char *suffix) {
   fc_assert_ret_val(!strchr(suffix, '/'), NULL);
 
   QVector<QString> *files = new QVector<QString>();

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -154,8 +154,7 @@ const QStringList *get_scenario_dirs();
 
 void free_data_dir_names();
 
-class QVector<QString> *fileinfolist(const QStringList *dirs,
-                                     const char *suffix);
+QVector<QString> *fileinfolist(const QStringList *dirs, const char *suffix);
 struct fileinfo_list *fileinfolist_infix(const QStringList *dirs,
                                          const char *infix, bool nodups);
 QString fileinfoname(const QStringList *dirs, const char *filename);


### PR DESCRIPTION
This change is done primarily because the Qt5 shipped in Homebrew appears to be
configured to use C++ 17 and breaks the build on Travis.

C++ 17 is available on Debian Buster (already our minimal requirement for Qt),
MSYS and OS X. Using it brings nice new features without significant pitfalls.
MSVC should also support it.

Closes #321 