### PR TITLE
Fix fc_rand(0) returning negative numbers

### DIFF
--- a/utility/rand.cpp
+++ b/utility/rand.cpp
@@ -50,6 +50,13 @@ std::uint_fast32_t fc_rand_debug(std::uint_fast32_t size,
                                  const char *called_as, int line,
                                  const char *file)
 {
+  // uniform_int_distribution(a, b) is UB if a > b, so protect
+  // against it. Also short-circuit for size == 1 which is always 0
+  // anyway.
+  if (size <= 1) {
+    return 0;
+  }
+
   std::uniform_int_distribution<std::uint_fast32_t> uniform(0, size - 1);
 
   auto random = uniform(generator);


### PR DESCRIPTION
Reported and investigated by panch93.

Closes #477.