### PR TITLE
Fix a performance issue when the server sends many messages

### DIFF
--- a/client/gui-qt/messagewin.cpp
+++ b/client/gui-qt/messagewin.cpp
@@ -317,7 +317,7 @@ void messagewdg::msg(const struct message *pmsg)
     item->setIcon(QIcon(*pix));
   }
   mesg_table->setItem(i, 0, item);
-  msg_update();
+  mesg_table->resizeRowToContents(i);
   mesg_table->scrollToBottom();
 }
 


### PR DESCRIPTION
This is for instance the case at the beginning of a turn. The code was resizing
every row for each recieved message, resulting in O(N^2) complexity. Change it
to resize only the new row for O(N) complexity.

Closes #615.