### PR TITLE
Stop broadcasting client IP and ping times

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Freeciv21 contributors are listed below in alphabetical order:
 
 - DobbyK
+- ilkkachu (Ilkka Virta)
 - jwrober (James Robertson)
 - louis94 (Louis Moureaux)
 - mir3x

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -2768,27 +2768,16 @@ void handle_conn_info(const struct packet_conn_info *pinfo)
 }
 
 /**
-   Handles a conn_ping_info packet from the server.  This packet contains
-   ping times for each connection.
+ * Handles a conn_ping_info packet from the server.  This packet contains
+ * ping times for each connection.
+ * FIXME Only present for backward compatibility.
  */
 void handle_conn_ping_info(int connections, const int *conn_id,
                            const float *ping_time)
 {
-  int i;
-
-  for (i = 0; i < connections; i++) {
-    struct connection *pconn = conn_by_number(conn_id[i]);
-
-    if (!pconn) {
-      continue;
-    }
-
-    pconn->ping_time = ping_time[i];
-    log_debug("conn-id=%d, ping=%fs", pconn->id, pconn->ping_time);
-  }
-  // The old_ping_time data is ignored.
-
-  players_dialog_update();
+  Q_UNUSED(connections)
+  Q_UNUSED(conn_id)
+  Q_UNUSED(ping_time)
 }
 
 /**

--- a/client/plrdlg_common.cpp
+++ b/client/plrdlg_common.cpp
@@ -268,15 +268,6 @@ QString plrdlg_col_state(const struct player *plr)
 }
 
 /**
-   Returns a string telling the player's client's hostname (the
-   machine from which he is connecting).
- */
-static QString col_host(const struct player *player)
-{
-  return player_addr_hack(player);
-}
-
-/**
    Returns a string telling how many turns the player has been idle.
  */
 static QString col_idle(const struct player *plr)
@@ -321,11 +312,8 @@ struct player_dlg_column player_dlg_columns[] = {
      "diplstate"},
     {true, COL_TEXT, N_("Vision"), col_vision, NULL, NULL, "vision"},
     {true, COL_TEXT, N_("State"), plrdlg_col_state, NULL, NULL, "state"},
-    {false, COL_TEXT, N_("?Player_dlg:Host"), col_host, NULL, NULL, "host"},
     {false, COL_RIGHT_TEXT, N_("?Player_dlg:Idle"), col_idle, NULL, NULL,
-     "idle"},
-    {false, COL_RIGHT_TEXT, N_("Ping"), get_ping_time_text, NULL, NULL,
-     "ping"}};
+     "idle"}};
 
 const int num_player_dlg_columns = ARRAY_SIZE(player_dlg_columns);
 
@@ -344,27 +332,4 @@ void init_player_dlg_common()
   for (i = 0; i < num_player_dlg_columns; i++) {
     player_dlg_columns[i].title = Q_(player_dlg_columns[i].title);
   }
-}
-
-/**
-   The only place where this is used is the player dialog.
-   Eventually this should go the way of the dodo with everything here
-   moved into col_host above, but some of the older clients (+win32) still
-   use this function directly.
-
-   This code in this function is only really needed so that the host is
-   kept as a blank address if no one is controlling a player, but there are
-   observers.
- */
-QString player_addr_hack(const struct player *pplayer)
-{
-  conn_list_iterate(pplayer->connections, pconn)
-  {
-    if (!pconn->observer) {
-      return pconn->addr;
-    }
-  }
-  conn_list_iterate_end;
-
-  return blank_addr_str;
 }

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -1750,36 +1750,6 @@ const QString format_duration(int duration)
 }
 
 /**
-   Return text giving the ping time for the player.  This is generally used
-   used in the playerdlg.  This should only be used in playerdlg_common.c.
- */
-QString get_ping_time_text(const struct player *pplayer)
-{
-  QString str;
-
-  conn_list_iterate(pplayer->connections, pconn)
-  {
-    if (!pconn->observer
-        // Certainly not needed, but safer.
-        && 0 == strcmp(pconn->username, pplayer->username)) {
-      if (pconn->ping_time != -1) {
-        double ping_time_in_ms = 1000 * pconn->ping_time;
-        str +=
-            QString(_("%1.%2 ms"))
-                .arg(QString::number(static_cast<int>(ping_time_in_ms)), 6)
-                .arg(QString::number(
-                         (static_cast<int>(ping_time_in_ms * 100.0)) % 100),
-                     2);
-      }
-      break;
-    }
-  }
-  conn_list_iterate_end;
-
-  return str.trimmed();
-}
-
-/**
    Return text giving the score of the player. This should only be used
    in playerdlg_common.c.
  */

