### PR TITLE
Exclude data/graphics from tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/graphics/** export-ignore


### PR DESCRIPTION
The folder is very large and not really useful to compile.

Closes #473.