### PR TITLE
Fix use-after-free related to qUtf8Printable()

### DIFF
--- a/ai/default/aitech.cpp
+++ b/ai/default/aitech.cpp
@@ -194,11 +194,12 @@ static void dai_select_tech(struct ai_type *ait, struct player *pplayer,
     goal->want = goal_values[newgoal] / num_cities_nonzero;
     goal->current_want =
         (goal_values[presearch->tech_goal] / num_cities_nonzero);
-    log_debug("Goal->choice = %s, goal->want = " ADV_WANT_PRINTF
-              ", goal_value = %d, "
-              "num_cities_nonzero = %d",
-              research_advance_rule_name(presearch, goal->choice),
-              goal->want, goal_values[newgoal], num_cities_nonzero);
+    log_debug(
+        "Goal->choice = %s, goal->want = " ADV_WANT_PRINTF
+        ", goal_value = %d, "
+        "num_cities_nonzero = %d",
+        qUtf8Printable(research_advance_rule_name(presearch, goal->choice)),
+        goal->want, goal_values[newgoal], num_cities_nonzero);
   }
 
   /* we can't have this, which will happen in the circumstance
@@ -366,7 +367,8 @@ void dai_manage_tech(struct ai_type *ait, struct player *pplayer)
                                              false))) {
       TECH_LOG(ait, LOG_DEBUG, pplayer, advance_by_number(choice.choice),
                "new research, was %s, penalty was %d",
-               research_advance_rule_name(research, research->researching),
+               qUtf8Printable(research_advance_rule_name(
+                   research, research->researching)),
                penalty);
       choose_tech(research, choice.choice);
     }
@@ -377,12 +379,15 @@ void dai_manage_tech(struct ai_type *ait, struct player *pplayer)
    * (research->tech_goal) is practically never used, see the comment for
    * ai_next_tech_goal */
   if (goal.choice != research->tech_goal) {
-    log_debug("%s change goal from %s (want=" ADV_WANT_PRINTF
-              ") to %s (want=" ADV_WANT_PRINTF ")",
-              player_name(pplayer),
-              research_advance_rule_name(research, research->tech_goal),
-              goal.current_want,
-              research_advance_rule_name(research, goal.choice), goal.want);
+    log_debug(
+        "%s change goal from %s (want=" ADV_WANT_PRINTF
+        ") to %s (want=" ADV_WANT_PRINTF ")",
+        player_name(pplayer),
+        qUtf8Printable(
+            research_advance_rule_name(research, research->tech_goal)),
+        goal.current_want,
+        qUtf8Printable(research_advance_rule_name(research, goal.choice)),
+        goal.want);
     choose_tech_goal(research, goal.choice);
   }
 }

