### PR TITLE
Weekly Travis builds including Coverity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
     before_script:
       - brew link gettext --force
   - name: "coverity"
-    if: branch = coverity_scan
+    if: branch = coverity_scan OR type = cron
     dist: focal
     compiler: gcc
     addons:


### PR DESCRIPTION
A weekly Travis run will be instated to:

* Follow Coverity defects more closely
* Make sure the build doesn't break due to updated dependencies as was recently the case for OS X (#321).

Closes #328