### PR TITLE
Fix opening the city screen from the city list

### DIFF
--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -55,6 +55,7 @@
 #include "mapview.h"
 #include "page_game.h"
 #include "qtg_cxxside.h"
+#include "sidebar.h"
 #include "tooltips.h"
 
 extern QApplication *qapp;
@@ -2838,6 +2839,7 @@ void city_dialog::update_title()
  */
 void qtg_real_city_dialog_popup(struct city *pcity)
 {
+  sidebarShowMap(true);
   queen()->mapview_wdg->hide_all_fcwidgets();
   center_tile_mapcanvas(pcity->tile);
 

--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -24,6 +24,7 @@
 #include "nation.h"
 #include "research.h"
 // client
+#include "citydlg_g.h"
 #include "client_main.h"
 #include "climisc.h"
 #include "ratesdlg_g.h"
@@ -546,6 +547,7 @@ void sidebar::resizeMe(int hght, bool force)
 void sidebarShowMap(bool nothing)
 {
   Q_UNUSED(nothing)
+  popdown_all_city_dialogs();
   queen()->game_tab_widget->setCurrentIndex(0);
 }
 


### PR DESCRIPTION
The map has to be shown first so the widgets inside get a layout. Also fix a similar issue when switching tab while the city screen is on.

Fixes #232.