### PR TITLE
Replace the random number generator

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -489,7 +489,7 @@ int client_main(int argc, char *argv[])
     } else {
       fc_snprintf(gui_options.default_user_name,
                   sizeof(gui_options.default_user_name), "player%d",
-                  fc_rand(10000));
+                  (int) fc_rand(10000));
     }
   }
 

--- a/server/generator/mapgen.cpp
+++ b/server/generator/mapgen.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -1305,31 +1305,15 @@ static void print_mapgen_map()
  */
 bool map_fractal_generate(bool autosize, struct unit_type *initial_unit)
 {
-  // save the current random state:
-  RANDOM_STATE rstate;
-  RANDOM_TYPE seed_rand;
-
-  /* Call fc_rand() even when result is not needed to make sure
-   * random state proceeds equally for random seeds and explicitly
-   * set seed. */
-  seed_rand = fc_rand(MAX_UINT32);
+  auto rstate = fc_rand_state();
 
   if (wld.map.server.seed_setting == 0) {
-    // Create a "random" map seed.
-    wld.map.server.seed = seed_rand & (MAX_UINT32 >> 1);
-#ifdef FREECIV_TESTMATIC
-    // Log command to reproduce the mapseed
-    log_testmatic("set mapseed %d", wld.map.server.seed);
-#else  // FREECIV_TESTMATICE
-    log_debug("Setting map.seed:%d", wld.map.server.seed);
-#endif // FREECIV_TESTMATIC
+    // Create a random map seed.
+    fc_rand_seed(fc_rand_state());
   } else {
-    wld.map.server.seed = wld.map.server.seed_setting;
+    fc_srand(wld.map.server.seed_setting);
   }
-
-  rstate = fc_rand_state();
-
-  fc_srand(wld.map.server.seed);
+  wld.map.server.seed = wld.map.server.seed_setting;
 
   /* don't generate tiles with mapgen == MAPGEN_SCENARIO as we've loaded *
      them from file.

--- a/server/savegame/savecompat.h
+++ b/server/savegame/savecompat.h
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -126,7 +126,7 @@ struct loaddata {
   enum server_states server_state;
 
   // loaded in sg_load_random(); needed in sg_load_sanitycheck()
-  RANDOM_STATE rstate;
+  std::mt19937 rstate;
 
   // loaded in sg_load_map_worked(); needed in sg_load_player_cities()
   int *worked_tiles;

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -73,6 +73,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 
 // utility
 #include "bitvector.h"
@@ -2205,28 +2206,22 @@ static void sg_load_random(struct loaddata *loading)
   sg_check_ret();
 
   if (secfile_lookup_bool_default(loading->file, false, "random.saved")) {
-    const char *str;
-    int i;
-
-    sg_failure_ret(secfile_lookup_int(loading->file, &loading->rstate.j,
-                                      "random.index_J"),
-                   "%s", secfile_error());
-    sg_failure_ret(secfile_lookup_int(loading->file, &loading->rstate.k,
-                                      "random.index_K"),
-                   "%s", secfile_error());
-    sg_failure_ret(secfile_lookup_int(loading->file, &loading->rstate.x,
-                                      "random.index_X"),
-                   "%s", secfile_error());
-
-    for (i = 0; i < 8; i++) {
-      str = secfile_lookup_str(loading->file, "random.table%d", i);
-      sg_failure_ret(NULL != str, "%s", secfile_error());
-      sscanf(str, "%8x %8x %8x %8x %8x %8x %8x", &loading->rstate.v[7 * i],
-             &loading->rstate.v[7 * i + 1], &loading->rstate.v[7 * i + 2],
-             &loading->rstate.v[7 * i + 3], &loading->rstate.v[7 * i + 4],
-             &loading->rstate.v[7 * i + 5], &loading->rstate.v[7 * i + 6]);
+    if (secfile_lookup_int(loading->file, nullptr, "random.index_J")) {
+      qWarning().noquote() << QString::fromUtf8(
+          _("Cannot load old random generator state. Seeding a new one."));
+      fc_rand_seed(loading->rstate);
+    } else if (auto *state =
+                   secfile_lookup_str(loading->file, "random.state")) {
+      std::stringstream ss;
+      ss.imbue(std::locale::classic());
+      ss.str(state);
+      ss >> loading->rstate;
+      if (ss.fail()) {
+        qWarning().noquote() << QString::fromUtf8(
+            _("Cannot load the random generator state. Seeding a new one."));
+        fc_rand_seed(loading->rstate);
+      }
     }
-    loading->rstate.is_init = true;
     fc_rand_set_state(loading->rstate);
   } else {
     // No random values - mark the setting.
@@ -2248,27 +2243,16 @@ static void sg_save_random(struct savedata *saving)
   // Check status and return if not OK (sg_success != TRUE).
   sg_check_ret();
 
-  if (fc_rand_is_init()
-      && (!saving->scenario || game.scenario.save_random)) {
-    int i;
-    RANDOM_STATE rstate = fc_rand_state();
+  if (!saving->scenario || game.scenario.save_random) {
+    auto rstate = fc_rand_state();
+
+    std::stringstream ss;
+    ss.imbue(std::locale::classic());
+    ss << rstate;
+    auto state = ss.str();
 
     secfile_insert_bool(saving->file, true, "random.saved");
-    fc_assert(rstate.is_init);
-
-    secfile_insert_int(saving->file, rstate.j, "random.index_J");
-    secfile_insert_int(saving->file, rstate.k, "random.index_K");
-    secfile_insert_int(saving->file, rstate.x, "random.index_X");
-
-    for (i = 0; i < 8; i++) {
-      char vec[100];
-
-      fc_snprintf(vec, sizeof(vec), "%8x %8x %8x %8x %8x %8x %8x",
-                  rstate.v[7 * i], rstate.v[7 * i + 1], rstate.v[7 * i + 2],
-                  rstate.v[7 * i + 3], rstate.v[7 * i + 4],
-                  rstate.v[7 * i + 5], rstate.v[7 * i + 6]);
-      secfile_insert_str(saving->file, vec, "random.table%d", i);
-    }
+    secfile_insert_str(saving->file, state.data(), "random.state");
   } else {
     secfile_insert_bool(saving->file, false, "random.saved");
   }

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 The Freeciv21 contributors
+ * (c) Copyright 2021 The Freeciv21 contributors
  *
  * This file is part of Freeciv21.
  *
@@ -870,7 +870,7 @@ bool server::shut_game_down()
 
   // Reset server
   server_game_free();
-  fc_rand_uninit();
+  fc_rand_set_init(false);
   server_game_init(false);
   mapimg_reset();
   load_rulesets(NULL, NULL, false, NULL, true, false, true);

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -160,20 +160,11 @@ static civtimer *between_turns = NULL;
 void init_game_seed()
 {
   if (game.server.seed_setting == 0) {
-    /* We strip the high bit for now because neither game file nor
-       server options can handle unsigned ints yet. - Cedric */
-    game.server.seed = time(NULL) & (MAX_UINT32 >> 1);
-#ifdef FREECIV_TESTMATIC
-    // Log command to reproduce the gameseed
-    log_testmatic("set gameseed %d", game.server.seed);
-#else // FREECIV_TESTMATIC
-    log_debug("Setting game.seed:%d", game.server.seed);
-#endif // FREECIV_TESTMATIC
+    game.server.seed = 0;
+    fc_rand_seed(fc_rand_state());
+    fc_rand_set_init(true);
   } else {
     game.server.seed = game.server.seed_setting;
-  }
-
-  if (!fc_rand_is_init()) {
     fc_srand(game.server.seed);
   }
 }

