### PR TITLE
Check if the new unit fits in transport when upgrading transported unit

### DIFF
--- a/common/unit.cpp
+++ b/common/unit.cpp
@@ -1869,7 +1869,7 @@ enum unit_upgrade_result unit_upgrade_test(const struct unit *punit,
 
   if (punit->transporter != NULL) {
     if (!can_unit_type_transport(unit_type_get(punit->transporter),
-                                 unit_class_get(punit))) {
+                                 utype_class(to_unittype))) {
       return UU_UNSUITABLE_TRANSPORT;
     }
   } else if (!can_exist_at_tile(&(wld.map), to_unittype, unit_tile(punit))) {


### PR DESCRIPTION
The old code checked if the current unit fits, so you could end up with
an impossible unit on the transport.

See hrm Bug #921691
Closes #248.