### PR TITLE
Fix info.artists entries in shipped tilesets

### DIFF
--- a/data/alio/hills.spec
+++ b/data/alio/hills.spec
@@ -2,6 +2,8 @@
 
 options = "+Freeciv-spec-Devel-2019-Jul-03"
 
+[info]
+
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)
 	 GriffonSpade

--- a/data/hexemplio/hills.spec
+++ b/data/hexemplio/hills.spec
@@ -2,6 +2,8 @@
 
 options = "+Freeciv-spec-Devel-2019-Jul-03"
 
+[info]
+
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)
 	 GriffonSpade

--- a/data/hexemplio/mountains.spec
+++ b/data/hexemplio/mountains.spec
@@ -2,6 +2,8 @@
 
 options = "+Freeciv-spec-Devel-2019-Jul-03"
 
+[info]
+
 artists = "
 	 Peter Arbor <peter.arbor@gmail.com> (original terrain)
 	 GriffonSpade


### PR DESCRIPTION
The client was showing warnings when loading them because of the unused entry
spec.artists. The client looks at info.artists, so add the [info] section
markers.

Closes #298.