### PR TITLE
Add support for Zstandard compression

### DIFF
--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -3015,7 +3015,7 @@ void mr_menu::save_game_as()
   }
 
   str = QString(_("Save Games"))
-        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz)");
+        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz *.sav.zst)");
   current_file = QFileDialog::getSaveFileName(
       king()->central_wdg, _("Save Game As..."), location, str);
   if (!current_file.isEmpty()) {

--- a/client/gui-qt/page_load.cpp
+++ b/client/gui-qt/page_load.cpp
@@ -163,7 +163,7 @@ void page_load::browse_saves()
 {
   QString str;
   str = QString(_("Save Files"))
-        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz)");
+        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz *.sav.zst)");
   current_file = QFileDialog::getOpenFileName(this, _("Open Save File"),
                                               QDir::homePath(), str);
   if (!current_file.isEmpty()) {

--- a/client/gui-qt/page_scenario.cpp
+++ b/client/gui-qt/page_scenario.cpp
@@ -87,7 +87,7 @@ void page_scenario::browse_scenarios()
   QString str;
 
   str = QString(_("Scenarios Files"))
-        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz)");
+        + QStringLiteral(" (*.sav *.sav.bz2 *.sav.gz *.sav.xz *.sav.zst)");
   current_file = QFileDialog::getOpenFileName(this, _("Open Scenario File"),
                                               QDir::homePath(), str);
   if (!current_file.isEmpty()) {

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -111,6 +111,7 @@ include(FreecivBackward)
 find_package(KF5Archive REQUIRED)
 set(FREECIV_HAVE_BZ2 ${KArchive_HAVE_BZIP2})
 set(FREECIV_HAVE_LZMA ${KArchive_HAVE_LZMA})
+set(FREECIV_HAVE_ZSTD ${KArchive_HAVE_ZSTD})
 
 find_package(ZLIB REQUIRED) # Network protocol code
 

--- a/common/game.h
+++ b/common/game.h
@@ -46,6 +46,9 @@ enum compress_type {
 #ifdef FREECIV_HAVE_LZMA
   COMPRESS_XZ,
 #endif
+#ifdef FREECIV_HAVE_ZSTD
+  COMPRESS_ZSTD,
+#endif
 };
 
 enum autosave_type {

--- a/server/savegame/savemain.cpp
+++ b/server/savegame/savemain.cpp
@@ -228,7 +228,7 @@ void save_game(const char *orig_filename, const char *save_reason,
       sz_strlcat(stdata->filepath, ".xz");
       break;
 #endif
-#ifdef FREECIV_HAVE_LZMA
+#ifdef FREECIV_HAVE_ZSTD
     case COMPRESS_ZSTD:
       // Append ".zst" to filename.
       sz_strlcat(stdata->filepath, ".zst");

--- a/server/savegame/savemain.cpp
+++ b/server/savegame/savemain.cpp
@@ -167,7 +167,8 @@ void save_game(const char *orig_filename, const char *save_reason,
       filename[0] = '\0';
     } else {
       char *end_dot;
-      const char *strip_extensions[] = {".sav", ".gz", ".bz2", ".xz", NULL};
+      const char *strip_extensions[] = {".sav", ".gz",  ".bz2",
+                                        ".xz",  ".zst", NULL};
       bool stripped = true;
 
       while ((end_dot = strrchr(dot, '.')) && stripped) {
@@ -225,6 +226,12 @@ void save_game(const char *orig_filename, const char *save_reason,
     case COMPRESS_XZ:
       // Append ".xz" to filename.
       sz_strlcat(stdata->filepath, ".xz");
+      break;
+#endif
+#ifdef FREECIV_HAVE_LZMA
+    case COMPRESS_ZSTD:
+      // Append ".zst" to filename.
+      sz_strlcat(stdata->filepath, ".zst");
       break;
 #endif
     case COMPRESS_PLAIN:

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -544,6 +544,9 @@ compresstype_name(enum compress_type compresstype)
 #ifdef FREECIV_HAVE_LZMA
     NAME_CASE(COMPRESS_XZ, "XZ", N_("Using xz"));
 #endif
+#ifdef FREECIV_HAVE_ZSTD
+    NAME_CASE(COMPRESS_ZSTD, "ZSTD", N_("Using Zstandard"));
+#endif
   }
   return NULL;
 }

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -3733,10 +3733,11 @@ bool load_command(struct connection *caller, const char *filename,
     if (!found) {
       for (const auto &path : paths) {
         const auto exts = {
-            QStringLiteral("sav"),    QStringLiteral("gz"),
-            QStringLiteral("bz2"),    QStringLiteral("xz"),
-            QStringLiteral("sav.gz"), QStringLiteral("sav.bz2"),
-            QStringLiteral("sav.xz")};
+            QStringLiteral("sav"),     QStringLiteral("gz"),
+            QStringLiteral("bz2"),     QStringLiteral("xz"),
+            QStringLiteral("zst"),     QStringLiteral("sav.gz"),
+            QStringLiteral("sav.bz2"), QStringLiteral("sav.xz"),
+            QStringLiteral("sav.zst")};
         for (const auto &ext : exts) {
           QString name = filename + QStringLiteral(".") + ext;
           auto file = fileinfoname(path, qUtf8Printable(name));

--- a/utility/cmake_fc_config.h.in
+++ b/utility/cmake_fc_config.h.in
@@ -125,6 +125,9 @@
 /* lzma compression is available in KArchive */
 #cmakedefine FREECIV_HAVE_LZMA
 
+/* zstd compression is available in KArchive */
+#cmakedefine FREECIV_HAVE_ZSTD
+
 /* Max number of AI modules */
 #cmakedefine FREECIV_AI_MOD_LAST ${FREECIV_AI_MOD_LAST}
 


### PR DESCRIPTION
Zstandard is as fast as gzip and as good as xz. This makes it a good candidate for savegame compression. Support it when KArchive is recent enough.

Leaving the default to xz for now, but we might want to revisit this in the future.

Closes #713.

Test plan (you need KArchive 5.82 or later built with zst support):

1. `set compresstype zstd`
2. Save game
3. Load game just saved