--- a/utility/genlist.cpp
+++ b/utility/genlist.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -642,7 +642,7 @@ void genlist_shuffle(struct genlist *pgenlist)
   }
 
   // randomize it
-  std::shuffle(shuffle.begin(), shuffle.end(), freeciv::random_generator());
+  std::shuffle(shuffle.begin(), shuffle.end(), fc_rand_state());
 
   // create the shuffled list
   myiter = genlist_head(pgenlist);

--- a/utility/rand.cpp
+++ b/utility/rand.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2021 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -12,23 +12,8 @@
       \____/        ********************************************************/
 
 /*************************************************************************
-   The following random number generator can be found in _The Art of
-   Computer Programming Vol 2._ (2nd ed) by Donald E. Knuth. (C)  1998.
-   The algorithm is described in section 3.2.2 as Mitchell and Moore's
-   variant of a standard additive number generator.  Note that the
-   the constants 55 and 24 are not random.  Please become familiar with
-   this algorithm before you mess with it.
-
-   Since the additive number generator requires a table of numbers from
-   which to generate its random sequences, we must invent a way to
-   populate that table from a single seed value.  I have chosen to do
-   this with a different PRNG, known as the "linear congruential method"
-   (also found in Knuth, Vol2).  I must admit that my choices of constants
-   (3, 257, and MAX_UINT32) are probably not optimal, but they seem to
-   work well enough for our purposes.
-
-   Original author for this code: Cedric Tefft <cedric@earthling.net>
-   Modified to use rand_state struct by David Pfitzner <dwp@mso.anu.edu.au>
+   The following random number generator is a simple wrapper around the
+   C++ standard library.
 *************************************************************************/
 
 #ifdef HAVE_CONFIG_H
