### PR TITLE
Show unit IDs in the client

### DIFF
--- a/client/gui-qt/hudwidget.cpp
+++ b/client/gui-qt/hudwidget.cpp
@@ -608,23 +608,31 @@ void hud_units::update_actions(unit_list *punits)
   pcity = player_city_by_number(owner, punit->homecity);
   if (punit->name.isEmpty()) {
     if (pcity == nullptr) {
-      text_str = QString(unit_name_translation(punit));
+      // TRANS: <unit> #<unit id>
+      text_str = QString(_("%1 #%2"))
+                     .arg(unit_name_translation(punit))
+                     .arg(punit->id);
     } else {
-      // TRANS: <unit> (<home city>)
-      text_str =
-          QString(_("%1 (%2)"))
-              .arg(unit_name_translation(punit), city_name_get(pcity));
+      // TRANS: <unit> #<unit id> (<home city>)
+      text_str = QString(_("%1 #%2 (%3)"))
+                     .arg(unit_name_translation(punit))
+                     .arg(punit->id)
+                     .arg(city_name_get(pcity));
     }
   } else {
     if (pcity == nullptr) {
-      // TRANS: <unit> "<unit name>"
-      text_str = QString(_("%1 \"%2\""))
-                     .arg(punit->name, unit_name_translation(punit));
+      // TRANS: <unit> #<unit id> "<unit name>"
+      text_str = QString(_("%1 #%2 \"%3\""))
+                     .arg(unit_name_translation(punit))
+                     .arg(punit->id)
+                     .arg(punit->name);
     } else {
-      // TRANS: <unit> "<unit name>" (<home city>)
-      text_str = QString(_("%1 \"%2\" (%3)"))
-                     .arg(unit_name_translation(punit), punit->name,
-                          city_name_get(pcity));
+      // TRANS: <unit> #<unit id> "<unit name>" (<home city>)
+      text_str = QString(_("%1 #%2 \"%3\" (%4)"))
+                     .arg(unit_name_translation(punit))
+                     .arg(punit->id)
+                     .arg(punit->name)
+                     .arg(city_name_get(pcity));
     }
   }
   text_str = text_str + " ";

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -380,17 +380,23 @@ const QString popup_info_text(struct tile *ptile)
       struct city *hcity = player_city_by_number(owner, punit->homecity);
 
       if (punit->name.isEmpty()) {
-        // TRANS: "Unit: <unit type> | <username> (<nation + team>)"
-        str = str
-              + QString(_("Unit: %1 | %2 (%3)"))
-                    .arg(utype_name_translation(ptype), username, nation)
-              + qendl();
-      } else {
-        // TRANS: "Unit: <unit type> "<unit name>" | <username> (<nation +
+        // TRANS: "Unit: <unit type> #<unit id> | <username> (<nation +
         // team>)"
-        str += QString(_("Unit: %1 \"%2\" | %3 (%4)"))
-                   .arg(utype_name_translation(ptype), punit->name, username,
-                        nation)
+        str += QString(_("Unit: %1 #%2 | %3 (%4)"))
+                   .arg(utype_name_translation(ptype))
+                   .arg(punit->id)
+                   .arg(username)
+                   .arg(nation)
+               + qendl();
+      } else {
+        // TRANS: "Unit: <unit type> #<unit id> "<unit name>" | <username>
+        // (<nation + team>)"
+        str += QString(_("Unit: %1 #%2 \"%3\" | %4 (%5)"))
+                   .arg(utype_name_translation(ptype))
+                   .arg(punit->id)
+                   .arg(punit->name)
+                   .arg(username)
+                   .arg(nation)
                + qendl();
       }
       if (game.info.citizen_nationality


### PR DESCRIPTION
As requested in #550, show unit ID for the selected unit and on middle click for all units. Here is an example for the middle click popup:
![image](https://user-images.githubusercontent.com/22327575/126907747-c83dc658-b8b4-4302-a8cc-b4653597f57f.png)

Closes #550.