### PR TITLE
Refactor: Replace `QString::SkipEmptyParts` with `Qt::SkipEmptyParts`

### DIFF
--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -734,8 +734,7 @@ static bool create_command(struct connection *caller, const char *str,
   QString ai_type_name;
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
 
   if (arg.count() == 1) {
     ai_type_name = default_ai_type_name();
@@ -1403,8 +1402,7 @@ static bool cmdlevel_command(struct connection *caller, char *str,
   enum cmdlevel level;
   struct connection *ptarget;
 
-  arg = QString(str).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(str).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
 
   if (arg.count() == 0) {
     // No argument supplied; list the levels
@@ -1617,8 +1615,7 @@ static bool timeout_command(struct connection *caller, char *str, bool check)
   timeouts[3] = &game.server.timeoutincmult;
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
 
   for (i = 0; i < arg.count(); i++) {
     if (!str_to_int(qUtf8Printable(arg.at(i)), timeouts[i])) {
@@ -2356,8 +2353,8 @@ static bool team_command(struct connection *caller, char *str, bool check)
 
   if (str != NULL || qstrlen(str) > 0) {
     sz_strlcpy(buf, str);
-    arg = QString(buf).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+    arg =
+        QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
     remove_quotes(arg);
     for (const auto &a : qAsConst(arg)) {
       qInfo() << a;
@@ -2471,8 +2468,7 @@ static bool vote_command(struct connection *caller, char *str, bool check)
   }
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(arg);
   if (arg.isEmpty()) {
     show_votes(caller);
@@ -2668,8 +2664,8 @@ static bool debug_command(struct connection *caller, char *str, bool check)
 
   if (str != NULL && qstrlen(str) > 0) {
     sz_strlcpy(buf, str);
-    arg = QString(buf).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+    arg =
+        QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
     remove_quotes(arg);
   }
 
@@ -2923,8 +2919,7 @@ static bool set_command(struct connection *caller, char *str, bool check)
   bool ret = false;
 
   // '=' is also a valid delimiter for this function.
-  args = QString(str).split(QRegularExpression(REG_EXP),
-                            QString::SkipEmptyParts);
+  args = QString(str).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(args);
 
   if (args.count() < 2) {
@@ -3258,8 +3253,7 @@ static bool observe_command(struct connection *caller, char *str, bool check)
   /******** PART I: fill pconn and pplayer ********/
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   // check syntax, only certain syntax if allowed depending on the caller
@@ -3405,8 +3399,7 @@ static bool take_command(struct connection *caller, char *str, bool check)
   /******** PART I: fill pconn and pplayer ********/
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   // check syntax
@@ -3586,8 +3579,7 @@ static bool detach_command(struct connection *caller, char *str, bool check)
   bool res = false;
 
   sz_strlcpy(buf, str);
-  arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+  arg = QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   if (!caller && arg.count() == 0) {
@@ -4113,8 +4105,8 @@ static bool playercolor_command(struct connection *caller, char *str,
   QStringList token;
   bool ret = true;
 
-  token = QString(str).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+  token =
+      QString(str).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() != 2) {
@@ -4204,8 +4196,8 @@ static bool playernation_command(struct connection *caller, char *str,
   bool is_male = false;
   QStringList token;
 
-  token = QString(str).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+  token =
+      QString(str).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() == 0) {
@@ -4914,8 +4906,8 @@ static bool lua_command(struct connection *caller, char *arg, bool check,
   enum m_pre_result result;
   bool ret = false;
 
-  tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+  tokens =
+      QString(arg).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() > 0) {
@@ -5108,8 +5100,8 @@ static bool delegate_command(struct connection *caller, char *arg,
     return false;
   }
 
-  tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+  tokens =
+      QString(arg).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() > 0) {
@@ -5601,8 +5593,8 @@ static bool mapimg_command(struct connection *caller, char *arg, bool check)
   QStringList token;
   bool ret = true;
 
-  token = QString(arg).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+  token =
+      QString(arg).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(token);
   if (token.count() > 0) {
     // match the argument
@@ -5829,8 +5821,8 @@ static bool aicmd_command(struct connection *caller, char *arg, bool check)
   char *cmd = NULL;
   bool ret = false;
 
-  tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+  tokens =
+      QString(arg).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() < 1) {
@@ -5920,8 +5912,8 @@ static bool fcdb_command(struct connection *caller, char *arg, bool check)
     return false;
   }
 
-  token = QString(arg).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+  token =
+      QString(arg).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() > 0) {

--- a/utility/astring.cpp
+++ b/utility/astring.cpp
@@ -65,8 +65,7 @@ QString qendl() { return QStringLiteral("\n"); }
 // break line after after n-th char
 QString break_lines(const QString &src, int after)
 {
-  QStringList broken =
-      src.split(QStringLiteral(" "), QString::SkipEmptyParts);
+  QStringList broken = src.split(QStringLiteral(" "), Qt::SkipEmptyParts);
   QString dst;
 
   int clen = 0;

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -632,7 +632,7 @@ static QStringList base_get_dirs(const char *env_var)
     return {};
   } else if (qEnvironmentVariableIsSet(env_var)) {
     return QString(qEnvironmentVariable(env_var))
-        .split(QDir::listSeparator(), QString::SkipEmptyParts);
+        .split(QDir::listSeparator(), Qt::SkipEmptyParts);
   } else {
     return {};
   }


### PR DESCRIPTION
`QString::SkipEmptyParts` has been deprecated.
https://doc.qt.io/qt-5/qstring-obsolete.html