@@ -37,8 +22,6 @@
 
 // utility
 #include "log.h"
-#include "shared.h"
-#include "support.h" // TRUE, FALSE
 
 #include "rand.h"
 
@@ -49,196 +32,96 @@
  * Can be duplicated/saved/restored via fc_rand_state()
  * and fc_rand_set_state().
  */
-static RANDOM_STATE rand_state;
+namespace {
+Q_LOGGING_CATEGORY(random_category, "freeciv.random");
+static std::mt19937 generator = std::mt19937();
+bool is_init = false;
+} // namespace
 
 /**
    Returns a new random value from the sequence, in the interval 0 to
    (size-1) inclusive, and updates global state for next call.
    This means that if size <= 1 the function will always return 0.
-
-   Once we calculate new_rand below uniform (we hope) between 0 and
-   MAX_UINT32 inclusive, need to reduce to required range.  Using
-   modulus is bad because generators like this are generally less
-   random for their low-significance bits, so this can give poor
-   results when 'size' is small.  Instead want to divide the range
-   0..MAX_UINT32 into (size) blocks, each with (divisor) values, and
-   for any remainder, repeat the calculation of new_rand.
-   Then:
-          return_val = new_rand / divisor;
-   Will repeat for new_rand > max, where:
-          max = size * divisor - 1
-   Then max <= MAX_UINT32 implies
-          size * divisor <= (MAX_UINT32+1)
-   thus   divisor <= (MAX_UINT32+1)/size
-
-   Need to calculate this divisor.  Want divisor as large as possible
-   given above contraint, but it doesn't hurt us too much if it is a
-   bit smaller (just have to repeat more often).  Calculation exactly
-   as above is complicated by fact that (MAX_UINT32+1) may not be
-   directly representable in type RANDOM_TYPE, so we do instead:
-          divisor = MAX_UINT32/size
  */
-RANDOM_TYPE fc_rand_debug(RANDOM_TYPE size, const char *called_as, int line,
-                          const char *file)
+std::uint_fast32_t fc_rand_debug(std::uint_fast32_t size,
+                                 const char *called_as, int line,
+                                 const char *file)
 {
-  RANDOM_TYPE new_rand, divisor, max;
-  int bailout = 0;
+  std::uniform_int_distribution<std::uint_fast32_t> uniform(0, size + 1);
 
-  fc_assert_ret_val(rand_state.is_init, 0);
-
-  if (size > 1) {
-    divisor = MAX_UINT32 / size;
-    max = size * divisor - 1;
-  } else {
-    // size == 0 || size == 1
-
-    /*
-     * These assignments are only here to make the compiler
-     * happy. Since each usage is guarded with a if (size > 1).
-     */
-    max = MAX_UINT32;
-    divisor = 1;
-  }
-
-  do {
-    new_rand = (rand_state.v[rand_state.j] + rand_state.v[rand_state.k])
-               & MAX_UINT32;
-
-    rand_state.x = (rand_state.x + 1) % 56;
-    rand_state.j = (rand_state.j + 1) % 56;
-    rand_state.k = (rand_state.k + 1) % 56;
-    rand_state.v[rand_state.x] = new_rand;
-
-    if (++bailout > 10000) {
-      qCritical("%s(%lu) = %lu bailout at %s:%d", called_as,
-                static_cast<unsigned long>(size),
-                static_cast<unsigned long>(new_rand), file, line);
-      new_rand = 0;
-      break;
-    }
-  } while (size > 1 && new_rand > max);
-
-  if (size > 1) {
-    new_rand /= divisor;
-  } else {
-    new_rand = 0;
-  }
-
-  log_rand("%s(%lu) = %lu at %s:%d", called_as, (unsigned long) size,
-           (unsigned long) new_rand, file, line);
-
-  return new_rand;
+  auto random = uniform(generator);
+  qCDebug(random_category, "%s(%lu) = %lu at %s:%d", called_as,
+          (unsigned long) size, (unsigned long) random, file, line);
+  return random;
 }
 
 /**
    Initialize the generator; see comment at top of file.
  */
