### PR TITLE
Replace usage of qPrintable() with qUtf8Printable()

### DIFF
--- a/ai/default/ailog.h
+++ b/ai/default/ailog.h
@@ -35,7 +35,7 @@ QString tech_log_prefix(ai_type *ait, const player *pplayer,
     if (notify) {                                                           \
       qCInfo(ai_category).noquote() << message;                             \
       notify_conn(NULL, NULL, E_AI_DEBUG, ftc_log, "%s",                    \
-                  qPrintable(message));                                     \
+                  qUtf8Printable(message));                                 \
     } else {                                                                \
       qCDebug(ai_category).noquote() << message;                            \
     }                                                                       \
@@ -52,7 +52,7 @@ QString diplo_log_prefix(ai_type *ait, const player *pplayer,
     if (notify) {                                                           \
       qCInfo(ai_category).noquote() << message;                             \
       notify_conn(NULL, NULL, E_AI_DEBUG, ftc_log, "%s",                    \
-                  qPrintable(message));                                     \
+                  qUtf8Printable(message));                                 \
     } else {                                                                \
       qCDebug(ai_category).noquote() << message;                            \
     }                                                                       \
@@ -68,7 +68,7 @@ QString bodyguard_log_prefix(ai_type *ait, const unit *punit);
     if (notify) {                                                           \
       qCInfo(ai_category).noquote() << message;                             \
       notify_conn(NULL, NULL, E_AI_DEBUG, ftc_log, "%s",                    \
-                  qPrintable(message));                                     \
+                  qUtf8Printable(message));                                 \
     } else {                                                                \
       qCDebug(ai_category).noquote() << message;                            \
     }                                                                       \

--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -273,7 +273,7 @@ const QVector<QString> *citybar_painter::available_vector(const option *)
   static QVector<QString> vector;
   if (vector.isEmpty()) {
     for (auto &name : available()) {
-      vector << _(qPrintable(name));
+      vector << _(qUtf8Printable(name));
     }
   }
   return &vector;
@@ -318,9 +318,10 @@ void citybar_painter::set_current(const QString &name)
   } else if (available().contains(name)) {
     qCCritical(bugs_category,
                "Could not instantiate known city bar style %s",
-               qPrintable(name));
+               qUtf8Printable(name));
   } else {
-    qCCritical(bugs_category, "Unknown city bar style %s", qPrintable(name));
+    qCCritical(bugs_category, "Unknown city bar style %s",
+               qUtf8Printable(name));
   }
 
   // Allocate the default to avoid crashes

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -434,7 +434,8 @@ int client_main(int argc, char *argv[])
     server_port =
         parser.value(QStringLiteral("port")).toUInt(&conversion_ok);
     if (!conversion_ok) {
-      qFatal(_("Invalid port number %s"), qPrintable(parser.value("port")));
+      qFatal(_("Invalid port number %s"),
+             qUtf8Printable(parser.value("port")));
       exit(EXIT_FAILURE);
     }
   }
@@ -455,7 +456,7 @@ int client_main(int argc, char *argv[])
       announce = ANNOUNCE_NONE;
     } else {
       qCritical(_("Illegal value \"%s\" for --Announce"),
-                qPrintable(parser.value("Announce")));
+                qUtf8Printable(parser.value("Announce")));
     }
   }
   if (parser.isSet(QStringLiteral("warnings"))) {
@@ -601,19 +602,19 @@ static void log_option_save_msg(QtMsgType lvl, const QString &msg)
 {
   switch (lvl) {
   case QtDebugMsg:
-    qDebug("%s", qPrintable(msg));
+    qDebug("%s", qUtf8Printable(msg));
     break;
   case QtInfoMsg:
-    qInfo("%s", qPrintable(msg));
+    qInfo("%s", qUtf8Printable(msg));
     break;
   case QtWarningMsg:
-    qWarning("%s", qPrintable(msg));
+    qWarning("%s", qUtf8Printable(msg));
     break;
   case QtCriticalMsg:
-    qCritical("%s", qPrintable(msg));
+    qCritical("%s", qUtf8Printable(msg));
     break;
   case QtFatalMsg:
-    qFatal("%s", qPrintable(msg));
+    qFatal("%s", qUtf8Printable(msg));
     break;
   }
 }

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -90,7 +90,7 @@ static void client_conn_close_callback(struct connection *pconn)
   close_socket_nomessage(pconn);
   // If we lost connection to the internal server - kill it.
   client_kill_server(true);
-  qCritical("Lost connection to server: %s.", qPrintable(reason));
+  qCritical("Lost connection to server: %s.", qUtf8Printable(reason));
   output_window_printf(ftc_client, _("Lost connection to server (%s)!"),
                        qUtf8Printable(reason));
 }

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -277,7 +277,7 @@ bool client_start_server()
   }
 
   // Start it
