### PR TITLE
Allow setting a random nation in /playernation

### DIFF
--- a/server/commands.cpp
+++ b/server/commands.cpp
@@ -504,7 +504,8 @@ static struct command commands[] = {
      N_("playernation <player-name> [nation] [is-male] [leader] [style]"),
      N_("Define the nation of a player."),
      N_("This command sets the nation, leader name, style, and gender of a "
-        "specific player.\nThe gender parameter should be 1 if male, "
+        "specific player. The string \"random\" can be used to select a "
+        "random nation.\nThe gender parameter should be 1 if male, "
         "otherwise 0. Omitting any of the player settings will reset the "
         "player to defaults.\n"
         "This command may not be used once the game has started."),

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -4239,25 +4239,30 @@ static bool playernation_command(struct connection *caller, char *str,
       send_player_info_c(pplayer, game.est_connections);
     }
   } else {
-    pnation = nation_by_rule_name(qUtf8Printable(token.at(1)));
-    if (pnation == NO_NATION_SELECTED) {
-      cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
-                _("Unrecognized nation: %s."), qUtf8Printable(token.at(1)));
-      return false;
-    }
+    if (token.at(1) == QStringLiteral("random")) {
+      pnation = NO_NATION_SELECTED;
+    } else {
+      pnation = nation_by_rule_name(qUtf8Printable(token.at(1)));
+      if (pnation == NO_NATION_SELECTED) {
+        cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
+                  _("Unrecognized nation: %s."),
+                  qUtf8Printable(token.at(1)));
+        return false;
+      }
 
-    if (!client_can_pick_nation(pnation)) {
-      cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
-                _("%s nation is not available for user selection."),
-                qUtf8Printable(token.at(1)));
-      return false;
-    }
+      if (!client_can_pick_nation(pnation)) {
+        cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
+                  _("%s nation is not available for user selection."),
+                  qUtf8Printable(token.at(1)));
+        return false;
+      }
 
-    if (pnation->player && pnation->player != pplayer) {
-      cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
-                _("%s nation is already in use."),
-                qUtf8Printable(token.at(1)));
-      return false;
+      if (pnation->player && pnation->player != pplayer) {
+        cmd_reply(CMD_PLAYERNATION, caller, C_FAIL,
+                  _("%s nation is already in use."),
+                  qUtf8Printable(token.at(1)));
+        return false;
+      }
     }
 
     if (token.count() < 3) {
@@ -4286,7 +4291,7 @@ static bool playernation_command(struct connection *caller, char *str,
                   _("Unrecognized style: %s."), qUtf8Printable(token.at(4)));
         return false;
       }
-    } else {
+    } else if (pnation != NO_NATION_SELECTED) {
       pstyle = style_of_nation(pnation);
     }
 
@@ -4308,7 +4313,8 @@ static bool playernation_command(struct connection *caller, char *str,
       }
       cmd_reply(CMD_PLAYERNATION, caller, C_OK,
                 _("Nation of player %s set to [%s]."), player_name(pplayer),
-                nation_rule_name(pnation));
+                pnation == NO_NATION_SELECTED ? "random"
+                                              : nation_rule_name(pnation));
       send_player_info_c(pplayer, game.est_connections);
     }
   }

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -4303,9 +4303,11 @@ static bool playernation_command(struct connection *caller, char *str,
       pplayer->is_male = is_male;
 
       if (token.count() > 3) {
-        if (!server_player_set_name_full(caller, pplayer, pnation,
-                                         qUtf8Printable(token.at(3)),
-                                         error_buf, sizeof(error_buf))) {
+        if (server_player_set_name_full(caller, pplayer, pnation,
+                                        qUtf8Printable(token.at(3)),
+                                        error_buf, sizeof(error_buf))) {
+          pplayer->random_name = false;
+        } else {
           cmd_reply(CMD_PLAYERNATION, caller, C_WARNING, "%s", error_buf);
         }
       } else {


### PR DESCRIPTION
**document-me**: The `playernation` server command can now be used to select a random nation.

Closes #520.