-void fc_srand(RANDOM_TYPE seed)
+void fc_srand(std::uint_fast32_t seed)
 {
-  int i;
-
-  rand_state.v[0] = (seed & MAX_UINT32);
-
-  for (i = 1; i < 56; i++) {
-    rand_state.v[i] = (3 * rand_state.v[i - 1] + 257) & MAX_UINT32;
-  }
-
-  rand_state.j = (55 - 55);
-  rand_state.k = (55 - 24);
-  rand_state.x = (55 - 0);
-
-  rand_state.is_init = true;
-  fc_rand(MAX_UINT32);
+  generator.seed(seed);
+  fc_rand_set_init(true);
 }
-
-/**
-   Mark fc_rand state uninitialized.
- */
-void fc_rand_uninit() { rand_state.is_init = false; }
 
 /**
    Return whether the current state has been initialized.
  */
-bool fc_rand_is_init() { return rand_state.is_init; }
+bool fc_rand_is_init() { return is_init; }
 
 /**
-   Return a copy of the current rand_state; eg for save/restore.
+ * Sets whether the current state has been initialized.
  */
-RANDOM_STATE fc_rand_state()
-{
-  int i;
+void fc_rand_set_init(bool init) { is_init = init; }
 
-  log_rand("fc_rand_state J=%d K=%d X=%d", rand_state.j, rand_state.k,
-           rand_state.x);
-  for (i = 0; i < 8; i++) {
-    log_rand("fc_rand_state %d, %08x %08x %08x %08x %08x %08x %08x", i,
-             rand_state.v[7 * i], rand_state.v[7 * i + 1],
-             rand_state.v[7 * i + 2], rand_state.v[7 * i + 3],
-             rand_state.v[7 * i + 4], rand_state.v[7 * i + 5],
-             rand_state.v[7 * i + 6]);
+namespace /* anonymous */ {
+
+/**
+ * Seed sequence based on std::random_device. Adapted from M. Skarupke,
+ * https://probablydance.com/2016/12/29/random_seed_seq-a-small-utility-to-properly-seed-random-number-generators-in-c/
+ */
+struct random_seed_seq {
+  /**
+   * Generates a random sequence.
+   */
+  template <typename It> void generate(It begin, It end)
+  {
+    for (; begin != end; ++begin) {
+      *begin = m_device();
+    }
   }
 
-  return rand_state;
+  /// Required by seed_seq.
+  using result_type = std::random_device::result_type;
+
+private:
+  std::random_device m_device;
+};
+} // anonymous namespace
+
+/**
+ * Seeds the given generator with a random value.
+ */
+void fc_rand_seed(std::mt19937 &gen)
+{
+  auto seed = random_seed_seq();
+  gen.seed(seed);
 }
+
+/**
+ * Returns a reference to the current random generator state; eg for
+ * save/restore.
+ */
+std::mt19937 &fc_rand_state() { return generator; }
 
 /**
    Replace current rand_state with user-supplied; eg for save/restore.
    Caller should take care to set state.is_init beforehand if necessary.
  */
-void fc_rand_set_state(RANDOM_STATE &state)
+void fc_rand_set_state(const std::mt19937 &state)
 {
-  int i;
-
-  rand_state = state;
-
-  log_rand("fc_rand_set_state J=%d K=%d X=%d", rand_state.j, rand_state.k,
-           rand_state.x);
-  for (i = 0; i < 8; i++) {
-    log_rand("fc_rand_set_state %d, %08x %08x %08x %08x %08x %08x %08x", i,
-             rand_state.v[7 * i], rand_state.v[7 * i + 1],
-             rand_state.v[7 * i + 2], rand_state.v[7 * i + 3],
-             rand_state.v[7 * i + 4], rand_state.v[7 * i + 5],
-             rand_state.v[7 * i + 6]);
-  }
-}
-
-/**
-   Test one aspect of randomness, using n numbers.
-   Reports results to LOG_TEST; with good randomness, behaviourchange
-   and behavioursame should be about the same size.
-   Tests current random state; saves and restores state, so can call
-   without interrupting current sequence.
- */
-void test_random1(int n)
-{
-  RANDOM_STATE saved_state;
-  int i, old_value = 0, new_value;
-  bool didchange, olddidchange = false;
-  int behaviourchange = 0, behavioursame = 0;
-
-  saved_state = fc_rand_state();
-  /* fc_srand(time(NULL)); */ // use current state
-
-  for (i = 0; i < n + 2; i++) {
-    new_value = fc_rand(2);
-    if (i > 0) { // have old
-      didchange = (new_value != old_value);
-      if (i > 1) { // have olddidchange
-        if (didchange != olddidchange) {
-          behaviourchange++;
-        } else {
-          behavioursame++;
-        }
-      }
-      olddidchange = didchange;
-    }
-    old_value = new_value;
-  }
-  log_test("test_random1(%d) same: %d, change: %d", n, behavioursame,
-           behaviourchange);
-
-  // restore state:
-  fc_rand_set_state(saved_state);
+  generator = state;
+  fc_rand_set_init(true);
 }
 
 /**
@@ -248,11 +131,12 @@ void test_random1(int n)
    Use an invariant equation for seed.
    Result is 0 to (size - 1).
  */
-RANDOM_TYPE fc_randomly_debug(RANDOM_TYPE seed, RANDOM_TYPE size,
-                              const char *called_as, int line,
-                              const char *file)
+std::uint_fast32_t fc_randomly_debug(std::uint_fast32_t seed,
+                                     std::uint_fast32_t size,
+                                     const char *called_as, int line,
+                                     const char *file)
 {
-  RANDOM_TYPE result;
+  std::uint_fast32_t result;
 
 #define LARGE_PRIME (10007)
 #define SMALL_PRIME (1009)

--- a/utility/rand.h
+++ b/utility/rand.h
@@ -1,5 +1,5 @@
 /**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
+ Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
   ( oo )        General Public License  as published by the Free Software
@@ -10,61 +10,29 @@
 **************************************************************************/
 #pragma once
 
-// Utility
-#include "support.h" // bool type
-
-typedef uint32_t RANDOM_TYPE;
-
-typedef struct {
-  RANDOM_TYPE v[56];
-  int j, k, x;
-  bool is_init; // initially 0 for static storage
-} RANDOM_STATE;
+#include <random>
 
 #define fc_rand(_size) fc_rand_debug((_size), "fc_rand", __LINE__, __FILE__)
 
-RANDOM_TYPE fc_rand_debug(RANDOM_TYPE size, const char *called_as, int line,
-                          const char *file);
+std::uint_fast32_t fc_rand_debug(std::uint_fast32_t size,
+                                 const char *called_as, int line,
+                                 const char *file);
 
-void fc_srand(RANDOM_TYPE seed);
+void fc_srand(std::uint_fast32_t seed);
+void fc_rand_seed(std::mt19937 &gen);
 
-void fc_rand_uninit();
 bool fc_rand_is_init();
-RANDOM_STATE fc_rand_state();
-void fc_rand_set_state(RANDOM_STATE &state);
+void fc_rand_set_init(bool init);
 
-void test_random1(int n);
+std::mt19937 &fc_rand_state();
+void fc_rand_set_state(const std::mt19937 &state);
 
 /*===*/
 
 #define fc_randomly(_seed, _size)                                           \
   fc_randomly_debug((_seed), (_size), "fc_randomly", __LINE__, __FILE__)
 
-RANDOM_TYPE fc_randomly_debug(RANDOM_TYPE seed, RANDOM_TYPE size,
-                              const char *called_as, int line,
-                              const char *file);
-
-namespace freeciv {
-
-/**
- * A UniformRandomBitGenerator class usable with STL algorithms and using the
- * Freeciv RNG under the hood.
- */
-class random_generator {
-public:
-  using result_type = RANDOM_TYPE;
-
-  static constexpr auto min() { return 0; }
-
-  static constexpr auto max()
-  {
-    return std::numeric_limits<result_type>::max() - 1;
-  }
-
-  auto operator()()
-  {
-    return fc_rand(std::numeric_limits<result_type>::max());
-  }
-};
-
-} // namespace freeciv
+std::uint_fast32_t fc_randomly_debug(std::uint_fast32_t seed,
+                                     std::uint_fast32_t size,
+                                     const char *called_as, int line,
+                                     const char *file);


### PR DESCRIPTION
Use an implementation from the standard library. The random generator is
constrained to use a well defined algorithm and produce the same results across
implementations. Seed it by pulling the state from the high-entropy
std::random_device: it has so many bits that it's likely very hard to figure
out the state. (Of course only if the implementation of std::random_device is
correct. I trust it more than anything I could write myself.)

The main drawback is that the state might be saved in an implementation defined
way, the reference isn't very clear about this. Work around this by generating
a new, truly random seed if loading the state fails. The main reason for saving
the state is to have deterministic results when loading a save several times,
so one can't "cheat" by reloading unit a warrior kills a tank. If someone wants
to cheat, s.he will manage: firing up the editor or editing the save directly
is much easier than building a server with another standard library.

Closes #358.