-  qInfo(_("Starting freeciv21-server at %s"), qPrintable(location));
+  qInfo(_("Starting freeciv21-server at %s"), qUtf8Printable(location));
 
   serverProcess::i()->start(location, arguments);
   if (!serverProcess::i()->waitForStarted(3000)) {
@@ -402,7 +402,7 @@ void send_client_wants_hack(const char *filename)
     QDir().mkpath(sdir);
 
     fc_snprintf(challenge_fullname, sizeof(challenge_fullname), "%s/%s",
-                qPrintable(sdir), filename);
+                qUtf8Printable(sdir), filename);
 
     // generate an authentication token
     randomize_string(req.token, sizeof(req.token));

--- a/client/gui-qt/helpdlg.cpp
+++ b/client/gui-qt/helpdlg.cpp
@@ -739,13 +739,14 @@ void help_widget::anchor_clicked(const QString &link)
   st = sl.at(1);
   st = st.replace("\u00A0", QLatin1String(" "));
 
-  if (strcmp(qPrintable(st), REQ_LABEL_NEVER) != 0
-      && strcmp(qPrintable(st), skip_intl_qualifier_prefix(REQ_LABEL_NONE))
+  if (strcmp(qUtf8Printable(st), REQ_LABEL_NEVER) != 0
+      && strcmp(qUtf8Printable(st),
+                skip_intl_qualifier_prefix(REQ_LABEL_NONE))
              != 0
-      && strcmp(qPrintable(st),
+      && strcmp(qUtf8Printable(st),
                 advance_name_translation(advance_by_number(A_NONE)))
              != 0) {
-    popup_help_dialog_typed(qPrintable(st), type);
+    popup_help_dialog_typed(qUtf8Printable(st), type);
   }
 }
 

--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -297,7 +297,8 @@ int main(int argc, char *argv[])
         parser.value(QStringLiteral("port")).toUInt(&conversion_ok);
     srvarg.user_specified_port = true;
     if (!conversion_ok) {
-      qFatal(_("Invalid port number %s"), qPrintable(parser.value("port")));
+      qFatal(_("Invalid port number %s"),
+             qUtf8Printable(parser.value("port")));
       exit(EXIT_FAILURE);
     }
   }
@@ -315,7 +316,8 @@ int main(int argc, char *argv[])
     srvarg.quitidle =
         parser.value(QStringLiteral("quitidle")).toUInt(&conversion_ok);
     if (!conversion_ok) {
-      qFatal(_("Invalid number %s"), qPrintable(parser.value("quitidle")));
+      qFatal(_("Invalid number %s"),
+             qUtf8Printable(parser.value("quitidle")));
       exit(EXIT_FAILURE);
     }
   }
