### PR TITLE
Combat_Rounds-related enhancements

### DIFF
--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -273,6 +273,10 @@ bool can_unit_attack_tile(const struct unit *punit,
  */
 double win_chance(int as, int ahp, int afp, int ds, int dhp, int dfp)
 {
+  if (afp == 0)
+    return 0.0;
+  if (dfp == 0)
+    return 1.0;
   // number of rounds a unit can fight without dying
   int att_N_lose = (ahp + dfp - 1) / dfp;
   int def_N_lose = (dhp + afp - 1) / afp;
@@ -705,7 +709,7 @@ static int get_defense_rating(const struct unit *attacker,
   get_modified_firepower(attacker, defender, &afp, &dfp);
 
   // How many rounds the defender will last
-  rating *= (defender->hp + afp - 1) / afp;
+  rating *= (defender->hp + afp - 1) / (afp ?: 1);
 
   rating *= dfp;
 

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -2017,18 +2017,6 @@ static bool load_ruleset_units(struct section_file *file,
       }
       u->move_rate *= SINGLE_MOVE;
 
-      if (u->firepower <= 0) {
-        qCCritical(ruleset_category,
-                   "\"%s\" unit_type \"%s\":"
-                   " firepower is %d,"
-                   " but must be at least 1. "
-                   "  If you want no attack ability,"
-                   " set the unit's attack strength to 0.",
-                   filename, utype_rule_name(u), u->firepower);
-        ok = false;
-        break;
-      }
-
       lookup_cbonus_list(compat, u->bonuses, file, sec_name, "bonuses");
 
       output_type_iterate(o)

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -298,12 +298,14 @@ void unit_versus_unit(struct unit *attacker, struct unit *defender,
   player_update_last_war_action(plr1);
   player_update_last_war_action(plr2);
 
-  if (attackpower == 0) {
-    *att_hp = 0;
-  } else if (defensepower == 0) {
-    *def_hp = 0;
-  }
   max_rounds = get_unit_bonus(attacker, EFT_COMBAT_ROUNDS);
+  if (max_rounds <= 0) {
+    if (attackpower == 0) {
+      *att_hp = 0;
+    } else if (defensepower == 0) {
+      *def_hp = 0;
+    }
+  }
   for (rounds = 0; *att_hp > 0 && *def_hp > 0
                    && (max_rounds <= 0 || max_rounds > rounds);
        rounds++) {

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -300,9 +300,9 @@ void unit_versus_unit(struct unit *attacker, struct unit *defender,
 
   max_rounds = get_unit_bonus(attacker, EFT_COMBAT_ROUNDS);
   if (max_rounds <= 0) {
-    if (attackpower == 0) {
+    if (attackpower == 0 || attack_firepower == 0) {
       *att_hp = 0;
-    } else if (defensepower == 0) {
+    } else if (defensepower == 0 || defense_firepower == 0) {
       *def_hp = 0;
     }
   }


### PR DESCRIPTION
With the ability to limit Combat_Rounds, it now makes sense to have full combat between units even when the defender's defence strength or FirePower is zero, as it might still survive if the attacker runs out of rounds.
Against a defender with D=0, you simply need to rack up enough rounds to take out its HP, because every shot hits.
Against a defender with D>0 but FP=0, combat becomes a bit like bombardment: you might not hit every round (you have to roll A/(A+D)), but you don't take damage when you miss.  This represents a unit that's unarmed but difficult to hit (e.g. high-flying aeroplane).

I have tested this patch with the following cases:
* A1 FP1 CR3 vs D0 FP1 HP4.  Defender took 3 HP of damage.  Attacker took none.
* A1 FP1 CR3 vs D1 FP0 HP4.  Defender sometimes took 1 HP of damage, sometimes 2.  (Presumably 0 and 3 are also possible, but didn't happen in my small sample.)  Attacker took no damage.

I haven't (yet) tested to verify the right thing happens if Combat_Rounds are not limited, or if attacker FP is 0.