### PR TITLE
Open the help dialog with at least 1280*800px

### DIFF
--- a/client/gui-qt/helpdlg.cpp
+++ b/client/gui-qt/helpdlg.cpp
@@ -193,7 +193,8 @@ void help_dialog::showEvent(QShowEvent *event)
     QList<QScreen *> screens = QGuiApplication::screens();
     QRect rect = screens[0]->availableGeometry();
 
-    resize((rect.width() * 3) / 5, (rect.height() * 3) / 6);
+    resize(qMax((rect.width() * 3) / 4, 1280),
+           qMax((rect.height() * 3) / 4, 800));
     sizes << rect.width() / 10 << rect.width() / 3;
     splitter->setSizes(sizes);
   }


### PR DESCRIPTION
This will enhances its layout on very busy pages (e.g. terrain and units).

Closes #563.