### PR TITLE
Disable Travis on Windows and Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ jobs:
     before_script:
       - scripts/travis-clang-format.sh
   - name: "windows"
-    if: branch != coverity_scan
+    if: branch = disabled
+    #if: branch != coverity_scan
     os: windows
     script:
       - $mingw64 pacman -Syu --noconfirm
@@ -63,7 +64,8 @@ jobs:
       - $mingw64 cmake --build build
       - $mingw64 cmake --build build --target package
   - name: "os_x"
-    if: branch != coverity_scan
+    if: branch = disabled
+    #if: branch != coverity_scan
     os: osx
     osx_image: xcode12.2
     env:


### PR DESCRIPTION
The free minutes available on Travis have been drastically reduced, with
Windows and Mac counting more than Linux. Windows takes 20 minutes to
complete and OS X takes over 40 minutes. The two Linux builds together
are about 20 minutes.

Disable Windows and Mac so we still have a CI while looking for
alternatives.

Closes #498.
See #499.