@@ -364,7 +366,7 @@ int main(int argc, char *argv[])
       srvarg.announce = ANNOUNCE_NONE;
     } else {
       qCritical(_("Illegal value \"%s\" for --Announce"),
-                qPrintable(parser.value("Announce")));
+                qUtf8Printable(parser.value("Announce")));
     }
   }
   if (parser.isSet(QStringLiteral("warnings"))) {

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -384,7 +384,7 @@ QTcpServer *server_open_socket()
   int max = srvarg.port + 100;
   for (; srvarg.port < max; ++srvarg.port) {
     qDebug("Server attempting to listen on %s:%d",
-           srvarg.bind_addr.isNull() ? qPrintable(srvarg.bind_addr)
+           srvarg.bind_addr.isNull() ? qUtf8Printable(srvarg.bind_addr)
                                      : "(any)",
            srvarg.port);
     if (server->listen(QHostAddress::Any, srvarg.port)) {
@@ -395,7 +395,7 @@ QTcpServer *server_open_socket()
     if (srvarg.user_specified_port) {
       // Failure to meet user expectations.
       qFatal("%s",
-             qPrintable(
+             qUtf8Printable(
                  QString::fromUtf8(
                      // TRANS: %1 is a port number, %2 is the error message
                      _("Server: cannot listen on port %1: %2"))

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -192,7 +192,7 @@ QTcpServer *srv_prepare()
         fileinfoname(get_data_dirs(), qUtf8Printable(srvarg.ruleset));
     if (testfilename.isEmpty()) {
       qFatal(_("Ruleset directory \"%s\" not found"),
-             qPrintable(srvarg.ruleset));
+             qUtf8Printable(srvarg.ruleset));
       QCoreApplication::exit(EXIT_FAILURE);
       return tcp_server;
     }
@@ -212,7 +212,7 @@ QTcpServer *srv_prepare()
 
   if (!(srvarg.metaserver_no_send)) {
     qInfo(_("Sending info to metaserver <%s>."),
-          qPrintable(meta_addr_port()));
+          qUtf8Printable(meta_addr_port()));
     // Open socket for meta server
     if (!server_open_meta(srvarg.metaconnection_persistent)
         || !send_server_info_to_metaserver(META_INFO)) {

--- a/server/srv_log.h
+++ b/server/srv_log.h
@@ -87,7 +87,7 @@ QString city_log_prefix(const city *pcity);
     if (notify) {                                                           \
       qInfo().noquote() << message;                                         \
       notify_conn(NULL, NULL, E_AI_DEBUG, ftc_log, "%s",                    \
-                  qPrintable(message));                                     \
+                  qUtf8Printable(message));                                 \
     } else {                                                                \
       qDebug().noquote() << message;                                        \
     }                                                                       \
@@ -104,7 +104,7 @@ QString unit_log_prefix(const unit *punit);
     if (notify) {                                                           \
       qInfo().noquote() << message;                                         \
       notify_conn(NULL, NULL, E_AI_DEBUG, ftc_log, "%s",                    \
-                  qPrintable(message));                                     \
+                  qUtf8Printable(message));                                 \
     } else {                                                                \
       qDebug().noquote() << message;                                        \
     }                                                                       \

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -811,7 +811,7 @@ int main(int argc, char **argv)
 
   // Set ruleset user requested in to use
   if (!ruleset.isEmpty()) {
-    sz_strlcpy(game.server.rulesetdir, qPrintable(ruleset));
+    sz_strlcpy(game.server.rulesetdir, qUtf8Printable(ruleset));
   }
 
   settings_init(false);

--- a/tools/fcmp/download.cpp
+++ b/tools/fcmp/download.cpp
@@ -526,7 +526,7 @@ const char *download_modpack_list(const struct fcmp_params *fcmp,
 
     // Call the callback with the modpack info we just parsed
     cb(name, resolved, version, license, type,
-       QString::fromUtf8(_(qPrintable(subtype))), notes);
+       QString::fromUtf8(_(qUtf8Printable(subtype))), notes);
   }
 
   return nullptr;

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -48,17 +48,17 @@ void load_install_info_lists(struct fcmp_params *fcmp)
 
   fc_snprintf(main_db_filename, sizeof(main_db_filename),
               "%s/" DATASUBDIR "/" FCMP_CONTROLD "/mp.db",
-              qPrintable(fcmp->inst_prefix));
+              qUtf8Printable(fcmp->inst_prefix));
   fc_snprintf(scenario_db_filename, sizeof(scenario_db_filename),
               "%s/scenarios/" FCMP_CONTROLD "/mp.db",
-              qPrintable(fcmp->inst_prefix));
+              qUtf8Printable(fcmp->inst_prefix));
 
   fc_snprintf(main_ii_filename, sizeof(main_ii_filename),
               "%s/" DATASUBDIR "/" FCMP_CONTROLD "/modpacks.db",
-              qPrintable(fcmp->inst_prefix));
+              qUtf8Printable(fcmp->inst_prefix));
   fc_snprintf(scenario_ii_filename, sizeof(scenario_ii_filename),
               "%s/scenarios/" FCMP_CONTROLD "/modpacks.db",
-              qPrintable(fcmp->inst_prefix));
+              qUtf8Printable(fcmp->inst_prefix));
 
   if (fc_stat(main_db_filename, &buf)) {
     create_mpdb(main_db_filename, false);

--- a/tools/ruleup.cpp
+++ b/tools/ruleup.cpp
@@ -154,11 +154,11 @@ int main(int argc, char **argv)
       qCritical(R__("Failed to load %s."), COMMENTS_FILE_NAME);
     }
 
