### PR TITLE
Build only once when doing a new release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ on:
   push:
     paths-ignore: docs
   pull_request: {}
-  release:
-    types: [published]
   schedule:
     - cron: "0 5 * * MON"
   workflow_dispatch: {}


### PR DESCRIPTION
Two builds were occurring when creating a new release from the Github UI: one
on the push event and another on the release event. Keep only the push event to
save free CPU time.

Closes #609.