### PR TITLE
Reverted load save to mem leak but without crash

### DIFF
--- a/client/gui-qt/page_load.cpp
+++ b/client/gui-qt/page_load.cpp
@@ -345,9 +345,7 @@ void page_load::slot_selection_changed(const QItemSelection &selected,
       }
       ui.load_pix->setFixedSize(ui.load_pix->pixmap()->width(),
                                 ui.load_pix->pixmap()->height());
-      if (sf) {
-        secfile_destroy(sf);
-      }
+
       sf = secfile_load_section(fn_bytes.data(), QStringLiteral("research"),
                                 true);
       if (sf) {


### PR DESCRIPTION
it fixes 1 in #349, I didnt see 2nd one
but I saw 2 more :dagger: 

3) quick changing files to load freezes client totally ( KArchieve strikes again :D ? )
4) there is no map preview at all, but maybe I had some old saves only.