-    save_ruleset(qPrintable(tgt_dir), game.control.name, &data);
-    qInfo("Saved %s", qPrintable(tgt_dir));
+    save_ruleset(qUtf8Printable(tgt_dir), game.control.name, &data);
+    qInfo("Saved %s", qUtf8Printable(tgt_dir));
     comments_free();
   } else {
-    qCritical(_("Can't load ruleset %s"), qPrintable(rs_selected));
+    qCritical(_("Can't load ruleset %s"), qUtf8Printable(rs_selected));
   }
 
   log_close();

--- a/utility/inputfile.cpp
+++ b/utility/inputfile.cpp
@@ -777,14 +777,14 @@ static QString get_token_value(struct inputfile *inf)
     if (rfname == NULL) {
 
       qCCritical(inf_category, _("Cannot find stringfile \"%s\"."),
-                 qPrintable(name));
+                 qUtf8Printable(name));
       return "";
     }
     auto fp = new KFilterDev(rfname);
     fp->open(QIODevice::ReadOnly);
     if (!fp->isOpen()) {
       qCCritical(inf_category, _("Cannot open stringfile \"%s\"."),
-                 qPrintable(rfname));
+                 qUtf8Printable(rfname));
       delete fp;
       return "";
     }

--- a/utility/log.cpp
+++ b/utility/log.cpp
@@ -137,7 +137,7 @@ bool log_init(const QString &level_str)
     //        "debug". It's exactly what the user must type.
     qCritical(_("\"%s\" is not a valid log level name (valid names are "
                 "fatal/critical/warning/info/debug)"),
-              qPrintable(level_str));
+              qUtf8Printable(level_str));
     return false;
   }
 }
@@ -256,6 +256,6 @@ void log_time(const QString &msg, bool log)
     logging = true;
   }
   if (logging) {
-    qInfo() << qPrintable(msg);
+    qInfo() << qUtf8Printable(msg);
   }
 }

--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -222,7 +222,7 @@ section_entry_filereference_new(struct section *psection, const char *name,
  */
 static QString datafilename(const QString &filename)
 {
-  return fileinfoname(get_data_dirs(), qPrintable(filename));
+  return fileinfoname(get_data_dirs(), qUtf8Printable(filename));
 }
 
 /**
@@ -346,14 +346,14 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
          * normally a section may be split up, and that will no longer
          * work here because it will be short-cut. */
         SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(
+                    qUtf8Printable(inf_log_str(
                         inf, "Found requested section; finishing")));
         goto END;
       }
       if (table_state) {
         SECFILE_LOG(
             secfile, psection, "%s",
-            qPrintable(inf_log_str(inf, "New section during table")));
+            qUtf8Printable(inf_log_str(inf, "New section during table")));
         error = true;
         goto END;
       }
@@ -373,8 +373,9 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
         }
       }
       if (inf_token(inf, INF_TOK_EOL).isEmpty()) {
-        SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Expected end of line")));
+        SECFILE_LOG(
+            secfile, psection, "%s",
+            qUtf8Printable(inf_log_str(inf, "Expected end of line")));
         error = true;
         goto END;
       }
