### PR TITLE
Initialize scan->servers in server_scan_begin

### DIFF
--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -518,6 +518,7 @@ struct server_scan *server_scan_begin(enum server_scan_type type,
   scan = new server_scan;
   scan->type = type;
   scan->error_func = error_func;
+  scan->servers = nullptr;
 
   switch (type) {
   case SERVER_SCAN_GLOBAL:


### PR DESCRIPTION
If it's different from 0 (and invalid) when the scan is destroyed, we get a
segfault. This wouldn't have happened with proper RAII semantics...

Closes #640.