### PR TITLE
Fix loading WWI scenario

### DIFF
--- a/common/ai.cpp
+++ b/common/ai.cpp
@@ -121,6 +121,7 @@ const char *ai_type_name_or_fallback(const char *orig_name)
 
   auto fb = ai_type_by_name("classic");
   if (fb != nullptr) {
+    qWarning(_("Unknown AI type %s, using \"classic\" instead"), orig_name);
     // Get pointer to persistent name of the ai_type
     return ai_name(fb);
   }

--- a/common/ai.cpp
+++ b/common/ai.cpp
@@ -119,15 +119,10 @@ const char *ai_type_name_or_fallback(const char *orig_name)
     return orig_name;
   }
 
-  if (!strcmp("threaded", orig_name)) {
-    struct ai_type *fb;
-
-    fb = ai_type_by_name("classic");
-
-    if (fb != NULL) {
-      // Get pointer to persistent name of the ai_type
-      return ai_name(fb);
-    }
+  auto fb = ai_type_by_name("classic");
+  if (fb != nullptr) {
+    // Get pointer to persistent name of the ai_type
+    return ai_name(fb);
   }
 
   return NULL;

--- a/common/game.cpp
+++ b/common/game.cpp
@@ -309,7 +309,7 @@ static void game_defaults(bool keep_ruleset_value)
   game.scenario.have_resources = true;
   game.scenario.ruleset_locked = true;
   game.scenario.save_random = false;
-  game.scenario.allow_ai_type_fallback = false;
+  game.scenario.allow_ai_type_fallback = true;
 
   game.scenario_desc.description[0] = '\0';
 


### PR DESCRIPTION
Collection of patches related to Freeciv(.org)'s new AI types "threaded" and "tex" that are not supported in fc21. Basically we always fall back to the classic AI, and only mention "classic" in our scenarios.

Closes #746.

Test plan:
* Save old Europe 1900 scenario somewhere else
* Checkout and build new code
* Load old Europe 1900
* Load new Europe 1900