### PR TITLE
Actually send the password entered by the user

### DIFF
--- a/client/gui-qt/page_network.cpp
+++ b/client/gui-qt/page_network.cpp
@@ -449,6 +449,7 @@ void page_network::slot_connect()
 
     return;
   case ENTER_PASSWORD_TYPE:
+    client_url().setPassword(ui.connect_password_edit->text());
     fc_strlcpy(reply.password, qUtf8Printable(client_url().password()),
                MAX_LEN_NAME);
     send_packet_authentication_reply(&client.conn, &reply);


### PR DESCRIPTION
Since the migration to QUrl, the password sent by the client to auth-enabled
servers was always empty.

Closes #518.