### PR TITLE
Pass the correct number of arguments to configure_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,6 @@ if(UNIX AND NOT APPLE)
     )
     configure_file(${CMAKE_SOURCE_DIR}/dist/net.longturn.freeciv21.client.desktop.in
                    net.longturn.freeciv21.client.desktop
-                   ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATAROOTDIR}
                    @ONLY NEWLINE_STYLE UNIX)
     install(
       FILES
@@ -234,7 +233,6 @@ if(UNIX AND NOT APPLE)
     )
     configure_file(${CMAKE_SOURCE_DIR}/dist/net.longturn.freeciv21.server.desktop.in
                    net.longturn.freeciv21.server.desktop
-                   ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATAROOTDIR}
                    @ONLY NEWLINE_STYLE UNIX)
     install(
       FILES
@@ -251,7 +249,6 @@ if(UNIX AND NOT APPLE)
     )
     configure_file(${CMAKE_SOURCE_DIR}/dist/net.longturn.freeciv21.modpack-qt.desktop.in
                    net.longturn.freeciv21.modpack-qt.desktop
-                   ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATAROOTDIR}
                    @ONLY NEWLINE_STYLE UNIX)
     install(
       FILES
@@ -268,7 +265,6 @@ if(UNIX AND NOT APPLE)
     )
     configure_file(${CMAKE_SOURCE_DIR}/dist/net.longturn.freeciv21.ruledit.desktop.in
                    net.longturn.freeciv21.ruledit.desktop
-                   ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATAROOTDIR}
                    @ONLY NEWLINE_STYLE UNIX)
     install(
       FILES


### PR DESCRIPTION
The additional paths were ignored but triggered warnings.

Closes #620.