### PR TITLE
Fix cutting connections on the server side

### DIFF
--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -88,11 +88,7 @@ static void close_connection(struct connection *pconn)
     }
     FC_FREE(pconn->server.ping_timers);
   }
-  conn_list_iterate(game.all_connections, xconn)
-  {
-    xconn->sock->disconnect();
-  }
-  conn_list_iterate_end;
+
   conn_pattern_list_destroy(pconn->server.ignore_list);
   pconn->server.ignore_list = NULL;
 


### PR DESCRIPTION
The server was disconnecting all signals from all existing sockets, resulting in an unusable server. Remove the offending code.

Closes #394.