--- a/client/text.h
+++ b/client/text.h
@@ -40,7 +40,6 @@ bool get_units_disband_info(char *buf, size_t bufsz,
 const QString get_spaceship_descr(struct player_spaceship *pship);
 const QString get_timeout_label_text();
 const QString format_duration(int duration);
-QString get_ping_time_text(const struct player *pplayer);
 QString get_score_text(const struct player *pplayer);
 const QString get_report_title(const char *report_name);
 

--- a/common/networking/connection.h
+++ b/common/networking/connection.h
@@ -292,7 +292,9 @@ bool conn_compression_frozen(const struct connection *pconn);
 void conn_list_compression_freeze(const struct conn_list *pconn_list);
 void conn_list_compression_thaw(const struct conn_list *pconn_list);
 
-const char *conn_description(const struct connection *pconn);
+const char *conn_description(const struct connection *pconn,
+                             bool is_private = true);
+const char *conn_addr_public(const struct connection *pconn);
 bool conn_controls_player(const struct connection *pconn);
 bool conn_is_global_observer(const struct connection *pconn);
 enum cmdlevel conn_get_access(const struct connection *pconn);

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -1264,6 +1264,10 @@ PACKET_CONN_INFO = 115; sc, lsend, is-info
 end
 
 # Information about the ping times of the connections.
+# This packet is kept for backward compatibility only and is no longer sent by
+# the server or used by the client.
+# Can be removed once we are confident that all 3.0-alpha3 servers are gone
+# (and the number can be reattributed once all 3.0-alpha3 clients are gone).
 PACKET_CONN_PING_INFO = 116; sc, lsend
   UINT8 connections;
   CONNECTION conn_id[MAX_NUM_CONNECTIONS:connections];

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -267,12 +267,12 @@ void establish_new_connection(struct connection *pconn)
   if (conn_controls_player(pconn)) {
     package_event(&connect_info, NULL, E_CONNECTION, ftc_server,
                   _("%s has connected from %s (player %s)."),
-                  pconn->username, qUtf8Printable(pconn->addr),
+                  pconn->username, conn_addr_public(pconn),
                   player_name(conn_get_player(pconn)));
   } else {
     package_event(&connect_info, NULL, E_CONNECTION, ftc_server,
                   _("%s has connected from %s."), pconn->username,
-                  qUtf8Printable(pconn->addr));
+                  conn_addr_public(pconn));
   }
   conn_list_iterate(game.est_connections, aconn)
   {
@@ -415,7 +415,7 @@ bool handle_login_request(struct connection *pconn,
     fc_snprintf(msg, sizeof(msg), _("Invalid username '%s'"), req->username);
     reject_new_connection(msg, pconn);
     qInfo(_("%s was rejected: Invalid name [%s]."), req->username,
-          qUtf8Printable(pconn->addr));
+          conn_addr_public(pconn));
     return false;
   }
 
@@ -439,7 +439,7 @@ bool handle_login_request(struct connection *pconn,
                   req->username);
       reject_new_connection(msg, pconn);
       qInfo(_("%s was rejected: Duplicate login name [%s]."), req->username,
-            qUtf8Printable(pconn->addr));
+            conn_addr_public(pconn));
       return false;
     }
   }
@@ -512,7 +512,7 @@ static void package_conn_info(struct connection *pconn,
   packet->access_level = pconn->access_level;
 
   sz_strlcpy(packet->username, pconn->username);
-  sz_strlcpy(packet->addr, qUtf8Printable(pconn->addr));
+  sz_strlcpy(packet->addr, conn_addr_public(pconn));
   sz_strlcpy(packet->capability, pconn->capability);
 }
 

--- a/server/edithand.cpp
+++ b/server/edithand.cpp
@@ -191,13 +191,13 @@ void handle_edit_mode(struct connection *pc, bool is_edit_mode)
     // Someone could be cheating! Warn people.
     notify_conn(NULL, NULL, E_SETTING, ftc_editor,
                 _(" *** Server set to edit mode by %s! *** "),
-                conn_description(pc));
+                conn_description(pc, false));
   }
 
   if (game.info.is_edit_mode && !is_edit_mode) {
     notify_conn(NULL, NULL, E_SETTING, ftc_editor,
                 _(" *** Edit mode canceled by %s. *** "),
-                conn_description(pc));
+                conn_description(pc, false));
 
     check_leaving_edit_mode();
   }

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -531,31 +531,6 @@ void handle_client_heartbeat(struct connection *pconn)
 }
 
 /**
-   Send ping time info about all connections to all connections.
- */
-void send_ping_times_to_all()
-{
-  struct packet_conn_ping_info packet;
-  int i;
-
-  i = 0;
-  conn_list_iterate(game.est_connections, pconn)
-  {
-    if (!pconn->used) {
-      continue;
-    }
-    fc_assert(i < ARRAY_SIZE(packet.conn_id));
-    packet.conn_id[i] = pconn->id;
-    packet.ping_time[i] = pconn->ping_time;
-    i++;
-  }
-  conn_list_iterate_end;
-  packet.connections = i;
-
-  lsend_packet_conn_ping_info(game.est_connections, &packet);
-}
-
-/**
    Listen for UDP packets multicasted from clients requesting
    announcement of servers on the LAN.
  */

--- a/server/sernet.h
+++ b/server/sernet.h
@@ -33,5 +33,4 @@ int server_make_connection(QTcpSocket *new_sock, const QString &client_addr);
 void connection_ping(struct connection *pconn);
 void handle_conn_pong(struct connection *pconn);
 void handle_client_heartbeat(struct connection *pconn);
-void send_ping_times_to_all();
 void get_lanserver_announcement();

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -429,9 +429,6 @@ void server::send_pings()
 {
   // Pinging around for statistics
   if (time(NULL) > (game.server.last_ping + game.server.pingtime)) {
-    // send data about the previous run
-    send_ping_times_to_all();
-
     conn_list_iterate(game.all_connections, pconn)
     {
       if ((!pconn->server.is_closing && 0 < pconn->server.ping_timers->size()

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -6562,7 +6562,12 @@ static void show_connections(struct connection *caller)
   } else {
     conn_list_iterate(game.all_connections, pconn)
     {
-      sz_strlcpy(buf, conn_description(pconn));
+      /* only admins get the actual hostnames of users */
+      if (caller && caller->access_level < ALLOW_ADMIN) {
+        sz_strlcpy(buf, conn_description(pconn, false));
+      } else {
+        sz_strlcpy(buf, conn_description(pconn));
+      }
       if (pconn->established) {
         cat_snprintf(buf, sizeof(buf), " command access level %s",
                      cmdlevel_name(pconn->access_level));


### PR DESCRIPTION
Closes #558. The corresponding columns have been removed from the nations screen.