### PR TITLE
Don't allow editing server output in pregame

### DIFF
--- a/client/gui-qt/page_pregame.cpp
+++ b/client/gui-qt/page_pregame.cpp
@@ -40,14 +40,10 @@ page_pregame::page_pregame(QWidget *parent, fc_client *gui) : QWidget(parent)
   king = gui;
   ui.setupUi(this);
 
-  QFont f;
   QStringList player_widget_list;
 
   ui.chat_line->setProperty("doomchat", true);
 
-  ui.output_window->setReadOnly(false);
-  f.setBold(true);
-  ui.output_window->setFont(f);
   player_widget_list << _("Name") << _("Ready") << Q_("?player:Leader")
                      << _("Flag") << _("Border") << _("Nation") << _("Team")
                      << _("Host");

--- a/client/gui-qt/page_pregame.ui
+++ b/client/gui-qt/page_pregame.ui
@@ -27,7 +27,11 @@
      <widget class="chat_input" name="chat_line"/>
     </item>
     <item row="1" column="0" colspan="5">
-     <widget class="QTextEdit" name="output_window"/>
+     <widget class="QTextEdit" name="output_window">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
     </item>
     <item row="3" column="2">
      <widget class="QPushButton" name="bpick">


### PR DESCRIPTION
And since I spotted this, don't force a bold font on the user.

Closes #747.