@@ -383,13 +384,14 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
     if (!inf_token(inf, INF_TOK_TABLE_END).isEmpty()) {
       if (!table_state) {
         SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Misplaced \"}\"")));
+                    qUtf8Printable(inf_log_str(inf, "Misplaced \"}\"")));
         error = true;
         goto END;
       }
       if (inf_token(inf, INF_TOK_EOL).isEmpty()) {
-        SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Expected end of line")));
+        SECFILE_LOG(
+            secfile, psection, "%s",
+            qUtf8Printable(inf_log_str(inf, "Expected end of line")));
         error = true;
         goto END;
       }
@@ -406,7 +408,7 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
         inf_discard_tokens(inf, INF_TOK_EOL); // allow newlines
         if ((tok = inf_token(inf, INF_TOK_VALUE)).isEmpty()) {
           SECFILE_LOG(secfile, psection, "%s",
-                      qPrintable(inf_log_str(inf, "Expected value")));
+                      qUtf8Printable(inf_log_str(inf, "Expected value")));
           error = true;
           goto END;
         }
@@ -424,8 +426,9 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
       } while (!inf_token(inf, INF_TOK_COMMA).isEmpty());
 
       if (inf_token(inf, INF_TOK_EOL).isEmpty()) {
-        SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Expected end of line")));
+        SECFILE_LOG(
+            secfile, psection, "%s",
+            qUtf8Printable(inf_log_str(inf, "Expected end of line")));
         error = true;
         goto END;
       }
@@ -435,7 +438,7 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
 
     if ((tok = inf_token(inf, INF_TOK_ENTRY_NAME)).isEmpty()) {
       SECFILE_LOG(secfile, psection, "%s",
-                  qPrintable(inf_log_str(inf, "Expected entry name")));
+                  qUtf8Printable(inf_log_str(inf, "Expected entry name")));
       error = true;
       goto END;
     }
@@ -452,13 +455,13 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
         inf_discard_tokens(inf, INF_TOK_EOL); // allow newlines
         if ((tok = inf_token(inf, INF_TOK_VALUE)).isEmpty()) {
           SECFILE_LOG(secfile, psection, "%s",
-                      qPrintable(inf_log_str(inf, "Expected value")));
+                      qUtf8Printable(inf_log_str(inf, "Expected value")));
           error = true;
           goto END;
         }
         if (tok[0] != '\"') {
           SECFILE_LOG(secfile, psection, "%s",
-                      qPrintable(inf_log_str(
+                      qUtf8Printable(inf_log_str(
                           inf, "Table column header non-string")));
           error = true;
           goto END;
@@ -467,8 +470,9 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
       } while (!inf_token(inf, INF_TOK_COMMA).isEmpty());
 
       if (inf_token(inf, INF_TOK_EOL).isEmpty()) {
-        SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Expected end of line")));
+        SECFILE_LOG(
+            secfile, psection, "%s",
+            qUtf8Printable(inf_log_str(inf, "Expected end of line")));
         error = true;
         goto END;
       }
@@ -483,7 +487,7 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
       inf_discard_tokens(inf, INF_TOK_EOL); // allow newlines
       if ((tok = inf_token(inf, INF_TOK_VALUE)).isEmpty()) {
         SECFILE_LOG(secfile, psection, "%s",
-                    qPrintable(inf_log_str(inf, "Expected value")));
+                    qUtf8Printable(inf_log_str(inf, "Expected value")));
         error = true;
         goto END;
       }
@@ -497,7 +501,7 @@ static struct section_file *secfile_from_input_file(struct inputfile *inf,
     } while (!inf_token(inf, INF_TOK_COMMA).isEmpty());
     if (inf_token(inf, INF_TOK_EOL).isEmpty()) {
       SECFILE_LOG(secfile, psection, "%s",
-                  qPrintable(inf_log_str(inf, "Expected end of line")));
+                  qUtf8Printable(inf_log_str(inf, "Expected end of line")));
       error = true;
       goto END;
     }
