### PR TITLE
Disallow drag-and-drop in the city dialog lists

### DIFF
--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -65,12 +65,12 @@ extern QString cut_helptext(const QString &text);
 /**
    Constructor
  */
-icon_list::icon_list(QWidget *parent) : QListWidget(parent)
+icon_list::icon_list(QWidget *parent) : QListWidget(parent), oneliner(true)
 {
   // Make sure viewportSizeHint is used
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
   setWrapping(true);
-  oneliner = true;
+  setMovement(QListView::Static);
 }
 
 /**


### PR DESCRIPTION
It was possible to drag-and-drop unit icons within the lists in the city dialog. This allowed one to seemingly duplicate units.

The reason for this was that QListView defaults to allowing drag and drop when in icon mode.

Closes #708.