--- a/client/helpdata.cpp
+++ b/client/helpdata.cpp
@@ -4133,8 +4133,8 @@ void helptext_government(char *buf, size_t bufsz, struct player *pplayer,
         output_type_iterate_end;
       }
       if (outputs.count()) {
-        or_outputs = qUtf8Printable(strvec_to_or_list(outputs));
-        and_outputs = qUtf8Printable(strvec_to_and_list(outputs));
+        or_outputs = strvec_to_or_list(outputs);
+        and_outputs = strvec_to_and_list(outputs);
       }
 
       switch (peffect->type) {

--- a/common/networking/connection.cpp
+++ b/common/networking/connection.cpp
@@ -740,14 +740,14 @@ void conn_pattern_destroy(struct conn_pattern *ppattern)
 bool conn_pattern_match(const struct conn_pattern *ppattern,
                         const struct connection *pconn)
 {
-  const char *test = NULL;
+  QString test;
 
   switch (ppattern->type) {
   case CPT_USER:
     test = pconn->username;
     break;
   case CPT_HOST:
-    test = qUtf8Printable(pconn->addr);
+    test = pconn->addr;
     break;
   case CPT_IP:
     if (is_server()) {
@@ -756,8 +756,8 @@ bool conn_pattern_match(const struct conn_pattern *ppattern,
     break;
   }
 
-  if (NULL != test) {
-    return wildcard_fit_string(ppattern->wildcard, test);
+  if (!test.isEmpty()) {
+    return wildcard_fit_string(ppattern->wildcard, qUtf8Printable(test));
   } else {
     qCritical("%s(): Invalid pattern type (%d)", __FUNCTION__,
               ppattern->type);

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -230,29 +230,22 @@ static const char *research_future_set_name(QVector<QString> *psv, int no,
 /**
    Store the rule name of the given tech (including A_FUTURE) in 'buf'.
    'presearch' may be NULL.
-   We don't return a static buffer because that would break anything that
-   needed to work with more than one name at a time.
  */
-const char *research_advance_rule_name(const struct research *presearch,
-                                       Tech_type_id tech)
+QString research_advance_rule_name(const struct research *presearch,
+                                   Tech_type_id tech)
 {
   if (A_FUTURE == tech && NULL != presearch) {
     const int no = presearch->future_tech;
-    const char *name;
 
-    name = qUtf8Printable(future_rule_name->at(no));
-    if (name == NULL) {
+    if (no >= future_rule_name->size()) {
       char buffer[256];
 
       // NB: 'presearch->future_tech == 0' means "Future Tech. 1".
       fc_snprintf(buffer, sizeof(buffer), "%s %d",
                   rule_name_get(&advance_future_name), no + 1);
-      name = research_future_set_name(future_rule_name, no, buffer);
+      return research_future_set_name(future_rule_name, no, buffer);
     }
-
-    fc_assert(name != NULL);
-
-    return name;
+    return future_rule_name->at(no);
   }
 
   return rule_name_get(research_advance_name(tech));
@@ -261,12 +254,9 @@ const char *research_advance_rule_name(const struct research *presearch,
 /**
    Store the translated name of the given tech (including A_FUTURE) in 'buf'.
    'presearch' may be NULL.
-   We don't return a static buffer because that would break anything that
-   needed to work with more than one name at a time.
  */
-const QString
-research_advance_name_translation(const struct research *presearch,
-                                  Tech_type_id tech)
+QString research_advance_name_translation(const struct research *presearch,
+                                          Tech_type_id tech)
 {
   if (A_FUTURE == tech && NULL != presearch) {
     const int no = presearch->future_tech;

--- a/common/research.h
+++ b/common/research.h
@@ -107,11 +107,10 @@ int research_pretty_name(const struct research *presearch, char *buf,
 struct research *research_by_number(int number);
 struct research *research_get(const struct player *pplayer);
 
-const char *research_advance_rule_name(const struct research *presearch,
-                                       Tech_type_id tech);
-const QString
-research_advance_name_translation(const struct research *presearch,
-                                  Tech_type_id tech);
+QString research_advance_rule_name(const struct research *presearch,
+                                   Tech_type_id tech);
+QString research_advance_name_translation(const struct research *presearch,
+                                          Tech_type_id tech);
 
 // Ancillary routines
 void research_update(struct research *presearch);

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -146,7 +146,6 @@ void do_tech_parasite_effect(struct player *pplayer)
   struct research *plr_research;
   QString effects;
   char research_name[MAX_LEN_NAME * 2];
-  const char *advance_name;
   Tech_type_id tech;
   /* Note that two EFT_TECH_PARASITE effects will combine into a single,
    * much worse effect. */
@@ -197,26 +196,26 @@ void do_tech_parasite_effect(struct player *pplayer)
 
   // Notify.
   research_pretty_name(plr_research, research_name, sizeof(research_name));
-  advance_name =
-      qUtf8Printable(research_advance_name_translation(plr_research, tech));
+  auto advance_name = research_advance_name_translation(plr_research, tech);
   effects = get_effect_list_req_text(plist);
 
   notify_player(pplayer, NULL, E_TECH_GAIN, ftc_server,
                 /* TRANS: Tech from source of an effect
                  * (Great Library) */
-                Q_("?fromeffect:%s acquired from %s!"), advance_name,
-                qUtf8Printable(effects));
+                Q_("?fromeffect:%s acquired from %s!"),
+                qUtf8Printable(advance_name), qUtf8Printable(effects));
   notify_research(plr_research, pplayer, E_TECH_GAIN, ftc_server,
                   /* TRANS: Tech from source of an effect
                    * (Great Library) */
-                  Q_("?fromeffect:%s acquired from %s's %s!"), advance_name,
-                  player_name(pplayer), qUtf8Printable(effects));
+                  Q_("?fromeffect:%s acquired from %s's %s!"),
+                  qUtf8Printable(advance_name), player_name(pplayer),
+                  qUtf8Printable(effects));
   notify_research_embassies(
       plr_research, NULL, E_TECH_EMBASSY, ftc_server,
       /* TRANS: Tech from source of an effect
        * (Great Library) */
       Q_("?fromeffect:The %s have acquired %s from %s."), research_name,
-      advance_name, qUtf8Printable(effects));
+      qUtf8Printable(advance_name), qUtf8Printable(effects));
 
   effect_list_destroy(plist);
 

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -569,21 +569,20 @@ void found_new_tech(struct research *presearch, Tech_type_id tech_found,
   if (bonus_tech_hack) {
     Tech_type_id additional_tech;
     char research_name[MAX_LEN_NAME * 2];
-    const char *radv_name;
 
     research_pretty_name(presearch, research_name, sizeof(research_name));
 
     additional_tech = pick_free_tech(presearch);
 
-    radv_name = qUtf8Printable(
-        research_advance_name_translation(presearch, additional_tech));
+    auto radv_name =
+        research_advance_name_translation(presearch, additional_tech);
 
     give_immediate_free_tech(presearch, additional_tech);
     if (advance_by_number(tech_found)->bonus_message != NULL
         && additional_tech != A_UNSET) {
       notify_research(presearch, NULL, E_TECH_GAIN, ftc_server,
                       _(advance_by_number(tech_found)->bonus_message),
-                      radv_name);
+                      qUtf8Printable(radv_name));
     } else if (additional_tech != A_UNSET) {
       /* FIXME: "your" when it was just civilization of one of the players
        * sharing the reseach. */
@@ -591,12 +590,12 @@ void found_new_tech(struct research *presearch, Tech_type_id tech_found,
                       _("Great scientists from all the "
                         "world join your civilization: you learn "
                         "%s immediately."),
-                      radv_name);
+                      qUtf8Printable(radv_name));
     }
     // TODO: Ruleset should be able to customize this message too
     notify_research_embassies(presearch, NULL, E_TECH_EMBASSY, ftc_server,
                               _("%s acquire %s as a result of learning %s."),
-                              research_name, radv_name,
+                              research_name, qUtf8Printable(radv_name),
                               qUtf8Printable(advance_name));
   }
 }

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -682,7 +682,8 @@ void update_bulbs(struct player *pplayer, int bulbs, bool check_tech)
         log_debug("%s: tech loss (%s)", research_rule_name(research),
                   (is_future_tech(tech)
                        ? "Future Tech"
-                       : research_advance_rule_name(research, tech)));
+                       : qUtf8Printable(
+                           research_advance_rule_name(research, tech))));
         research_tech_lost(research, tech);
         /* Make notification after losing the research, in case it is
          * a future tech (for getting the right tech number). */

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2237,7 +2237,8 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
         break;
       } else {
         log_debug("Pressed tech %s from captured enemy",
-                  research_advance_rule_name(research_get(pvictor), ttid));
+                  qUtf8Printable(research_advance_rule_name(
+                      research_get(pvictor), ttid)));
         if (!fc_rand(3)) {
           break; // out of luck
         }

--- a/tools/ruleutil/rulesave.cpp
+++ b/tools/ruleutil/rulesave.cpp
@@ -343,15 +343,7 @@ static bool save_strvec(struct section_file *sfile,
                         const char *entry)
 {
   if (to_save != NULL) {
-    int sect_count = to_save->count();
-    const char *sections[sect_count];
-    int i;
-
-    for (i = 0; i < sect_count; i++) {
-      sections[i] = qUtf8Printable(to_save->at(i));
-    }
-
-    secfile_insert_str_vec(sfile, sections, sect_count, "%s.%s", path,
+    secfile_insert_str_vec(sfile, *to_save, to_save->size(), "%s.%s", path,
                            entry);
   }
 

--- a/utility/registry_ini.h
+++ b/utility/registry_ini.h
@@ -185,6 +185,12 @@ size_t secfile_insert_str_vec_full(struct section_file *secfile,
                                    const char *comment, bool allow_replace,
                                    bool no_escape, const char *path, ...)
     fc__attribute((__format__(__printf__, 7, 8)));
+size_t secfile_insert_str_vec_full(struct section_file *secfile,
+                                   const QVector<QString> &strings,
+                                   size_t dim, const char *comment,
+                                   bool allow_replace, bool no_escape,
+                                   const char *path, ...)
+    fc__attribute((__format__(__printf__, 7, 8)));
 #define secfile_insert_str_vec(secfile, strings, dim, path, ...)            \
   secfile_insert_str_vec_full(secfile, strings, dim, NULL, false, false,    \
                               path, ##__VA_ARGS__)


### PR DESCRIPTION
`qUtf8Printable(...)` returns a pointer to the data of a temporary `QByteArray` that is freed at the end of the statement, and therefore the returned pointer shouldn't be saved as it's going to be dangling immediately. This PR fixes all such cases I could find by turning the saved variable into a `QString`.