### PR TITLE
Don't allow the city info grid to become squeezed

### DIFF
--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -1046,7 +1046,6 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
     qlt[iter]->setFont(*small_font);
     qlt[iter]->setProperty(fonts::notify_label, "true");
     info_grid_layout->addWidget(qlt[iter], iter, 1);
-    info_grid_layout->setRowStretch(iter, 0);
   }
   setLayout(info_grid_layout);
 }


### PR DESCRIPTION
The grid layout showing city output info in the city screen allowed rows to
shrink below their preferred size, which created overlap when there were many
units in a city. Not setting the row weights to 0 prevents this with no
apparent negative consequence.

Closes #665.