### PR TITLE
Workaround for lack of random_device randomness

### DIFF
--- a/utility/rand.cpp
+++ b/utility/rand.cpp
@@ -25,6 +25,9 @@
 
 #include "rand.h"
 
+// Qt
+#include <QRandomGenerator>
+
 #define log_rand log_debug
 
 /* A global random state:
@@ -74,37 +77,13 @@ bool fc_rand_is_init() { return is_init; }
  */
 void fc_rand_set_init(bool init) { is_init = init; }
 
-namespace /* anonymous */ {
-
-/**
- * Seed sequence based on std::random_device. Adapted from M. Skarupke,
- * https://probablydance.com/2016/12/29/random_seed_seq-a-small-utility-to-properly-seed-random-number-generators-in-c/
- */
-struct random_seed_seq {
-  /**
-   * Generates a random sequence.
-   */
-  template <typename It> void generate(It begin, It end)
-  {
-    for (; begin != end; ++begin) {
-      *begin = m_device();
-    }
-  }
-
-  /// Required by seed_seq.
-  using result_type = std::random_device::result_type;
-
-private:
-  std::random_device m_device;
-};
-} // anonymous namespace
-
 /**
  * Seeds the given generator with a random value.
  */
 void fc_rand_seed(std::mt19937 &gen)
 {
-  auto seed = random_seed_seq();
+  auto seed = std::seed_seq();
+  QRandomGenerator::securelySeeded().seed(seed);
   gen.seed(seed);
 }
 


### PR DESCRIPTION
The RDRAND instruction is broken on certain AMD processors and always returns
-1. libstdc++ trusts it for the default behaviour of its std::random_device,
which obviously results in a very bad seed.

This patch switches to QRandomGenerator for seeding. QRandomGenerator
implements a workaround since Qt 5.12.6, disabling hardware random generation
if it looks broken.

See GCC bug #100444 at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100444
See QTBUG-69423 at https://bugreports.qt.io/browse/QTBUG-69423
See issue #455