@@ -834,7 +838,7 @@ bool secfile_save(const struct section_file *secfile, QString filename)
 
   if (fs->error() != 0) {
     SECFILE_LOG(secfile, NULL, "Error before closing %s: %s", real_filename,
-                qPrintable(fs->errorString()));
+                qUtf8Printable(fs->errorString()));
     return false;
   }
 
@@ -2790,7 +2794,7 @@ struct section *secfile_section_new(struct section_file *secfile,
 
   if (!is_secfile_entry_name_valid(name)) {
     SECFILE_LOG(secfile, NULL, "\"%s\" is not a valid section name.",
-                qPrintable(name));
+                qUtf8Printable(name));
     return NULL;
   }
 
@@ -2798,13 +2802,13 @@ struct section *secfile_section_new(struct section_file *secfile,
     /* We cannot duplicate sections in any case! Not even if one is
      * include -section and the other not. */
     SECFILE_LOG(secfile, NULL, "Section \"%s\" already exists.",
-                qPrintable(name));
+                qUtf8Printable(name));
     return NULL;
   }
 
   psection = new section;
   psection->special = EST_NORMAL;
-  psection->name = qstrdup(qPrintable(name));
+  psection->name = qstrdup(qUtf8Printable(name));
   psection->entries = entry_list_new_full(entry_destroy);
 
   // Append to secfile.
@@ -3002,19 +3006,19 @@ static entry *entry_new(struct section *psection, const QString &name)
 
   if (!is_secfile_entry_name_valid(name)) {
     SECFILE_LOG(secfile, psection, "\"%s\" is not a valid entry name.",
-                qPrintable(name));
+                qUtf8Printable(name));
     return NULL;
   }
 
   if (!secfile->allow_duplicates
       && NULL != section_entry_by_name(psection, name)) {
     SECFILE_LOG(secfile, psection, "Entry \"%s\" already exists.",
-                qPrintable(name));
+                qUtf8Printable(name));
     return NULL;
   }
 
   pentry = new entry;
-  pentry->name = qstrdup(qPrintable(name));
+  pentry->name = qstrdup(qUtf8Printable(name));
   pentry->type = ENTRY_ILLEGAL; // Invalid case
   pentry->used = 0;
   pentry->comment = NULL;
@@ -3512,8 +3516,8 @@ static void entry_from_inf_token(struct section *psection,
                                  struct inputfile *inf)
 {
   if (!entry_from_token(psection, name, tok)) {
-    qCritical("%s",
-              qPrintable(inf_log_str(inf, "Entry value not recognized: %s",
-                                     qPrintable(tok))));
+    qCritical("%s", qUtf8Printable(
+                        inf_log_str(inf, "Entry value not recognized: %s",
+                                    qUtf8Printable(tok))));
   }
 }

--- a/utility/section_file.cpp
+++ b/utility/section_file.cpp
@@ -119,7 +119,7 @@ bool entry_from_token(struct section *psection, const QString &name,
   if ('*' == tok[0]) {
     auto buf = remove_escapes(tok.mid(1), false);
     (void) section_entry_str_new(psection, name, buf, false);
-    DEBUG_ENTRIES("entry %s '%s'", name, qPrintable(buf));
+    DEBUG_ENTRIES("entry %s '%s'", name, qUtf8Printable(buf));
     return true;
   }
 
@@ -127,7 +127,7 @@ bool entry_from_token(struct section *psection, const QString &name,
     bool escaped = ('"' == tok[0]);
     auto buf = remove_escapes(tok.mid(1), escaped);
     (void) section_entry_str_new(psection, name, buf, escaped);
-    DEBUG_ENTRIES("entry %s '%s'", name, qPrintable(buf));
+    DEBUG_ENTRIES("entry %s '%s'", name, qUtf8Printable(buf));
     return true;
   }
 


### PR DESCRIPTION
On Windows, qPrintable() may return a string in the local code page, while the code expects UTF-8 everywhere.

Unfortunately, console I/O on Windows is still a broken mess.

Closes #280.