### PR TITLE
Make sprite getters return const QPixmap*

### DIFF
--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -801,7 +801,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
     line.add_icon(production_progress.get());
 
     // Icon
-    QPixmap *xsprite = nullptr;
+    const QPixmap *xsprite = nullptr;
     const auto &target = pcity->production;
     if (can_see_inside && (VUT_UTYPE == target.kind)) {
       xsprite =

--- a/client/climisc.cpp
+++ b/client/climisc.cpp
@@ -348,7 +348,7 @@ void nuclear_winter_scaled(int *chance, int *rate, int max)
 /**
    Return the sprite for the research indicator.
  */
-QPixmap *client_research_sprite()
+const QPixmap *client_research_sprite()
 {
   if (NULL != client.conn.playing && can_client_change_view()) {
     const struct research *presearch = research_get(client_player());
@@ -371,7 +371,7 @@ QPixmap *client_research_sprite()
 /**
    Return the sprite for the global-warming indicator.
  */
-QPixmap *client_warming_sprite()
+const QPixmap *client_warming_sprite()
 {
   int idx;
 
@@ -388,7 +388,7 @@ QPixmap *client_warming_sprite()
 /**
    Return the sprite for the global-cooling indicator.
  */
-QPixmap *client_cooling_sprite()
+const QPixmap *client_cooling_sprite()
 {
   int idx;
 
@@ -405,7 +405,7 @@ QPixmap *client_cooling_sprite()
 /**
    Return the sprite for the government indicator.
  */
-QPixmap *client_government_sprite()
+const QPixmap *client_government_sprite()
 {
   if (NULL != client.conn.playing && can_client_change_view()
       && government_count() > 0) {

--- a/client/climisc.h
+++ b/client/climisc.h
@@ -38,10 +38,10 @@ void client_diplomacy_clause_string(char *buf, int bufsiz,
 void global_warming_scaled(int *chance, int *rate, int max);
 void nuclear_winter_scaled(int *chance, int *rate, int max);
 
-QPixmap *client_research_sprite();
-QPixmap *client_warming_sprite();
-QPixmap *client_cooling_sprite();
-QPixmap *client_government_sprite();
+const QPixmap *client_research_sprite();
+const QPixmap *client_warming_sprite();
+const QPixmap *client_cooling_sprite();
+const QPixmap *client_government_sprite();
 
 void center_on_something();
 

--- a/client/gui-qt/civstatus.cpp
+++ b/client/gui-qt/civstatus.cpp
@@ -28,7 +28,6 @@
 
 civstatus::civstatus(QWidget *parent) : fcwidget()
 {
-  QPixmap *spr;
   QLabel *label;
   QImage img, cropped_img;
   QPixmap pix;
@@ -45,7 +44,7 @@ civstatus::civstatus(QWidget *parent) : fcwidget()
   fm = new QFontMetrics(f);
   icon_size = fm->height() * 7 / 8;
 
-  spr = get_tax_sprite(tileset, O_GOLD);
+  auto spr = get_tax_sprite(tileset, O_GOLD);
   label = new QLabel();
   label->setAlignment(Qt::AlignVCenter);
   img = spr->toImage();

--- a/client/gui-qt/dialogs.cpp
+++ b/client/gui-qt/dialogs.cpp
@@ -363,7 +363,6 @@ races_dialog::races_dialog(struct player *pplayer, QWidget *parent)
   QGridLayout *qgroupbox_layout;
   QGroupBox *no_name;
   QTableWidgetItem *item;
-  QPixmap *pix;
   QHeaderView *header;
   QSize size;
   QString title;
@@ -443,7 +442,7 @@ races_dialog::races_dialog(struct player *pplayer, QWidget *parent)
     if (i >= 0) {
       item = new QTableWidgetItem;
       styles->insertRow(i);
-      pix = get_sample_city_sprite(tileset, i);
+      auto pix = get_sample_city_sprite(tileset, i);
       item->setData(Qt::DecorationRole, *pix);
       item->setData(Qt::UserRole, style_number(pstyle));
       size.setWidth(pix->width());
@@ -624,11 +623,9 @@ void races_dialog::group_selected(const QItemSelection &sl,
 void races_dialog::set_index(int index)
 {
   QTableWidgetItem *item;
-  QPixmap *pix;
   QFont f;
   struct nation_group *group;
   int i;
-  QPixmap *s;
   QHeaderView *header;
   selected_nation_tabs->clearContents();
   selected_nation_tabs->setRowCount(0);
@@ -652,14 +649,13 @@ void races_dialog::set_index(int index)
     }
     item = new QTableWidgetItem;
     selected_nation_tabs->insertRow(i);
-    s = get_nation_flag_sprite(tileset, pnation);
+    auto s = get_nation_flag_sprite(tileset, pnation);
     if (pnation->player) {
       f = item->font();
       f.setStrikeOut(true);
       item->setFont(f);
     }
-    pix = s;
-    item->setData(Qt::DecorationRole, *pix);
+    item->setData(Qt::DecorationRole, *s);
     item->setData(Qt::UserRole, nation_number(pnation));
     item->setText(nation_adjective_translation(pnation));
     selected_nation_tabs->setItem(i, 0, item);

--- a/client/gui-qt/diplodlg.cpp
+++ b/client/gui-qt/diplodlg.cpp
@@ -64,8 +64,7 @@ diplo_wdg::diplo_wdg(int counterpart, int initiated_from)
   QLabel *goldlab2;
   QPushButton *add_clause1;
   QPushButton *add_clause2;
-  QPixmap *pix = NULL;
-  QPixmap *sprite, *sprite2;
+  const QPixmap *sprite, *sprite2;
   char plr_buf[4 * MAX_LEN_NAME];
   const struct player_diplstate *state;
   QHeaderView *header;
@@ -124,9 +123,8 @@ diplo_wdg::diplo_wdg(int counterpart, int initiated_from)
   label = new QLabel;
   sprite = get_nation_flag_sprite(
       tileset, nation_of_player(player_by_number(initiated_from)));
-  if (sprite != NULL) {
-    pix = sprite;
-    plr1_label->setPixmap(*pix);
+  if (sprite != nullptr) {
+    plr1_label->setPixmap(*sprite);
   } else {
     plr1_label->setText(QStringLiteral("FLAG MISSING"));
   }
@@ -143,8 +141,7 @@ diplo_wdg::diplo_wdg(int counterpart, int initiated_from)
       tileset, nation_of_player(player_by_number(counterpart)));
   plr2_label = new QLabel;
   if (sprite2 != NULL) {
-    pix = sprite2;
-    plr2_label->setPixmap(*pix);
+    plr2_label->setPixmap(*sprite2);
   } else {
     plr2_label->setText(QStringLiteral("FLAG MISSING"));
   }
@@ -631,8 +628,6 @@ void diplo_wdg::update_wdg()
 {
   bool blank;
   int i;
-  QPixmap *sprite;
-  QPixmap *pix = NULL;
   QTableWidgetItem *qitem;
 
   blank = true;
@@ -662,18 +657,16 @@ void diplo_wdg::update_wdg()
     text_edit->setItem(0, 0, qitem);
   }
 
-  sprite = get_treaty_thumb_sprite(tileset, treaty.accept0);
-  if (sprite != NULL) {
-    pix = sprite;
-    plr1_accept->setPixmap(*pix);
+  auto sprite = get_treaty_thumb_sprite(tileset, treaty.accept0);
+  if (sprite != nullptr) {
+    plr1_accept->setPixmap(*sprite);
   } else {
     plr1_accept->setText(QStringLiteral("PIXMAP MISSING"));
   }
 
   sprite = get_treaty_thumb_sprite(tileset, treaty.accept1);
-  if (sprite != NULL) {
-    pix = sprite;
-    plr2_accept->setPixmap(*pix);
+  if (sprite != nullptr) {
+    plr2_accept->setPixmap(*sprite);
   } else {
     plr2_accept->setText(QStringLiteral("PIXMAP MISSING"));
   }
@@ -727,22 +720,16 @@ diplo_dlg::diplo_dlg(int counterpart, int initiated_from) : QTabWidget()
 void diplo_dlg::add_widget(int counterpart, int initiated_from)
 {
   diplo_wdg *dw;
-  QPixmap *sprite;
-  QPixmap *pix;
   int i;
 
-  pix = NULL;
   dw = new diplo_wdg(counterpart, initiated_from);
   treaty_list.insert(counterpart, dw);
   i = addTab(dw, nation_plural_for_player(player_by_number(counterpart)));
   dw->set_index(i);
-  sprite = get_nation_flag_sprite(
+  auto sprite = get_nation_flag_sprite(
       tileset, nation_of_player(player_by_number(counterpart)));
   if (sprite != NULL) {
-    pix = sprite;
-  }
-  if (pix != NULL) {
-    setTabIcon(i, QIcon(*pix));
+    setTabIcon(i, QIcon(*sprite));
   }
 }
 
@@ -871,7 +858,8 @@ void handle_diplomacy_init_meeting(int counterpart, int initiated_from)
   int i;
   diplo_dlg *dd;
   QPainter p;
-  QPixmap *pix, *pix2, *pix3;
+  const QPixmap *pix;
+  QPixmap *pix2, *pix3;
   QWidget *w;
   QWidget *fw;
 

--- a/client/gui-qt/economyreport.cpp
+++ b/client/gui-qt/economyreport.cpp
@@ -70,9 +70,6 @@ void eco_report::update_report()
   int h;
   QFontMetrics fm(f);
   h = fm.height() + 6;
-  QPixmap *pix;
-  QPixmap pix_scaled;
-  QPixmap *sprite;
 
   ui.eco_widget->setRowCount(0);
   ui.eco_widget->clearContents();
@@ -82,26 +79,19 @@ void eco_report::update_report()
     struct improvement_entry *pentry = building_entries + i;
     struct impr_type *pimprove = pentry->type;
 
-    pix = NULL;
-    sprite = get_building_sprite(tileset, pimprove);
-    if (sprite != NULL) {
-      pix = sprite;
-    }
-    if (pix != NULL) {
-      pix_scaled = pix->scaledToHeight(h);
-    } else {
-      pix_scaled.fill();
-    }
     cid id = cid_encode_building(pimprove);
 
     ui.eco_widget->insertRow(i);
     for (j = 0; j < 6; j++) {
       item = new QTableWidgetItem;
       switch (j) {
-      case 0:
-        item->setData(Qt::DecorationRole, pix_scaled);
+      case 0: {
+        auto sprite = get_building_sprite(tileset, pimprove);
+        if (sprite != nullptr) {
+          item->setData(Qt::DecorationRole, sprite->scaledToHeight(h));
+        }
         item->setData(Qt::UserRole, id);
-        break;
+      } break;
       case 1:
         item->setTextAlignment(Qt::AlignLeft);
         item->setText(improvement_name_translation(pimprove));
@@ -130,11 +120,7 @@ void eco_report::update_report()
     struct unit_type *putype = pentry->type;
     cid id;
 
-    pix = NULL;
-    sprite = get_unittype_sprite(tileset, putype, direction8_invalid());
-    if (sprite != NULL) {
-      pix = sprite;
-    }
+    auto sprite = get_unittype_sprite(tileset, putype, direction8_invalid());
     id = cid_encode_unit(putype);
 
     ui.eco_widget->insertRow(i + max_row);
@@ -143,9 +129,8 @@ void eco_report::update_report()
       item->setTextAlignment(Qt::AlignHCenter);
       switch (j) {
       case 0:
-        if (pix != NULL) {
-          pix_scaled = pix->scaledToHeight(h);
-          item->setData(Qt::DecorationRole, pix_scaled);
+        if (sprite != nullptr) {
+          item->setData(Qt::DecorationRole, sprite->scaledToHeight(h));
         }
         item->setData(Qt::UserRole, id);
         break;

--- a/client/gui-qt/endgamereport.cpp
+++ b/client/gui-qt/endgamereport.cpp
@@ -77,7 +77,6 @@ void endgame_report::update_report(
     const struct packet_endgame_player *packet)
 {
   QTableWidgetItem *item;
-  QPixmap *pix;
   unsigned int i;
   const struct player *pplayer = player_by_number(packet->player_id);
   const size_t col_num = packet->category_num + 3;
@@ -88,12 +87,12 @@ void endgame_report::update_report(
     case 0:
       item->setText(player_name(pplayer));
       break;
-    case 1:
-      pix = get_nation_flag_sprite(tileset, nation_of_player(pplayer));
+    case 1: {
+      auto pix = get_nation_flag_sprite(tileset, nation_of_player(pplayer));
       if (pix != NULL) {
         item->setData(Qt::DecorationRole, *pix);
       }
-      break;
+    } break;
     case 2:
       item->setText(QString::number(packet->score));
       item->setTextAlignment(Qt::AlignHCenter);

--- a/client/gui-qt/fc_client.cpp
+++ b/client/gui-qt/fc_client.cpp
@@ -544,19 +544,12 @@ void popup_client_options()
  */
 void fc_client::create_cursors()
 {
-  enum cursor_type curs;
-  int cursor;
-  QPixmap *pix;
-  int hot_x, hot_y;
-  QPixmap *sprite;
-  int frame;
-  QCursor *c;
-  for (cursor = 0; cursor < CURSOR_LAST; cursor++) {
-    for (frame = 0; frame < NUM_CURSOR_FRAMES; frame++) {
-      curs = static_cast<cursor_type>(cursor);
-      sprite = get_cursor_sprite(tileset, curs, &hot_x, &hot_y, frame);
-      pix = sprite;
-      c = new QCursor(*pix, hot_x, hot_y);
+  for (int cursor = 0; cursor < CURSOR_LAST; cursor++) {
+    for (int frame = 0; frame < NUM_CURSOR_FRAMES; frame++) {
+      auto curs = static_cast<cursor_type>(cursor);
+      int hot_x, hot_y;
+      auto sprite = get_cursor_sprite(tileset, curs, &hot_x, &hot_y, frame);
+      auto c = new QCursor(*sprite, hot_x, hot_y);
       fc_cursors[cursor][frame] = c;
     }
   }

--- a/client/gui-qt/gotodlg.cpp
+++ b/client/gui-qt/gotodlg.cpp
@@ -222,9 +222,6 @@ void goto_dialog::fill_tab(player *pplayer)
   QFont f = QApplication::font();
   QFontMetrics fm(f);
   int h;
-  QPixmap *sprite;
-  QPixmap *pix;
-  QPixmap pix_scaled;
   QTableWidgetItem *item;
 
   h = fm.height() + 6;
@@ -238,15 +235,14 @@ void goto_dialog::fill_tab(player *pplayer)
       case 0:
         str = city_name_get(pcity);
         break;
-      case 1:
-        sprite = get_nation_flag_sprite(tileset, nation_of_player(pplayer));
+      case 1: {
+        auto sprite =
+            get_nation_flag_sprite(tileset, nation_of_player(pplayer));
         if (sprite != NULL) {
-          pix = sprite;
-          pix_scaled = pix->scaledToHeight(h);
-          item->setData(Qt::DecorationRole, pix_scaled);
+          item->setData(Qt::DecorationRole, sprite->scaledToHeight(h));
         }
         str = nation_adjective_translation(nation_of_player(pplayer));
-        break;
+      } break;
       case 2:
         str = get_airlift_text(get_units_in_focus(), pcity);
         if (str.isEmpty()) {

--- a/client/gui-qt/gui_main.cpp
+++ b/client/gui-qt/gui_main.cpp
@@ -92,13 +92,10 @@ static void migrate_options_from_2_5()
 void qtg_ui_main()
 {
   if (true) {
-    QPixmap *qpm;
-    QIcon app_icon;
-
     tileset_init(tileset);
     tileset_load_tiles(tileset);
-    qpm = get_icon_sprite(tileset, ICON_FREECIV);
-    app_icon = ::QIcon(*qpm);
+    auto qpm = get_icon_sprite(tileset, ICON_FREECIV);
+    auto app_icon = QIcon(*qpm);
     qApp->setWindowIcon(app_icon);
     if (gui_options.first_boot) {
       /* We're using fresh defaults for this version of this client,

--- a/client/gui-qt/helpdlg.cpp
+++ b/client/gui-qt/helpdlg.cpp
@@ -588,7 +588,7 @@ void help_widget::show_info_panel()
 /**
    Adds a pixmap to the information panel.
  */
-void help_widget::add_info_pixmap(QPixmap *pm, bool shadow)
+void help_widget::add_info_pixmap(const QPixmap *pm, bool shadow)
 {
   QLabel *label = new QLabel();
   QGraphicsDropShadowEffect *effect;
@@ -960,7 +960,6 @@ void help_widget::set_topic_building(const help_item *topic,
 {
   char buffer[MAX_HELP_TEXT_SIZE];
   int type, value;
-  QPixmap *spr;
   struct impr_type *itype = improvement_by_translated_name(title);
   char req_buf[512];
   QString str, s1, s2;
@@ -971,7 +970,7 @@ void help_widget::set_topic_building(const help_item *topic,
                       topic->text, itype);
     text_browser->setPlainText(buffer);
     show_info_panel();
-    spr = get_building_sprite(tileset, itype);
+    auto spr = get_building_sprite(tileset, itype);
     if (spr) {
       add_info_pixmap(spr);
     }
@@ -1051,7 +1050,6 @@ void help_widget::set_topic_building(const help_item *topic,
 void help_widget::set_topic_tech(const help_item *topic, const char *title)
 {
   char buffer[MAX_HELP_TEXT_SIZE];
-  QPixmap *spr;
   QLabel *tb;
   struct advance *padvance = advance_by_translated_name(title);
   QString str;
@@ -1060,7 +1058,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
     int n = advance_number(padvance);
     if (!is_future_tech(n)) {
       show_info_panel();
-      spr = get_tech_sprite(tileset, n);
+      auto spr = get_tech_sprite(tileset, n);
       if (spr) {
         add_info_pixmap(spr);
       }

--- a/client/gui-qt/helpdlg.h
+++ b/client/gui-qt/helpdlg.h
@@ -90,7 +90,7 @@ class help_widget : public QWidget {
   void undo_layout();
 
   void show_info_panel();
-  void add_info_pixmap(QPixmap *pm, bool shadow = false);
+  void add_info_pixmap(const QPixmap *pm, bool shadow = false);
   void add_info_label(const QString &text);
   void add_info_progress(const QString &label, int progress, int min,
                          int max, const QString &value = QString());

--- a/client/gui-qt/hudwidget.cpp
+++ b/client/gui-qt/hudwidget.cpp
@@ -1229,7 +1229,6 @@ void hud_unit_loader::show_me()
   int max_size = 0;
   int i, j;
   int w, h;
-  QPixmap *spite;
 
   unit_list_iterate(qtile->units, ptransport)
   {
@@ -1245,22 +1244,21 @@ void hud_unit_loader::show_me()
   setRowCount(transports.count());
   setColumnCount(max_size + 1);
   for (i = 0; i < transports.count(); i++) {
-    QString str;
-    spite = get_unittype_sprite(tileset, transports.at(i)->utype,
-                                direction8_invalid());
-    str = utype_rule_name(transports.at(i)->utype);
+    auto sprite = get_unittype_sprite(tileset, transports.at(i)->utype,
+                                      direction8_invalid());
+    QString str = utype_rule_name(transports.at(i)->utype);
     // TRANS: MP - just movement points
-    str = str + " ("
-          + QString(move_points_text(transports.at(i)->moves_left, false))
-          + _("MP") + ")";
-    new_item = new QTableWidgetItem(QIcon(*spite), str);
+    str += " ("
+           + QString(move_points_text(transports.at(i)->moves_left, false))
+           + _("MP") + ")";
+    new_item = new QTableWidgetItem(QIcon(*sprite), str);
     setItem(i, 0, new_item);
     j = 1;
     unit_list_iterate(transports.at(i)->transporting, tunit)
     {
-      spite =
+      sprite =
           get_unittype_sprite(tileset, tunit->utype, direction8_invalid());
-      new_item = new QTableWidgetItem(QIcon(*spite), QLatin1String(""));
+      new_item = new QTableWidgetItem(QIcon(*sprite), QLatin1String(""));
       setItem(i, j, new_item);
       j++;
     }

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -455,17 +455,6 @@ void update_turn_done_button(bool do_restore)
 }
 
 /**
-   Set information for the indicator icons typically shown in the main
-   client window.  The parameters tell which sprite to use for the
-   indicator.
- */
-void set_indicator_icons(QPixmap *bulb, QPixmap *sol, QPixmap *flake,
-                         QPixmap *gov)
-{
-  queen()->sw_indicators->updateFinalPixmap();
-}
-
-/**
    Flush the given part of the canvas buffer (if there is one) to the
    screen.
  */
@@ -551,7 +540,8 @@ void update_city_descriptions(void) { update_map_canvas_visible(); }
 /**
    Put overlay tile to pixmap
  */
-void pixmap_put_overlay_tile(int canvas_x, int canvas_y, QPixmap *ssprite)
+void pixmap_put_overlay_tile(int canvas_x, int canvas_y,
+                             const QPixmap *ssprite)
 {
   if (!ssprite) {
     return;

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -222,15 +222,14 @@ void gov_menu::create()
 void gov_menu::update()
 {
   struct government *gov, *revol_gov;
-  QPixmap *sprite;
 
   revol_gov = game.government_during_revolution;
   for (int i = 0, j = 0; i < actions.count(); ++i) {
     gov = government_by_number(i);
     if (gov != revol_gov) { // Skip revolution goverment
-      sprite = get_government_sprite(tileset, gov);
+      auto sprite = get_government_sprite(tileset, gov);
       if (sprite != NULL) {
-        actions[j + 1]->setIcon(QIcon(*(sprite)));
+        actions[j + 1]->setIcon(QIcon(*sprite));
       }
       actions[j + 1]->setEnabled(
           can_change_to_government(client.conn.playing, gov));

--- a/client/gui-qt/messagewin.cpp
+++ b/client/gui-qt/messagewin.cpp
@@ -202,7 +202,6 @@ messagewdg::messagewdg(QWidget *parent) : QWidget(parent)
   palette.setColor(QPalette::Highlight, QColor(0, 0, 0, 0));
   palette.setColor(QPalette::HighlightedText, QColor(205, 206, 173));
   palette.setColor(QPalette::Text, QColor(205, 206, 173));
-  pix = nullptr;
   mesg_table->setPalette(palette);
   connect(mesg_table->selectionModel(),
           &QItemSelectionModel::selectionChanged, this,
@@ -304,9 +303,8 @@ void messagewdg::msg(const struct message *pmsg)
     item->setFont(f);
   }
   auto icon = get_event_sprite(tileset, pmsg->event);
-  if (icon != NULL) {
-    pix = icon;
-    item->setIcon(QIcon(*pix));
+  if (icon != nullptr) {
+    item->setIcon(QIcon(*icon));
   }
 }
 

--- a/client/gui-qt/messagewin.h
+++ b/client/gui-qt/messagewin.h
@@ -40,7 +40,6 @@ public:
 private:
   QListWidget *mesg_table;
   QGridLayout *layout;
-  QPixmap *pix;
 
 protected:
   void enterEvent(QEvent *event) override;

--- a/client/gui-qt/page_game.cpp
+++ b/client/gui-qt/page_game.cpp
@@ -238,9 +238,6 @@ void pageGame::updateInfoLabelTimeout()
   sw_map->setCustomLabels(s);
   sw_map->updateFinalPixmap();
 
-  set_indicator_icons(client_research_sprite(), client_warming_sprite(),
-                      client_cooling_sprite(), client_government_sprite());
-
   if (client.conn.playing != NULL) {
     if (player_get_expected_income(client.conn.playing) > 0) {
       eco_info =
@@ -259,6 +256,7 @@ void pageGame::updateInfoLabelTimeout()
   } else {
     sw_economy->setCustomLabels(QLatin1String(""));
   }
+  sw_indicators->updateFinalPixmap();
   sw_tax->updateFinalPixmap();
   sw_economy->updateFinalPixmap();
   FC_FREE(update_info_timer);

--- a/client/gui-qt/page_pregame.cpp
+++ b/client/gui-qt/page_pregame.cpp
@@ -91,9 +91,6 @@ void page_pregame::update_start_page()
   QVariant qvar, qvar2;
   bool is_ready;
   QString host, nation, leader, team, str;
-  QPixmap *pixmap;
-  QPainter p;
-  QPixmap *psprite;
   QTreeWidgetItem *item;
   QTreeWidgetItem *item_r;
   QList<QTreeWidgetItem *> items;
@@ -199,29 +196,29 @@ void page_pregame::update_start_page()
         case 2:
           item->setText(col, leader);
           break;
-        case 3:
+        case 3: {
           if (!pplayer->nation) {
             break;
           }
-          psprite = get_nation_flag_sprite(tileset, pplayer->nation);
-          pixmap = psprite;
+          auto pixmap = get_nation_flag_sprite(tileset, pplayer->nation);
           item->setData(col, Qt::DecorationRole, *pixmap);
-          break;
-        case 4:
+        } break;
+        case 4: {
           if (!player_has_color(tileset, pplayer)) {
             break;
           }
-          pixmap = new QPixmap(
+          auto pixmap = std::make_unique<QPixmap>(
               ui.start_players_tree->header()->sectionSizeHint(col), 16);
           pixmap->fill(Qt::transparent);
-          p.begin(pixmap);
+
+          QPainter p;
+          p.begin(pixmap.get());
           p.fillRect(pixmap->width() / 2 - 8, 0, 16, 16, Qt::black);
           p.fillRect(pixmap->width() / 2 - 7, 1, 14, 14,
                      *get_player_color(tileset, pplayer));
           p.end();
           item->setData(col, Qt::DecorationRole, *pixmap);
-          delete pixmap;
-          break;
+        } break;
         case 5:
           item->setText(col, nation);
           break;

--- a/client/gui-qt/plrdlg.cpp
+++ b/client/gui-qt/plrdlg.cpp
@@ -149,9 +149,6 @@ bool plr_item::setData(int column, const QVariant &value, int role)
  */
 QVariant plr_item::data(int column, int role) const
 {
-  QFont f;
-  QFontMetrics *fm;
-  QPixmap *pix;
   QString str;
   struct player_dlg_column *pdc;
 
@@ -163,14 +160,12 @@ QVariant plr_item::data(int column, int role) const
   }
   pdc = &player_dlg_columns[column];
   switch (player_dlg_columns[column].type) {
-  case COL_FLAG:
-    pix = get_nation_flag_sprite(tileset, nation_of_player(ipplayer));
-    f = *fcFont::instance()->getFont(fonts::default_font);
-    fm = new QFontMetrics(f);
-    *pix = pix->scaledToHeight(fm->height());
-    delete fm;
-    return *pix;
-    break;
+  case COL_FLAG: {
+    auto f = *fcFont::instance()->getFont(fonts::default_font);
+    auto fm = std::make_unique<QFontMetrics>(f);
+    return get_nation_flag_sprite(tileset, nation_of_player(ipplayer))
+        ->scaledToHeight(fm->height());
+  } break;
   case COL_COLOR:
     return *get_player_color(tileset, ipplayer);
     break;
@@ -188,9 +183,9 @@ QVariant plr_item::data(int column, int role) const
       return -1;
     }
     return str;
-  default:
-    return QVariant();
   }
+
+  return QVariant();
 }
 
 /**

--- a/client/gui-qt/pregameoptions.cpp
+++ b/client/gui-qt/pregameoptions.cpp
@@ -126,8 +126,6 @@ void pregame_options::set_aifill(int aifill)
  */
 void pregame_options::update_buttons()
 {
-  QPixmap *psprite = nullptr;
-  QPixmap *pixmap = nullptr;
   const struct player *pplayer = client_player();
 
   // Update the "Select Nation" button
@@ -137,8 +135,7 @@ void pregame_options::update_buttons()
       ui.nation->setText(
           QString(nation_adjective_for_player(pplayer))
               .replace(QLatin1String("&"), QLatin1String("&&")));
-      psprite = get_nation_shield_sprite(tileset, pplayer->nation);
-      pixmap = psprite;
+      auto pixmap = get_nation_shield_sprite(tileset, pplayer->nation);
       ui.nation->setIconSize(pixmap->size());
       ui.nation->setIcon(QIcon(*pixmap));
     } else {

--- a/client/gui-qt/ratesdlg.cpp
+++ b/client/gui-qt/ratesdlg.cpp
@@ -328,7 +328,6 @@ void fc_double_edge::paintEvent(QPaintEvent *event)
   Q_UNUSED(event)
   QPainter p;
   int i, j, pos;
-  QPixmap *pix;
   QPixmap pix_scaled;
   QSize s;
   double x_min, x_max;
@@ -348,7 +347,7 @@ void fc_double_edge::paintEvent(QPaintEvent *event)
           + cursor_size;
 
   pos = cursor_size;
-  pix = get_tax_sprite(tileset, O_GOLD);
+  auto pix = get_tax_sprite(tileset, O_GOLD);
   s.setWidth((width() - 2 * cursor_size) / 10);
   s.setHeight(height());
   pix_scaled =

--- a/client/gui-qt/sciencedlg.cpp
+++ b/client/gui-qt/sciencedlg.cpp
@@ -353,7 +353,6 @@ void science_report::update_report()
   double not_used;
   QString str;
   qlist_item item;
-  QPixmap *sp;
 
   fc_assert_ret(NULL != research);
 
@@ -425,7 +424,7 @@ void science_report::update_report()
   for (int i = 0; i < curr_list->count(); i++) {
     QIcon ic;
 
-    sp = get_tech_sprite(tileset, curr_list->at(i).id);
+    auto sp = get_tech_sprite(tileset, curr_list->at(i).id);
     if (sp) {
       ic = QIcon(*sp);
     }
@@ -436,7 +435,7 @@ void science_report::update_report()
   for (int i = 0; i < goal_list->count(); i++) {
     QIcon ic;
 
-    sp = get_tech_sprite(tileset, goal_list->at(i).id);
+    auto sp = get_tech_sprite(tileset, goal_list->at(i).id);
     if (sp) {
       ic = QIcon(*sp);
     }

--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -689,10 +689,9 @@ void sidebarRightClickScience()
     menu = new QMenu(king()->central_wdg);
     for (int i = 0; i < curr_list.count(); i++) {
       QIcon ic;
-      QPixmap *sp;
 
       qvar = curr_list.at(i).id;
-      sp = get_tech_sprite(tileset, curr_list.at(i).id);
+      auto sp = get_tech_sprite(tileset, curr_list.at(i).id);
       if (sp) {
         ic = QIcon(*sp);
       }

--- a/client/gui-qt/unitreport.cpp
+++ b/client/gui-qt/unitreport.cpp
@@ -163,7 +163,7 @@ unittype_item::unittype_item(QWidget *parent, struct unit_type *ut)
   QSpacerItem *spacer;
   QVBoxLayout *vbox;
   QVBoxLayout *vbox_main;
-  QPixmap *spr;
+  const QPixmap *spr;
 
   setParent(parent);
   utype = ut;
@@ -238,9 +238,7 @@ unittype_item::~unittype_item() = default;
  */
 void unittype_item::init_img()
 {
-  QPixmap *sp;
-
-  sp = get_unittype_sprite(get_tileset(), utype, direction8_invalid());
+  auto sp = get_unittype_sprite(get_tileset(), utype, direction8_invalid());
   label_pix.setPixmap(*sp);
 }
 

--- a/client/include/mapview_g.h
+++ b/client/include/mapview_g.h
@@ -33,8 +33,6 @@ GUI_FUNC_PROTO(void, update_mouse_cursor, enum cursor_type new_cursor_type)
 GUI_FUNC_PROTO(void, update_timeout_label, void)
 GUI_FUNC_PROTO(void, update_turn_done_button, bool do_restore)
 GUI_FUNC_PROTO(void, update_city_descriptions, void)
-GUI_FUNC_PROTO(void, set_indicator_icons, QPixmap *bulb, QPixmap *sol,
-               QPixmap *flake, QPixmap *gov)
 
 GUI_FUNC_PROTO(void, start_turn, void)
 

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1077,9 +1077,7 @@ void put_unit_city_overlays(struct unit *punit, QPixmap *pcanvas,
                             int canvas_x, int canvas_y, int *upkeep_cost,
                             int happy_cost)
 {
-  QPixmap *sprite;
-
-  sprite = get_unit_unhappy_sprite(tileset, punit, happy_cost);
+  auto sprite = get_unit_unhappy_sprite(tileset, punit, happy_cost);
   if (sprite) {
     canvas_put_sprite_full(pcanvas, canvas_x, canvas_y, sprite);
   }
@@ -1149,7 +1147,7 @@ void toggle_unit_color(struct unit *punit)
 void put_nuke_mushroom_pixmaps(struct tile *ptile)
 {
   float canvas_x, canvas_y;
-  QPixmap *mysprite = get_nuke_explode_sprite(tileset);
+  auto mysprite = get_nuke_explode_sprite(tileset);
   int width, height;
 
   get_sprite_dimensions(mysprite, &width, &height);
@@ -2769,7 +2767,7 @@ void free_mapcanvas_and_overview()
  */
 void get_spaceship_dimensions(int *width, int *height)
 {
-  QPixmap *sprite = get_spaceship_sprite(tileset, SPACESHIP_HABITATION);
+  auto sprite = get_spaceship_sprite(tileset, SPACESHIP_HABITATION);
 
   get_sprite_dimensions(sprite, width, height);
   *width *= 7;
@@ -2787,7 +2785,7 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
   int i, x, y;
   const struct player_spaceship *ship = &pplayer->spaceship;
   int w, h;
-  QPixmap *spr;
+  const QPixmap *spr;
   struct tileset *t = tileset;
 
   spr = get_spaceship_sprite(t, SPACESHIP_HABITATION);

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -112,7 +112,7 @@ static void node_rectangle_minimum_size(struct tree_node *node, int *width,
 {
   int max_icon_height; // maximal height of icons below the text
   int icons_width_sum; // sum of icons width plus space between them
-  QPixmap *sprite;
+  const QPixmap *sprite;
   int swidth, sheight;
 
   if (node->is_dummy) {
@@ -992,7 +992,7 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
   Q_UNUSED(canvas_y)
   int i, j, k;
   int swidth, sheight;
-  QPixmap *sprite;
+  const QPixmap *sprite;
   QColor *color;
   req_tooltip_help *rttp;
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -170,9 +170,9 @@ struct named_sprites {
     QPixmap *tile, *worked_tile, *unworked_tile;
   } mask;
 
-  QPixmap *tech[A_LAST];
-  QPixmap *building[B_LAST];
-  QPixmap *government[G_LAST];
+  const QPixmap *tech[A_LAST];
+  const QPixmap *building[B_LAST];
+  const QPixmap *government[G_LAST];
 
   struct {
     QPixmap *icon[U_LAST];
@@ -3721,8 +3721,8 @@ void tileset_setup_nation_flag(struct tileset *t, struct nation_type *nation)
 /**
    Return the flag graphic to be used by the city.
  */
-QPixmap *get_city_flag_sprite(const struct tileset *t,
-                              const struct city *pcity)
+const QPixmap *get_city_flag_sprite(const struct tileset *t,
+                                    const struct city *pcity)
 {
   return get_nation_flag_sprite(t, nation_of_city(pcity));
 }
@@ -3788,7 +3788,7 @@ static void fill_unit_type_sprite_array(const struct tileset *t,
                                         const struct unit_type *putype,
                                         enum direction8 facing)
 {
-  QPixmap *uspr = get_unittype_sprite(t, putype, facing);
+  auto uspr = get_unittype_sprite(t, putype, facing);
 
   sprs.emplace_back(t, uspr, true, FULL_TILE_X_OFFSET + t->unit_offset_x,
                     FULL_TILE_Y_OFFSET + t->unit_offset_y);
@@ -5354,8 +5354,8 @@ void tileset_free_tiles(struct tileset *t)
 /**
    Return the sprite for drawing the given spaceship part.
  */
-QPixmap *get_spaceship_sprite(const struct tileset *t,
-                              enum spaceship_part part)
+const QPixmap *get_spaceship_sprite(const struct tileset *t,
+                                    enum spaceship_part part)
 {
   return t->sprites.spaceship[part];
 }
@@ -5367,9 +5367,10 @@ QPixmap *get_spaceship_sprite(const struct tileset *t,
    value indicates there is no city; i.e., the sprite is just being
    used as a picture).
  */
-QPixmap *get_citizen_sprite(const struct tileset *t,
-                            enum citizen_category type, int citizen_index,
-                            const struct city *pcity)
+const QPixmap *get_citizen_sprite(const struct tileset *t,
+                                  enum citizen_category type,
+                                  int citizen_index,
+                                  const struct city *pcity)
 {
   const struct citizen_graphic *graphic;
   int gfx_index = citizen_index;
@@ -5396,8 +5397,8 @@ QPixmap *get_citizen_sprite(const struct tileset *t,
 /**
    Return the sprite for the nation.
  */
-QPixmap *get_nation_flag_sprite(const struct tileset *t,
-                                const struct nation_type *pnation)
+const QPixmap *get_nation_flag_sprite(const struct tileset *t,
+                                      const struct nation_type *pnation)
 {
   return t->sprites.nation_flag.p[nation_index(pnation)];
 }
@@ -5405,8 +5406,8 @@ QPixmap *get_nation_flag_sprite(const struct tileset *t,
 /**
    Return the shield sprite for the nation.
  */
-QPixmap *get_nation_shield_sprite(const struct tileset *t,
-                                  const struct nation_type *pnation)
+const QPixmap *get_nation_shield_sprite(const struct tileset *t,
+                                        const struct nation_type *pnation)
 {
   return t->sprites.nation_shield.p[nation_index(pnation)];
 }
@@ -5414,7 +5415,7 @@ QPixmap *get_nation_shield_sprite(const struct tileset *t,
 /**
    Return the sprite for the technology/advance.
  */
-QPixmap *get_tech_sprite(const struct tileset *t, Tech_type_id tech)
+const QPixmap *get_tech_sprite(const struct tileset *t, Tech_type_id tech)
 {
   fc_assert_ret_val(0 <= tech && tech < advance_count(), NULL);
   return t->sprites.tech[tech];
@@ -5423,8 +5424,8 @@ QPixmap *get_tech_sprite(const struct tileset *t, Tech_type_id tech)
 /**
    Return the sprite for the building/improvement.
  */
-QPixmap *get_building_sprite(const struct tileset *t,
-                             const struct impr_type *pimprove)
+const QPixmap *get_building_sprite(const struct tileset *t,
+                                   const struct impr_type *pimprove)
 {
   fc_assert_ret_val(NULL != pimprove, NULL);
   return t->sprites.building[improvement_index(pimprove)];
@@ -5433,8 +5434,8 @@ QPixmap *get_building_sprite(const struct tileset *t,
 /**
    Return the sprite for the government.
  */
-QPixmap *get_government_sprite(const struct tileset *t,
-                               const struct government *gov)
+const QPixmap *get_government_sprite(const struct tileset *t,
+                                     const struct government *gov)
 {
   fc_assert_ret_val(NULL != gov, NULL);
   return t->sprites.government[government_index(gov)];
@@ -5445,9 +5446,9 @@ QPixmap *get_government_sprite(const struct tileset *t,
    If 'facing' is direction8_invalid(), will use an unoriented sprite or
    a default orientation.
  */
-QPixmap *get_unittype_sprite(const struct tileset *t,
-                             const struct unit_type *punittype,
-                             enum direction8 facing)
+const QPixmap *get_unittype_sprite(const struct tileset *t,
+                                   const struct unit_type *punittype,
+                                   enum direction8 facing)
 {
   int uidx = utype_index(punittype);
   bool icon = !direction8_is_valid(facing);
@@ -5476,7 +5477,7 @@ QPixmap *get_unittype_sprite(const struct tileset *t,
 /**
    Return a "sample" sprite for this city style.
  */
-QPixmap *get_sample_city_sprite(const struct tileset *t, int style_idx)
+const QPixmap *get_sample_city_sprite(const struct tileset *t, int style_idx)
 {
   int num_thresholds =
       t->sprites.city.tile->styles[style_idx].land_num_thresholds;
@@ -5493,7 +5494,7 @@ QPixmap *get_sample_city_sprite(const struct tileset *t, int style_idx)
 /**
    Return a tax sprite for the given output type (usually gold/lux/sci).
  */
-QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype)
+const QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype)
 {
   switch (otype) {
   case O_SCIENCE:
@@ -5514,7 +5515,8 @@ QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype)
 /**
    Return event icon sprite
  */
-QPixmap *get_event_sprite(const struct tileset *t, enum event_type event)
+const QPixmap *get_event_sprite(const struct tileset *t,
+                                enum event_type event)
 {
   return t->sprites.events[event];
 }
@@ -5522,7 +5524,7 @@ QPixmap *get_event_sprite(const struct tileset *t, enum event_type event)
 /**
  * Return dither sprite
  */
-QPixmap *get_dither_sprite(const struct tileset *t)
+const QPixmap *get_dither_sprite(const struct tileset *t)
 {
   return t->sprites.dither_tile;
 }
@@ -5530,7 +5532,7 @@ QPixmap *get_dither_sprite(const struct tileset *t)
 /**
  * Return tile mask sprite
  */
-QPixmap *get_mask_sprite(const struct tileset *t)
+const QPixmap *get_mask_sprite(const struct tileset *t)
 {
   return t->sprites.mask.tile;
 }
@@ -5539,7 +5541,7 @@ QPixmap *get_mask_sprite(const struct tileset *t)
    Return a thumbs-up/thumbs-down sprite to show treaty approval or
    disapproval.
  */
-QPixmap *get_treaty_thumb_sprite(const struct tileset *t, bool on_off)
+const QPixmap *get_treaty_thumb_sprite(const struct tileset *t, bool on_off)
 {
   return t->sprites.treaty_thumb[on_off ? 1 : 0];
 }
@@ -5559,7 +5561,7 @@ get_unit_explode_animation(const struct tileset *t)
 
    TODO: This should be an animation like the unit explode animation.
  */
-QPixmap *get_nuke_explode_sprite(const struct tileset *t)
+const QPixmap *get_nuke_explode_sprite(const struct tileset *t)
 {
   return t->sprites.explode.nuke;
 }
@@ -5586,8 +5588,9 @@ const struct editor_sprites *get_editor_sprites(const struct tileset *t)
    (*hot_x, *hot_y).
    A cursor can consist of several frames to be used for animation.
  */
-QPixmap *get_cursor_sprite(const struct tileset *t, enum cursor_type cursor,
-                           int *hot_x, int *hot_y, int frame)
+const QPixmap *get_cursor_sprite(const struct tileset *t,
+                                 enum cursor_type cursor, int *hot_x,
+                                 int *hot_y, int frame)
 {
   *hot_x = t->sprites.cursor[cursor].hot_x;
   *hot_y = t->sprites.cursor[cursor].hot_y;
@@ -5603,7 +5606,7 @@ QPixmap *get_cursor_sprite(const struct tileset *t, enum cursor_type cursor,
    The GUI code must be sure to call tileset_load_tiles before setting the
    top-level icon.
  */
-QPixmap *get_icon_sprite(const struct tileset *t, enum icon_type icon)
+const QPixmap *get_icon_sprite(const struct tileset *t, enum icon_type icon)
 {
   return t->sprites.icon[icon];
 }
@@ -5614,7 +5617,7 @@ QPixmap *get_icon_sprite(const struct tileset *t, enum icon_type icon)
    FIXME: This function shouldn't be needed if the attention graphics are
    drawn natively by the tileset code.
  */
-QPixmap *get_attention_crosshair_sprite(const struct tileset *t)
+const QPixmap *get_attention_crosshair_sprite(const struct tileset *t)
 {
   return t->sprites.user.attention;
 }
@@ -5623,8 +5626,8 @@ QPixmap *get_attention_crosshair_sprite(const struct tileset *t)
    Returns a sprite for the given indicator with the given index.  The
    index should be in [0, NUM_TILES_PROGRESS).
  */
-QPixmap *get_indicator_sprite(const struct tileset *t,
-                              enum indicator_type indicator, int idx)
+const QPixmap *get_indicator_sprite(const struct tileset *t,
+                                    enum indicator_type indicator, int idx)
 {
   idx = CLIP(0, idx, NUM_TILES_PROGRESS - 1);
 
@@ -5639,8 +5642,9 @@ QPixmap *get_indicator_sprite(const struct tileset *t,
 
    May return NULL if there's no unhappiness.
  */
-QPixmap *get_unit_unhappy_sprite(const struct tileset *t,
-                                 const struct unit *punit, int happy_cost)
+const QPixmap *get_unit_unhappy_sprite(const struct tileset *t,
+                                       const struct unit *punit,
+                                       int happy_cost)
 {
   Q_UNUSED(punit)
   const int unhappy = CLIP(0, happy_cost, MAX_NUM_UPKEEP_SPRITES - 1);
@@ -5658,10 +5662,10 @@ QPixmap *get_unit_unhappy_sprite(const struct tileset *t,
 
    May return NULL if there's no upkeep of the kind.
  */
-QPixmap *get_unit_upkeep_sprite(const struct tileset *t,
-                                Output_type_id otype,
-                                const struct unit *punit,
-                                const int *upkeep_cost)
+const QPixmap *get_unit_upkeep_sprite(const struct tileset *t,
+                                      Output_type_id otype,
+                                      const struct unit *punit,
+                                      const int *upkeep_cost)
 {
   Q_UNUSED(punit)
   const int upkeep = CLIP(0, upkeep_cost[otype], MAX_NUM_UPKEEP_SPRITES);
@@ -5677,7 +5681,7 @@ QPixmap *get_unit_upkeep_sprite(const struct tileset *t,
    Return a rectangular sprite containing a fog "color".  This can be used
    for drawing fog onto arbitrary areas (like the overview).
  */
-QPixmap *get_basic_fog_sprite(const struct tileset *t)
+const QPixmap *get_basic_fog_sprite(const struct tileset *t)
 {
   return t->sprites.tx.fog;
 }

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -209,56 +209,62 @@ struct editor_sprites {
 
 #define NUM_WALL_TYPES 7
 
-QPixmap *get_spaceship_sprite(const struct tileset *t,
-                              enum spaceship_part part);
-QPixmap *get_citizen_sprite(const struct tileset *t,
-                            enum citizen_category type, int citizen_index,
-                            const struct city *pcity);
-QPixmap *get_city_flag_sprite(const struct tileset *t,
-                              const struct city *pcity);
+const QPixmap *get_spaceship_sprite(const struct tileset *t,
+                                    enum spaceship_part part);
+const QPixmap *get_citizen_sprite(const struct tileset *t,
+                                  enum citizen_category type,
+                                  int citizen_index,
+                                  const struct city *pcity);
+const QPixmap *get_city_flag_sprite(const struct tileset *t,
+                                    const struct city *pcity);
 void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
                      struct terrain **tterrain_near,
                      bv_extras *textras_near);
-QPixmap *get_nation_flag_sprite(const struct tileset *t,
-                                const struct nation_type *nation);
-QPixmap *get_nation_shield_sprite(const struct tileset *t,
-                                  const struct nation_type *nation);
-QPixmap *get_tech_sprite(const struct tileset *t, Tech_type_id tech);
-QPixmap *get_building_sprite(const struct tileset *t,
-                             const struct impr_type *pimprove);
-QPixmap *get_government_sprite(const struct tileset *t,
-                               const struct government *gov);
-QPixmap *get_unittype_sprite(const struct tileset *t,
-                             const struct unit_type *punittype,
-                             enum direction8 facing);
-QPixmap *get_sample_city_sprite(const struct tileset *t, int style_idx);
-QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype);
-QPixmap *get_treaty_thumb_sprite(const struct tileset *t, bool on_off);
+const QPixmap *get_nation_flag_sprite(const struct tileset *t,
+                                      const struct nation_type *nation);
+const QPixmap *get_nation_shield_sprite(const struct tileset *t,
+                                        const struct nation_type *nation);
+const QPixmap *get_tech_sprite(const struct tileset *t, Tech_type_id tech);
+const QPixmap *get_building_sprite(const struct tileset *t,
+                                   const struct impr_type *pimprove);
+const QPixmap *get_government_sprite(const struct tileset *t,
+                                     const struct government *gov);
+const QPixmap *get_unittype_sprite(const struct tileset *t,
+                                   const struct unit_type *punittype,
+                                   enum direction8 facing);
+const QPixmap *get_sample_city_sprite(const struct tileset *t,
+                                      int style_idx);
+const QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype);
+const QPixmap *get_treaty_thumb_sprite(const struct tileset *t, bool on_off);
 const struct sprite_vector *
 get_unit_explode_animation(const struct tileset *t);
-QPixmap *get_nuke_explode_sprite(const struct tileset *t);
-QPixmap *get_cursor_sprite(const struct tileset *t, enum cursor_type cursor,
-                           int *hot_x, int *hot_y, int frame);
+const QPixmap *get_nuke_explode_sprite(const struct tileset *t);
+const QPixmap *get_cursor_sprite(const struct tileset *t,
+                                 enum cursor_type cursor, int *hot_x,
+                                 int *hot_y, int frame);
 const struct citybar_sprites *get_citybar_sprites(const struct tileset *t);
 const struct editor_sprites *get_editor_sprites(const struct tileset *t);
-QPixmap *get_icon_sprite(const struct tileset *t, enum icon_type icon);
-QPixmap *get_attention_crosshair_sprite(const struct tileset *t);
-QPixmap *get_indicator_sprite(const struct tileset *t,
-                              enum indicator_type indicator, int index);
-QPixmap *get_unit_unhappy_sprite(const struct tileset *t,
-                                 const struct unit *punit, int happy_cost);
-QPixmap *get_unit_upkeep_sprite(const struct tileset *t,
-                                Output_type_id otype,
-                                const struct unit *punit,
-                                const int *upkeep_cost);
-QPixmap *get_basic_fog_sprite(const struct tileset *t);
+const QPixmap *get_icon_sprite(const struct tileset *t, enum icon_type icon);
+const QPixmap *get_attention_crosshair_sprite(const struct tileset *t);
+const QPixmap *get_indicator_sprite(const struct tileset *t,
+                                    enum indicator_type indicator,
+                                    int index);
+const QPixmap *get_unit_unhappy_sprite(const struct tileset *t,
+                                       const struct unit *punit,
+                                       int happy_cost);
+const QPixmap *get_unit_upkeep_sprite(const struct tileset *t,
+                                      Output_type_id otype,
+                                      const struct unit *punit,
+                                      const int *upkeep_cost);
+const QPixmap *get_basic_fog_sprite(const struct tileset *t);
 std::vector<drawn_sprite>
 fill_basic_extra_sprite_array(const struct tileset *t,
                               const struct extra_type *pextra);
 bool is_extra_drawing_enabled(struct extra_type *pextra);
-QPixmap *get_event_sprite(const struct tileset *t, enum event_type event);
-QPixmap *get_dither_sprite(const struct tileset *t);
-QPixmap *get_mask_sprite(const struct tileset *t);
+const QPixmap *get_event_sprite(const struct tileset *t,
+                                enum event_type event);
+const QPixmap *get_dither_sprite(const struct tileset *t);
+const QPixmap *get_mask_sprite(const struct tileset *t);
 
 QPixmap *tiles_lookup_sprite_tag_alt(struct tileset *t, QtMsgType level,
                                      const char *tag, const char *alt,


### PR DESCRIPTION
Functions that retrieve sprites from the tileset used to return a non-const
pointer, which allowed other code to change them. This resulted in #745.
This commit changes all sprite getters to return const QPixmap* instead of
QPixmap*, solving #745 and preventing it from happening in the future.

Maybe this should've been done in smaller commits but it's too late for that.

Closes #745.

Test plan (from #745 instructions):

*    Use city style "simple"
*    Found a city
*    Do F3
*    Make sure the map at your city gets redrawn (for instance by scrolling away)
*    See error
