### PR TITLE
Give names to units

### DIFF
--- a/client/gui-qt/hudwidget.cpp
+++ b/client/gui-qt/hudwidget.cpp
@@ -604,12 +604,28 @@ void hud_units::update_actions(unit_list *punits)
     tmp = tileset;
     tileset = unscaled_tileset;
   }
-  text_str = QString(unit_name_translation(punit));
   owner = punit->owner;
   pcity = player_city_by_number(owner, punit->homecity);
-  if (pcity != NULL) {
-    text_str = QString(("%1(%2)"))
-                   .arg(unit_name_translation(punit), city_name_get(pcity));
+  if (punit->name.isEmpty()) {
+    if (pcity == nullptr) {
+      text_str = QString(unit_name_translation(punit));
+    } else {
+      // TRANS: <unit> (<home city>)
+      text_str =
+          QString(_("%1 (%2)"))
+              .arg(unit_name_translation(punit), city_name_get(pcity));
+    }
+  } else {
+    if (pcity == nullptr) {
+      // TRANS: <unit> "<unit name>"
+      text_str = QString(_("%1 \"%2\""))
+                     .arg(punit->name, unit_name_translation(punit));
+    } else {
+      // TRANS: <unit> "<unit name>" (<home city>)
+      text_str = QString(_("%1 \"%2\" (%3)"))
+                     .arg(unit_name_translation(punit), punit->name,
+                          city_name_get(pcity));
+    }
   }
   text_str = text_str + " ";
   mp = QString(move_points_text(punit->moves_left, false));

--- a/client/gui-qt/menu.h
+++ b/client/gui-qt/menu.h
@@ -34,6 +34,7 @@ enum munit {
   UNLOAD,
   TRANSPORTER,
   DISBAND,
+  RENAME,
   CONVERT,
   MINE,
   PLANT,
@@ -256,6 +257,7 @@ private slots:
   void slot_upgrade();
   void slot_convert();
   void slot_disband();
+  void slot_rename();
 
   /*used by combat menu*/
   void slot_unit_fortify();

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -194,6 +194,8 @@ static struct unit *unpackage_unit(const struct packet_unit_info *packet)
   unit_tile_set(punit, index_to_tile(&(wld.map), packet->tile));
   punit->facing = packet->facing;
   punit->homecity = packet->homecity;
+  punit->name = QString::fromUtf8(QByteArray(packet->name,
+                                             ARRAY_SIZE(packet->name)));
   output_type_iterate(o) { punit->upkeep[o] = packet->upkeep[o]; }
   output_type_iterate_end;
   punit->moves_left = packet->movesleft;
@@ -290,6 +292,7 @@ unpackage_short_unit(const struct packet_unit_short_info *packet)
   punit->veteran = packet->veteran;
   punit->hp = packet->hp;
   punit->activity = static_cast<unit_activity>(packet->activity);
+  punit->name = QString::fromUtf8(packet->name, ARRAY_SIZE(packet->name));
 
   if (packet->activity_tgt == EXTRA_NONE) {
     punit->activity_target = NULL;

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -1707,6 +1707,16 @@ static bool handle_unit_packet_common(struct unit *packet_unit)
       need_units_report_update = true;
     }
 
+    if (punit->name != packet_unit->name) {
+      // Name changed
+      punit->name = packet_unit->name;
+
+      if (unit_is_in_focus(punit)) {
+        // Update the orders menu -- the name is shown there
+        need_menus_update = true;
+      }
+    }
+
     if (punit->hp != packet_unit->hp) {
       // hp changed
       punit->hp = packet_unit->hp;

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -372,11 +372,21 @@ const QString popup_info_text(struct tile *ptile)
     if (!client_player() || owner == client_player()) {
       struct city *hcity = player_city_by_number(owner, punit->homecity);
 
-      // TRANS: "Unit: <unit type> | <username> (<nation + team>)"
-      str = str
-            + QString(_("Unit: %1 | %2 (%3)"))
-                  .arg(utype_name_translation(ptype), username, nation)
-            + qendl();
+      if (punit->name.isEmpty()) {
+        // TRANS: "Unit: <unit type> | <username> (<nation + team>)"
+        str = str
+              + QString(_("Unit: %1 | %2 (%3)"))
+                    .arg(utype_name_translation(ptype), username, nation)
+              + qendl();
+      } else {
+        // TRANS: "Unit: <unit type> "<unit name>" | <username> (<nation +
+        // team>)"
+        str = str
+              + QString(_("Unit: %1 \"%2\" | %3 (%4)"))
+                    .arg(utype_name_translation(ptype), punit->name,
+                         username, nation)
+              + qendl();
+      }
       if (game.info.citizen_nationality
           && unit_nationality(punit) != unit_owner(punit)) {
         if (hcity != NULL) {

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -1040,6 +1040,7 @@ PACKET_UNIT_INFO = 63; sc, lsend, is-game-info, cancel(PACKET_UNIT_SHORT_INFO)
   EXTRA changed_from_tgt;
 
   SINT8 battlegroup;
+  STRING name[MAX_LEN_NAME];
 
   BOOL has_orders;
   UINT16 orders_length, orders_index;
@@ -1059,6 +1060,7 @@ PACKET_UNIT_SHORT_INFO = 64; sc, lsend, is-game-info, force, cancel(PACKET_UNIT_
 
   UINT8 veteran;
   BOOL occupied, transported;
+  STRING name[MAX_LEN_NAME];
 
   UINT8 hp, activity;
   EXTRA activity_tgt;
@@ -1150,6 +1152,11 @@ PACKET_UNIT_ACTIONS = 90; sc, dsend
 
   /* How to interpret action probabilities is documented in fc_types.h */
   ACT_PROB action_probabilities[MAX_NUM_ACTIONS];
+end
+
+PACKET_UNIT_RENAME = 91; cs, dsend
+  UNIT unit_id;
+  STRING name[MAX_LEN_NAME];
 end
 
 PACKET_UNIT_CHANGE_ACTIVITY = 222; cs, dsend

--- a/common/unit.h
+++ b/common/unit.h
@@ -127,6 +127,7 @@ struct unit {
   struct player *nationality;
   int id;
   int homecity;
+  QString name;
 
   int upkeep[O_LAST]; // unit upkeep with regards to the homecity
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -5668,6 +5668,12 @@ static bool sg_load_player_unit(struct loaddata *loading, struct player *plr,
   sg_warn_ret_val(secfile_lookup_int(loading->file, &punit->homecity,
                                      "%s.homecity", unitstr),
                   false, "%s", secfile_error());
+
+  if (auto name = secfile_lookup_str(loading->file, "%s.name", unitstr)) {
+    // Support earlier saves
+    punit->name = QString::fromUtf8(name);
+  }
+
   sg_warn_ret_val(secfile_lookup_int(loading->file, &punit->moves_left,
                                      "%s.moves", unitstr),
                   false, "%s", secfile_error());
@@ -6206,6 +6212,8 @@ static void sg_save_player_units(struct savedata *saving, struct player *plr)
     secfile_insert_int(saving->file, punit->veteran, "%s.veteran", buf);
     secfile_insert_int(saving->file, punit->hp, "%s.hp", buf);
     secfile_insert_int(saving->file, punit->homecity, "%s.homecity", buf);
+    secfile_insert_str(saving->file, punit->name.toUtf8(), "%s.name", buf);
+
     secfile_insert_str(saving->file, unit_rule_name(punit),
                        "%s.type_by_name", buf);
 

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -1941,6 +1941,19 @@ void handle_unit_get_actions(struct connection *pc, const int actor_unit_id,
 }
 
 /**
+ * Handle request to rename a unit.
+ */
+void handle_unit_rename(player *pplayer, int unit_id, const char *name)
+{
+  auto unit = game_unit_by_number(unit_id);
+  fc_assert_ret(unit != nullptr);
+  fc_assert_ret(pplayer == unit->owner);
+
+  // Use the QByteArray overload to prevent unbounded read
+  unit->name = QString::fromUtf8(name, MAX_LEN_NAME);
+}
+
+/**
    Try to explain to the player why an action is illegal.
 
    Event type should be E_BAD_COMMAND if the player should know that the

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -1951,6 +1951,7 @@ void handle_unit_rename(player *pplayer, int unit_id, const char *name)
 
   // Use the QByteArray overload to prevent unbounded read
   unit->name = QString::fromUtf8(name, MAX_LEN_NAME);
+  send_unit_info(NULL, unit);
 }
 
 /**

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2539,6 +2539,7 @@ void package_unit(struct unit *punit, struct packet_unit_info *packet)
   packet->tile = tile_index(unit_tile(punit));
   packet->facing = punit->facing;
   packet->homecity = punit->homecity;
+  fc_strlcpy(packet->name, punit->name.toUtf8(), ARRAY_SIZE(packet->name));
   output_type_iterate(o) { packet->upkeep[o] = punit->upkeep[o]; }
   output_type_iterate_end;
   packet->veteran = punit->veteran;
@@ -2624,6 +2625,7 @@ void package_short_unit(struct unit *punit,
   packet->type = utype_number(unit_type_get(punit));
   packet->hp = punit->hp;
   packet->occupied = (get_transporter_occupancy(punit) > 0);
+  fc_strlcpy(packet->name, punit->name.toUtf8(), ARRAY_SIZE(packet->name));
   if (punit->activity == ACTIVITY_EXPLORE
       || punit->activity == ACTIVITY_GOTO) {
     packet->activity = ACTIVITY_IDLE;

--- a/utility/fc_version.h
+++ b/utility/fc_version.h
@@ -11,7 +11,7 @@
 #define VERSION_STRING "3.0.1337.1-haxx"
 #endif
 
-#define NETWORK_CAPSTRING "+Freeciv21.21March06"
+#define NETWORK_CAPSTRING "+Freeciv21.21April06"
 
 #ifndef FOLLOWTAG
 #define FOLLOWTAG "S_HAXXOR"


### PR DESCRIPTION
This would be useful eg in a WWII scenario with Pearl Harbour ships called by their historical names. Changes the network protocol. Requested by @jwrober.

Closes #281.