### PR TITLE
unit shields set to normal size

### DIFF
--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -166,7 +166,7 @@ files =
   "misc/cursors.spec",
   "misc/overlays.spec",
   "misc/citybar.spec",
-  "misc/shields-large.spec",
+  "misc/shields.spec",
   "misc/editor.spec",
   "misc/icons.spec"
 


### PR DESCRIPTION
the unit shield graphic was set to shields-large.spec which sometimes partially covered up units and distracted from the unit graphic itself. 
now set to the normal sized shields.spec the shield will be more 'out of the way'