### PR TITLE
Move Freeciv21 files outside of .freeciv

### DIFF
--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -228,7 +228,7 @@ bool client_start_server()
     return false;
   }
 
-  storage = QString::fromUtf8(freeciv_storage_dir());
+  storage = freeciv_storage_dir();
   if (storage == NULL) {
     output_window_append(ftc_client,
                          _("Cannot find freeciv storage directory"));
@@ -389,9 +389,9 @@ void send_client_wants_hack(const char *filename)
   if (filename[0] != '\0') {
     struct packet_single_want_hack_req req;
     struct section_file *file;
-    const char *sdir = freeciv_storage_dir();
+    auto sdir = freeciv_storage_dir();
 
-    if (sdir == NULL) {
+    if (sdir.isEmpty()) {
       return;
     }
 
@@ -399,10 +399,10 @@ void send_client_wants_hack(const char *filename)
       return;
     }
 
-    make_dir(sdir);
+    QDir().mkpath(sdir);
 
     fc_snprintf(challenge_fullname, sizeof(challenge_fullname), "%s/%s",
-                sdir, filename);
+                qPrintable(sdir), filename);
 
     // generate an authentication token
     randomize_string(req.token, sizeof(req.token));

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -2960,7 +2960,7 @@ void mr_menu::save_game_as()
   QString current_file;
   QString location;
 
-  for (const auto &dirname : *get_save_dirs()) {
+  for (const auto &dirname : get_save_dirs()) {
     location = dirname;
     // choose last location
   }

--- a/client/gui-qt/themes.cpp
+++ b/client/gui-qt/themes.cpp
@@ -106,11 +106,11 @@ void qtg_gui_clear_theme()
  */
 QStringList qtg_get_gui_specific_themes_directories(int *count)
 {
-  const QStringList *data_dirs = get_data_dirs();
+  auto data_dirs = get_data_dirs();
   QStringList directories;
 
-  *count = data_dirs->size();
-  for (const auto &data_dir : *data_dirs) {
+  *count = data_dirs.size();
+  for (const auto &data_dir : data_dirs) {
     directories.append(QStringLiteral("%1/themes/gui-qt").arg(data_dir));
   }
 

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -3939,23 +3939,22 @@ static void save_cma_presets(struct section_file *file)
 static const char *get_current_option_file_name()
 {
   static char name_buffer[256];
-  const char *name;
 
-  name = getenv("FREECIV_OPT");
+  auto name = QString::fromLocal8Bit(qgetenv("FREECIV_OPT"));
 
-  if (name) {
-    sz_strlcpy(name_buffer, name);
+  if (!name.isEmpty()) {
+    sz_strlcpy(name_buffer, qUtf8Printable(name));
   } else {
 #ifdef OPTION_FILE_NAME
     fc_strlcpy(name_buffer, OPTION_FILE_NAME, sizeof(name_buffer));
 #else
     name = freeciv_storage_dir();
-    if (!name) {
+    if (name.isEmpty()) {
       qCritical(_("Cannot find freeciv storage directory"));
       return NULL;
     }
     fc_snprintf(name_buffer, sizeof(name_buffer),
-                "%s/freeciv-client-rc-%d.%d", name,
+                "%s/freeciv-client-rc-%d.%d", qUtf8Printable(name),
                 MAJOR_NEW_OPTION_FILE_NAME, MINOR_NEW_OPTION_FILE_NAME);
 #endif // OPTION_FILE_NAME
   }
@@ -3974,7 +3973,6 @@ static const char *get_current_option_file_name()
 static const char *get_last_option_file_name(bool *allow_digital_boolean)
 {
   static char name_buffer[256];
-  const char *name;
   static int last_minors[] = {
       0,  // There was no 0.x releases
       14, // 1.14
@@ -3990,9 +3988,11 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
 #endif
 
   *allow_digital_boolean = false;
-  name = getenv("FREECIV_OPT");
-  if (name) {
-    sz_strlcpy(name_buffer, name);
+
+  auto name = QString::fromLocal8Bit(qgetenv("FREECIV_OPT"));
+
+  if (!name.isEmpty()) {
+    sz_strlcpy(name_buffer, qUtf8Printable(name));
   } else {
 #ifdef OPTION_FILE_NAME
     fc_strlcpy(name_buffer, OPTION_FILE_NAME, sizeof(name_buffer));
@@ -4001,7 +4001,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
     struct stat buf;
 
     name = freeciv_storage_dir();
-    if (name == NULL) {
+    if (name.isEmpty()) {
       qCritical(_("Cannot find freeciv storage directory"));
 
       return NULL;
@@ -4015,14 +4015,14 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
                   : minor >= 0);
            minor--) {
         fc_snprintf(name_buffer, sizeof(name_buffer),
-                    "%s/freeciv-client-rc-%d.%d", name, major, minor);
+                    "%s/freeciv-client-rc-%d.%d", qUtf8Printable(name), major, minor);
         if (0 == fc_stat(name_buffer, &buf)) {
           if (MAJOR_NEW_OPTION_FILE_NAME != major
               || MINOR_NEW_OPTION_FILE_NAME != minor) {
             qInfo(_("Didn't find '%s' option file, "
                     "loading from '%s' instead."),
-                  get_current_option_file_name() + qstrlen(name) + 1,
-                  name_buffer + qstrlen(name) + 1);
+                  get_current_option_file_name(),
+                  name_buffer);
           }
 
           return name_buffer;
@@ -4045,7 +4045,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
         qInfo(_("Didn't find '%s' option file, "
                 "loading from '%s' instead."),
               get_current_option_file_name() + qstrlen(qUtf8Printable(QDir::homePath())) + 1,
-              name_buffer + qstrlen(name) + 1);
+              name_buffer);
 
         if (FIRST_MINOR_NEW_BOOLEAN > minor) {
           *allow_digital_boolean = true;
@@ -4055,12 +4055,12 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
     }
 
     // Try with the old one.
-    fc_snprintf(name_buffer, sizeof(name_buffer), "%s/%s", name,
+    fc_snprintf(name_buffer, sizeof(name_buffer), "%s/%s", qUtf8Printable(name),
                 OLD_OPTION_FILE_NAME);
     if (0 == fc_stat(name_buffer, &buf)) {
       qInfo(_("Didn't find '%s' option file, "
               "loading from '%s' instead."),
-            get_current_option_file_name() + qstrlen(name) + 1,
+            get_current_option_file_name(),
             OLD_OPTION_FILE_NAME);
       *allow_digital_boolean = true;
       return name_buffer;

--- a/cmake/FreecivBuildOptions.cmake
+++ b/cmake/FreecivBuildOptions.cmake
@@ -37,10 +37,6 @@ set(FREECIV_META_URL "http://meta.freeciv.org/metaserver.php"
     CACHE STRING "Metaserver URL")
 mark_as_advanced(FREECIV_META_URL)
 
-set(FREECIV_STORAGE_DIR "~/.freeciv"
-    CACHE STRING "Location for freeciv to store its information")
-mark_as_advanced(FREECIV_STORAGE_DIR)
-
 set(FREECIV_AI_MOD_LAST 2 CACHE STRING "The number of AI modules to build")
 mark_as_advanced(FREECIV_AI_MOD_LAST)
 

--- a/common/fc_interface.cpp
+++ b/common/fc_interface.cpp
@@ -75,8 +75,5 @@ void fc_interface_init()
 void free_libfreeciv()
 {
   diplrel_mess_close();
-  free_data_dir_names();
   free_multicast_group();
-  free_freeciv_storage_dir();
-  free_fileinfo_data();
 }

--- a/server/gamehand.cpp
+++ b/server/gamehand.cpp
@@ -1080,7 +1080,7 @@ static const char *get_challenge_filename(struct connection *pc)
 static const char *get_challenge_fullname(struct connection *pc)
 {
   static char fullname[MAX_LEN_PATH];
-  const char *sdir = freeciv_storage_dir();
+  auto sdir = freeciv_storage_dir();
   const char *cname;
 
   if (sdir == NULL) {
@@ -1093,7 +1093,7 @@ static const char *get_challenge_fullname(struct connection *pc)
     return NULL;
   }
 
-  fc_snprintf(fullname, sizeof(fullname), "%s/%s", sdir, cname);
+  fc_snprintf(fullname, sizeof(fullname), "%s/%s", qUtf8Printable(sdir), cname);
 
   return fullname;
 }

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -1281,18 +1281,13 @@ static void sg_load_savefile(struct loaddata *loading)
     if (!fc_strcasecmp("none", game.scenario.datafile)) {
       game.server.luadata = NULL;
     } else {
-      const QStringList *pathes[] = {get_scenario_dirs(), NULL};
-      const QStringList **path;
-      QString found;
       char testfile[MAX_LEN_PATH];
       struct section_file *secfile;
 
-      for (path = pathes; found == NULL && *path != NULL; path++) {
-        fc_snprintf(testfile, sizeof(testfile), "%s.luadata",
-                    game.scenario.datafile);
+      fc_snprintf(testfile, sizeof(testfile), "%s.luadata",
+                  game.scenario.datafile);
 
-        found = fileinfoname(*path, testfile);
-      }
+      auto found = fileinfoname(get_scenario_dirs(), testfile);
 
       if (found.isEmpty()) {
         qCritical(_("Can't find scenario luadata file %s.luadata."),

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -303,7 +303,7 @@ server::~server()
 {
   if (m_interactive) {
     // Save history
-    auto history_file = QString::fromUtf8(freeciv_storage_dir())
+    auto history_file = freeciv_storage_dir()
                         + QStringLiteral("/")
                         + QLatin1String(HISTORY_FILENAME);
     auto history_file_encoded = history_file.toLocal8Bit();
@@ -330,7 +330,7 @@ server::~server()
 void server::init_interactive()
 {
   // Read the history file
-  auto storage_dir = QString::fromUtf8(freeciv_storage_dir());
+  auto storage_dir = freeciv_storage_dir();
   if (QDir().mkpath(storage_dir)) {
     auto history_file =
         storage_dir + QStringLiteral("/") + QLatin1String(HISTORY_FILENAME);

--- a/utility/cmake_fc_config.h.in
+++ b/utility/cmake_fc_config.h.in
@@ -130,9 +130,6 @@
 /* lzma compression is available in KArchive */
 #cmakedefine FREECIV_HAVE_LZMA
 
-/* Location for freeciv to store its information */
-#cmakedefine FREECIV_STORAGE_DIR "${FREECIV_STORAGE_DIR}"
-
 /* Max number of AI modules */
 #cmakedefine FREECIV_AI_MOD_LAST ${FREECIV_AI_MOD_LAST}
 

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -50,21 +50,11 @@
 
 #include "shared.h"
 
-// environment
-#ifndef FREECIV_DATA_PATH
-#define FREECIV_DATA_PATH "FREECIV_DATA_PATH"
-#endif
-#ifndef FREECIV_SAVE_PATH
-#define FREECIV_SAVE_PATH "FREECIV_SAVE_PATH"
-#endif
-#ifndef FREECIV_SCENARIO_PATH
-#define FREECIV_SCENARIO_PATH "FREECIV_SCENARIO_PATH"
-#endif
-
 static QStringList default_data_path()
 {
   return {QStringLiteral("."), QStringLiteral("data"),
-          freeciv_storage_dir() + QStringLiteral("/" DATASUBDIR)};
+          freeciv_storage_dir() + QStringLiteral("/" DATASUBDIR),
+          QStringLiteral(FREECIV_INSTALL_DATADIR)};
 }
 
 static QStringList default_save_path()
@@ -666,10 +656,9 @@ const QStringList &get_data_dirs()
    * allocate the directory listing.  Subsequently we will already
    * know the list and can just return it. */
   if (data_dir_names.isEmpty()) {
-    data_dir_names = base_get_dirs(FREECIV_DATA_PATH);
+    data_dir_names = base_get_dirs("FREECIV_DATA_PATH");
     if (data_dir_names.isEmpty()) {
       data_dir_names = default_data_path();
-      data_dir_names.append(FREECIV_INSTALL_DATADIR);
       data_dir_names.removeDuplicates();
     }
     for (const auto &name : qAsConst(data_dir_names)) {
@@ -697,7 +686,7 @@ const QStringList &get_save_dirs()
    * allocate the directory listing.  Subsequently we will already
    * know the list and can just return it. */
   if (save_dir_names.isEmpty()) {
-    save_dir_names = base_get_dirs(FREECIV_SAVE_PATH);
+    save_dir_names = base_get_dirs("FREECIV_SAVE_PATH");
     if (save_dir_names.isEmpty()) {
       save_dir_names = default_save_path();
       save_dir_names.removeDuplicates();
@@ -728,7 +717,7 @@ const QStringList &get_scenario_dirs()
    * allocate the directory listing.  Subsequently we will already
    * know the list and can just return it. */
   if (scenario_dir_names.isEmpty()) {
-    scenario_dir_names = base_get_dirs(FREECIV_SCENARIO_PATH);
+    scenario_dir_names = base_get_dirs("FREECIV_SCENARIO_PATH");
     if (scenario_dir_names.isEmpty()) {
       scenario_dir_names = default_scenario_path();
       scenario_dir_names.removeDuplicates();

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -566,7 +566,7 @@ bool str_to_float(const char *str, float *pfloat)
    Gets value once, and then caches result.
    Note the caller should not mess with the returned string.
  */
-char *freeciv_storage_dir()
+QString freeciv_storage_dir()
 {
   if (storage_dir_freeciv == NULL) {
     storage_dir_freeciv = new char[strlen(FREECIV_STORAGE_DIR) + 1];

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -146,19 +146,15 @@ struct fileinfo {
 
 char *user_username(char *buf, size_t bufsz);
 QString freeciv_storage_dir();
-void free_freeciv_storage_dir();
 
-const QStringList *get_data_dirs();
-const QStringList *get_save_dirs();
-const QStringList *get_scenario_dirs();
+const QStringList &get_data_dirs();
+const QStringList &get_save_dirs();
+const QStringList &get_scenario_dirs();
 
-void free_data_dir_names();
-
-QVector<QString> *fileinfolist(const QStringList *dirs, const char *suffix);
-struct fileinfo_list *fileinfolist_infix(const QStringList *dirs,
+QVector<QString> *fileinfolist(const QStringList &dirs, const char *suffix);
+struct fileinfo_list *fileinfolist_infix(const QStringList &dirs,
                                          const char *infix, bool nodups);
-QString fileinfoname(const QStringList *dirs, const char *filename);
-void free_fileinfo_data();
+QString fileinfoname(const QStringList &dirs, const char *filename);
 
 void init_nls();
 void free_nls();

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -145,7 +145,7 @@ struct fileinfo {
 #define fileinfo_list_iterate_end LIST_ITERATE_END
 
 char *user_username(char *buf, size_t bufsz);
-char *freeciv_storage_dir();
+QString freeciv_storage_dir();
 void free_freeciv_storage_dir();
 
 const QStringList *get_data_dirs();


### PR DESCRIPTION
This PR moves freeciv21 user-specific files (saves, scenarios, …) to the standard location `.local/share/freeciv21` on Linux and similar locations on other systems. There is still room for improvement: settings and challenge files should be moved to other locations (`~/.config` and `~/.cache/freeciv21` respectively).

This is part of *QString everywhere* because some `char*` code was reworked in the process.

Closes #347.