### PR TITLE
Client positional argument to connect to URL

### DIFF
--- a/client/client_main.h
+++ b/client/client_main.h
@@ -14,6 +14,10 @@
 
 #include "packets.h" // enum report_type
 
+// Forward declarations
+class QString;
+class QUrl;
+
 /*
  * Every TIMER_INTERVAL milliseconds real_timer_callback is
  * called. TIMER_INTERVAL has to stay 500 because real_timer_callback
@@ -58,17 +62,15 @@ bool is_server_busy();
 void client_remove_cli_conn(struct connection *pconn);
 void client_remove_all_cli_conn();
 
+QUrl &client_url();
+
 extern QString logfile;
 extern QString scriptfile;
 extern QString savefile;
 extern QString sound_plugin_name;
 extern QString sound_set_name;
 extern QString music_set_name;
-extern QString server_host;
-extern QString user_name;
-extern char password[MAX_LEN_PASSWORD];
 extern QString cmd_metaserver;
-extern int server_port;
 extern bool auto_connect;
 extern bool auto_spawn;
 extern bool waiting_for_end_turn;

--- a/client/clinet.h
+++ b/client/clinet.h
@@ -12,14 +12,15 @@
 
 // Forward declarations
 class QTcpSocket;
+class QString;
+class QUrl;
 
-int connect_to_server(QString &username, QString &hostname, int port,
-                      char *errbuf, int errbufsize);
+int connect_to_server(const QUrl &url, char *errbuf, int errbufsize);
 
-void make_connection(QTcpSocket *sock, QString &username);
+void make_connection(QTcpSocket *sock, const QString &username);
 
 void input_from_server(QTcpSocket *sock);
 void disconnect_from_server();
 
-double try_to_autoconnect();
-void start_autoconnecting_to_server();
+double try_to_autoconnect(const QUrl &url);
+void start_autoconnecting_to_server(const QUrl &url);

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -18,6 +18,7 @@
 #include <QProcess>
 #include <QStandardPaths>
 #include <QTcpServer>
+#include <QUrl>
 
 #include <cstdio>
 #include <cstring>
@@ -201,7 +202,7 @@ static int find_next_free_port(int starting_port, int highest_port)
    Forks a server if it can. Returns FALSE if we find we
    couldn't start the server.
  */
-bool client_start_server()
+bool client_start_server(const QString &user_name)
 {
   QStringList arguments;
   QString trueFcser, ruleset, storage, port_buf, savesdir, scensdir;
@@ -293,10 +294,17 @@ bool client_start_server()
   serverProcess::i()->waitForReadyRead();
   serverProcess::i()->waitForStarted();
   server_quitting = false;
+
+  // Local server URL
+  auto url = QUrl();
+  url.setScheme(QStringLiteral("fc21"));
+  url.setUserName(user_name);
+  url.setHost(QStringLiteral("localhost"));
+  url.setPort(internal_server_port);
+
   // a reasonable number of tries
-  QString srv = QStringLiteral("localhost");
   while (connect_to_server(
-             user_name, srv, internal_server_port, buf,
+             url, buf,
              sizeof(buf) && serverProcess::i()->state() == QProcess::Running)
          == -1) {
     fc_usleep(WAIT_BETWEEN_TRIES);

--- a/client/connectdlg_common.h
+++ b/client/connectdlg_common.h
@@ -10,7 +10,10 @@
 **************************************************************************/
 #pragma once
 
-bool client_start_server();
+// Forward declarations
+class QString;
+
+bool client_start_server(const QString &user_name);
 void client_kill_server(bool force);
 
 bool is_server_running();

--- a/client/gui-qt/fc_client.cpp
+++ b/client/gui-qt/fc_client.cpp
@@ -640,7 +640,7 @@ void fc_client::create_loading_page()
  */
 void fc_client::start_new_game()
 {
-  if (is_server_running() || client_start_server()) {
+  if (is_server_running() || client_start_server(client_url().userName())) {
     /* saved settings are sent in client/options.c load_settable_options() */
   }
 }

--- a/client/gui-qt/page_load.cpp
+++ b/client/gui-qt/page_load.cpp
@@ -22,6 +22,7 @@
 #include "connectdlg_common.h"
 #include "rgbcolor.h"
 // client
+#include "client_main.h"
 #include "options.h"
 // gui-qt
 #include "fc_client.h"
@@ -143,7 +144,7 @@ void page_load::update_load_page()
 void page_load::start_from_save()
 {
   if (!is_server_running()) {
-    client_start_server();
+    client_start_server(client_url().userName());
     send_chat("/detach");
   }
   if (is_server_running() && !current_file.isEmpty()) {

--- a/client/gui-qt/page_scenario.cpp
+++ b/client/gui-qt/page_scenario.cpp
@@ -20,6 +20,8 @@
 #include "chatline_common.h"
 #include "connectdlg_common.h"
 #include "version.h"
+// client
+#include "client_main.h"
 // gui-qt
 #include "colors.h"
 #include "dialogs.h"
@@ -99,7 +101,7 @@ void page_scenario::browse_scenarios()
 void page_scenario::start_scenario()
 {
   if (!is_server_running()) {
-    client_start_server();
+    client_start_server(client_url().userName());
     send_chat("/detach");
   }
   if (is_server_running() && !current_file.isEmpty()) {

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -15,11 +15,14 @@
 #include <fc_config.h>
 #endif
 
-#include <QHash>
 #include <cstdarg>
 #include <cstring>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+// Qt
+#include <QHash>
+#include <QUrl>
 
 // utility
 #include "deprecations.h"
@@ -4520,8 +4523,10 @@ void options_load()
   secfile_allow_digital_boolean(sf, allow_digital_boolean);
 
   // a "secret" option for the lazy. TODO: make this saveable
-  sz_strlcpy(password,
-             secfile_lookup_str_default(sf, "", "%s.password", prefix));
+  if (client_url().password().isEmpty()) {
+    client_url().setPassword(
+        secfile_lookup_str_default(sf, "", "%s.password", prefix));
+  }
 
   gui_options.save_options_on_exit =
       secfile_lookup_bool_default(sf, gui_options.save_options_on_exit,

--- a/client/update_queue.cpp
+++ b/client/update_queue.cpp
@@ -15,6 +15,9 @@
 #include <fc_config.h>
 #endif
 
+// Qt
+#include <QUrl>
+
 // utility
 #include "log.h"
 #include "support.h" // bool
@@ -349,7 +352,7 @@ void client_start_server_and_set_page(enum client_pages page)
 {
   log_debug("Requested server start + page: %s.", client_pages_name(page));
 
-  if (client_start_server()) {
+  if (client_start_server(client_url().userName())) {
     update_queue::uq()->connect_processing_finished(
         client.conn.client.last_request_id_used, set_client_page_callback,
         FC_INT_TO_PTR(page));


### PR DESCRIPTION
This allows to connect immediately using a command of the form:

    freeciv21-client user:password@host:port -a

URL syntax is easier to remember than the combination of the -n -s -p options
that was previously needed (and is still supported), and as a side-effect
allows to give a password as well. Supporting URLs also brings us closer to
setting the system handler for fc21:// links to the client (so websites can
give a fc21:// link to help users connect to a server).

Closes #468.

Internally, a single static QUrl is used to pass connection information instead
of several static field. This will allow using the path part for a
WebSocket-backed protocol and eventually WS-based encryption.