### PR TITLE
Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ build.ninja
 build*
 
 # IDE files
+.cache
 .clangd
 # Folder
 .kdev4


### PR DESCRIPTION
It's generated by clangd.

Was getting annoyed by this folder being listed in `git status`. Since this is only a dev quality of life thing there's no issue.