### PR TITLE
Make fcFonts more const-correct

### DIFF
--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -364,7 +364,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
   // First line
   if (gui_options.draw_city_names) {
     // City name
-    format.setFont(*get_font(FONT_CITY_NAME));
+    format.setFont(get_font(FONT_CITY_NAME));
     format.setForeground(*get_color(tileset, COLOR_MAPVIEW_CITYTEXT));
     first.add_text(name, format);
 
@@ -376,7 +376,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
       first.add_text(en_space, format);
 
       // Text
-      format.setFont(*get_font(FONT_CITY_PROD));
+      format.setFont(get_font(FONT_CITY_PROD));
       format.setForeground(*get_color(tileset, growth_color));
       first.add_text(growth, format);
     }
@@ -393,7 +393,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
           pcity, trade_routes, sizeof(trade_routes), &trade_routes_color);
 
       // Add it
-      format.setFont(*get_font(FONT_CITY_PROD));
+      format.setFont(get_font(FONT_CITY_PROD));
       format.setForeground(*get_color(tileset, trade_routes_color));
       first.add_text(en_space + trade_routes, format);
     }
@@ -406,7 +406,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
     get_city_mapview_production(pcity, prod, sizeof(prod));
 
     // Add text
-    format.setFont(*get_font(FONT_CITY_PROD));
+    format.setFont(get_font(FONT_CITY_PROD));
     format.setForeground(*get_color(tileset, production_color));
     second.add_text(prod, format);
   }
@@ -509,7 +509,7 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
     first.add_spacer();
 
     // City size (on colored background)
-    format.setFont(*get_font(FONT_CITY_NAME));
+    format.setFont(get_font(FONT_CITY_NAME));
     format.setBackground(owner_color);
 
     // Try to pick a color for city size text that contrasts with player
@@ -528,7 +528,7 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
   // Second line
   if (should_draw_lower_bar) {
     // All items share the same font
-    format.setFont(*get_font(FONT_CITY_PROD));
+    format.setFont(get_font(FONT_CITY_PROD));
 
     if (should_draw_productions) {
       // Icon
@@ -648,10 +648,10 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   // occupied indicator (we assume all indicators have the same size).
   // It's used to scale the flag, progress bars and production.
   double target_height = citybar->occupancy.p[0]->height();
-  target_height = std::max(
-      target_height, QFontMetricsF(*get_font(FONT_CITY_NAME)).height());
-  target_height = std::max(
-      target_height, QFontMetricsF(*get_font(FONT_CITY_PROD)).height());
+  target_height = std::max(target_height,
+                           QFontMetricsF(get_font(FONT_CITY_NAME)).height());
+  target_height = std::max(target_height,
+                           QFontMetricsF(get_font(FONT_CITY_PROD)).height());
 
   // Build the contents
   line_of_text line;
@@ -660,7 +660,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   QTextCharFormat format;
 
   // Size
-  format.setFont(*get_font(FONT_CITY_NAME));
+  format.setFont(get_font(FONT_CITY_NAME));
   format.setForeground(text_color);
   line.add_text(QString::number(pcity->size), format, false, text_margins);
 
@@ -704,7 +704,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
     line.add_icon(growth_progress.get());
 
     // Text
-    format.setFont(*get_font(FONT_CITY_PROD));
+    format.setFont(get_font(FONT_CITY_PROD));
     format.setFontPointSize(format.fontPointSize() / 1.5);
     format.setForeground(*get_color(t, growth_color));
     line.add_text(growth, format, false, text_margins);
@@ -735,7 +735,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
 
   // Name
   if (gui_options.draw_city_names) {
-    format.setFont(*get_font(FONT_CITY_NAME));
+    format.setFont(get_font(FONT_CITY_NAME));
     format.setForeground(text_color);
     line.add_text(name, format, false, text_margins);
   }
@@ -745,7 +745,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   std::unique_ptr<QPixmap> production_progress;
   if (should_draw_productions) {
     // Format
-    format.setFont(*get_font(FONT_CITY_PROD));
+    format.setFont(get_font(FONT_CITY_PROD));
     format.setFontPointSize(format.fontPointSize() / 1.5);
     format.setForeground(*get_color(t, production_color));
 
@@ -851,7 +851,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
     get_city_mapview_trade_routes(pcity, trade_routes, sizeof(trade_routes),
                                   &trade_routes_color);
 
-    format.setFont(*get_font(FONT_CITY_PROD));
+    format.setFont(get_font(FONT_CITY_PROD));
     format.setForeground(*get_color(t, trade_routes_color));
     trade_line.add_text(trade_routes, format, false, text_margins);
 

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -325,8 +325,8 @@ void qtg_canvas_put_curved_line(QPixmap *pcanvas, const QColor *pcolor,
 void qtg_get_text_size(int *width, int *height, enum client_font font,
                        const QString &text)
 {
-  QFont *afont = get_font(font);
-  QScopedPointer<QFontMetrics> fm(new QFontMetrics(*afont));
+  QFont afont = get_font(font);
+  QScopedPointer<QFontMetrics> fm(new QFontMetrics(afont));
 
   if (width) {
     *width = fm->horizontalAdvance(text);
@@ -348,13 +348,13 @@ void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,
 {
   QPainter p;
   QPen pen;
-  QFont *afont = get_font(font);
-  QScopedPointer<QFontMetrics> fm(new QFontMetrics(*afont));
+  QFont afont = get_font(font);
+  QScopedPointer<QFontMetrics> fm(new QFontMetrics(afont));
 
   pen.setColor(*pcolor);
   p.begin(pcanvas);
   p.setPen(pen);
-  p.setFont(*afont);
+  p.setFont(afont);
   p.drawText(canvas_x, canvas_y + fm->ascent(), text);
   p.end();
 }
@@ -362,40 +362,25 @@ void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,
 /**
    Returns given font
  */
-QFont *get_font(client_font font)
+QFont get_font(client_font font)
 {
-  QFont *qf;
-  int ssize;
+  QFont qf;
 
   switch (font) {
   case FONT_CITY_NAME:
-    qf = fcFont::instance()->getFont(fonts::city_names);
-    if (king()->map_scale != 1.0f && gui_options.zoom_scale_fonts) {
-      ssize = ceil(king()->map_scale * fcFont::instance()->city_fontsize);
-      if (qf->pointSize() != ssize) {
-        qf->setPointSize(ssize);
-      }
-    }
+    qf = fcFont::instance()->getFont(fonts::city_names, king()->map_scale);
     break;
   case FONT_CITY_PROD:
-    qf = fcFont::instance()->getFont(fonts::city_productions);
-    if (king()->map_scale != 1.0f && gui_options.zoom_scale_fonts) {
-      ssize = ceil(king()->map_scale * fcFont::instance()->prod_fontsize);
-      if (qf->pointSize() != ssize) {
-        qf->setPointSize(ssize);
-      }
-    }
+    qf = fcFont::instance()->getFont(fonts::city_productions,
+                                     king()->map_scale);
     break;
   case FONT_REQTREE_TEXT:
     qf = fcFont::instance()->getFont(fonts::reqtree_text);
     break;
   case FONT_COUNT:
-    qf = NULL;
-    break;
-  default:
-    qf = NULL;
     break;
   }
+
   return qf;
 }
 

--- a/client/gui-qt/chatline.cpp
+++ b/client/gui-qt/chatline.cpp
@@ -250,7 +250,7 @@ chatwdg::chatwdg(QWidget *parent)
   gl = new QGridLayout;
   chat_line = new chat_input;
   chat_output = new text_browser_dblclck(this);
-  chat_output->setFont(*fcFont::instance()->getFont(fonts::chatline));
+  chat_output->setFont(fcFont::instance()->getFont(fonts::chatline));
   remove_links = new QPushButton(QLatin1String(""));
   remove_links->setIcon(
       style()->standardPixmap(QStyle::SP_DialogCancelButton));
@@ -317,9 +317,7 @@ void chatwdg::scroll_to_bottom()
  */
 void chatwdg::update_font()
 {
-  QFont *qf;
-  qf = fcFont::instance()->getFont(fonts::chatline);
-  chat_output->setFont(*qf);
+  chat_output->setFont(fcFont::instance()->getFont(fonts::chatline));
 }
 
 /**

--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -897,7 +897,7 @@ bool unit_list_event_filter::eventFilter(QObject *object, QEvent *event)
 
 cityIconInfoLabel::cityIconInfoLabel(QWidget *parent) : QWidget(parent)
 {
-  QFont f = *fcFont::instance()->getFont(fonts::default_font);
+  auto f = fcFont::instance()->getFont(fonts::default_font);
   QFontMetrics fm(f);
 
   pixHeight = fm.height();
@@ -1015,29 +1015,28 @@ void city_label::set_city(city *pciti) { pcity = pciti; }
 city_info::city_info(QWidget *parent) : QWidget(parent)
 {
   int iter;
-  QFont *small_font;
   QLabel *ql;
   QStringList info_list;
 
   QGridLayout *info_grid_layout = new QGridLayout();
-  small_font = fcFont::instance()->getFont(fonts::notify_label);
+  auto small_font = fcFont::instance()->getFont(fonts::notify_label);
   info_list << _("Food:") << _("Prod:") << _("Trade:") << _("Gold:")
             << _("Luxury:") << _("Science:") << _("Granary:")
             << _("Change in:") << _("Corruption:") << _("Waste:")
             << _("Culture:") << _("Pollution:") << _("Plague risk:")
             << _("Tech Stolen:") << _("Airlift:");
-  setFont(*small_font);
+  setFont(small_font);
   info_grid_layout->setSpacing(0);
   info_grid_layout->setContentsMargins(0, 0, 0, 0);
 
   fc_assert(info_list.count() == NUM_INFO_FIELDS);
   for (iter = 0; iter < NUM_INFO_FIELDS; iter++) {
     ql = new QLabel(info_list[iter], this);
-    ql->setFont(*small_font);
+    ql->setFont(small_font);
     ql->setProperty(fonts::notify_label, "true");
     info_grid_layout->addWidget(ql, iter, 0);
     qlt[iter] = new QLabel(this);
-    qlt[iter]->setFont(*small_font);
+    qlt[iter]->setFont(small_font);
     qlt[iter]->setProperty(fonts::notify_label, "true");
     info_grid_layout->addWidget(qlt[iter], iter, 1);
   }
@@ -1181,11 +1180,11 @@ governor_sliders::governor_sliders(QWidget *parent) : QGroupBox(parent)
   str_list << _("Food") << _("Shield") << _("Trade") << _("Gold")
            << _("Luxury") << _("Science") << _("Celebrate");
   some_label = new QLabel(_("Minimal Surplus"));
-  some_label->setFont(*fcFont::instance()->getFont(fonts::notify_label));
+  some_label->setFont(fcFont::instance()->getFont(fonts::notify_label));
   some_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
   slider_grid->addWidget(some_label, 0, 0, 1, 3);
   some_label = new QLabel(_("Priority"));
-  some_label->setFont(*fcFont::instance()->getFont(fonts::notify_label));
+  some_label->setFont(fcFont::instance()->getFont(fonts::notify_label));
   some_label->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
   slider_grid->addWidget(some_label, 0, 3, 1, 3);
 
@@ -1307,12 +1306,11 @@ city_dialog::city_dialog(QWidget *parent) : QWidget(parent)
 
 {
   QFont f = QApplication::font();
-  QFont *small_font;
   QFontMetrics fm(f);
   QHeaderView *header;
 
   int h = 2 * fm.height() + 2;
-  small_font = fcFont::instance()->getFont(fonts::notify_label);
+  auto small_font = fcFont::instance()->getFont(fonts::notify_label);
   ui.setupUi(this);
 
   // Prevent mouse events from going through the panels to the main map
@@ -1420,12 +1418,12 @@ city_dialog::city_dialog(QWidget *parent) : QWidget(parent)
   ui.label4->setText(_("Nationality:"));
   ui.label5->setText(_("Units:"));
   ui.label6->setText(_("Wonders:"));
-  ui.label1->setFont(*small_font);
-  ui.label2->setFont(*small_font);
-  ui.label4->setFont(*small_font);
-  ui.label3->setFont(*small_font);
-  ui.label5->setFont(*small_font);
-  ui.label6->setFont(*small_font);
+  ui.label1->setFont(small_font);
+  ui.label2->setFont(small_font);
+  ui.label4->setFont(small_font);
+  ui.label3->setFont(small_font);
+  ui.label5->setFont(small_font);
+  ui.label6->setFont(small_font);
   lab_table[0] = ui.lab_table1;
   lab_table[1] = ui.lab_table2;
   lab_table[2] = ui.lab_table3;
@@ -2874,15 +2872,14 @@ void qtg_real_city_dialog_refresh(struct city *pcity)
 void city_font_update()
 {
   QList<QLabel *> l;
-  QFont *f;
 
   l = queen()->city_overlay->findChildren<QLabel *>();
 
-  f = fcFont::instance()->getFont(fonts::notify_label);
+  auto f = fcFont::instance()->getFont(fonts::notify_label);
 
   for (auto i : qAsConst(l)) {
     if (i->property(fonts::notify_label).isValid()) {
-      i->setFont(*f);
+      i->setFont(f);
     }
   }
 }
@@ -3213,7 +3210,7 @@ void city_production_model::populate()
   struct universal *renegade, *renegate;
   int item, targets_used;
   QString str;
-  QFont f = *fcFont::instance()->getFont(fonts::default_font);
+  auto f = fcFont::instance()->getFont(fonts::default_font);
   QFontMetrics fm(f);
 
   sh.setY(fm.height() * 2);

--- a/client/gui-qt/civstatus.cpp
+++ b/client/gui-qt/civstatus.cpp
@@ -34,13 +34,12 @@ civstatus::civstatus(QWidget *parent) : fcwidget()
   QRect crop;
   int icon_size;
   QFontMetrics *fm;
-  QFont f;
 
   setParent(parent);
   layout = new QHBoxLayout;
   layout->setSizeConstraint(QLayout::SetMinimumSize);
   setProperty("civstatus_bg", true);
-  f = *fcFont::instance()->getFont(fonts::default_font);
+  auto f = fcFont::instance()->getFont(fonts::default_font);
   fm = new QFontMetrics(f);
   icon_size = fm->height() * 7 / 8;
 

--- a/client/gui-qt/fc_client.cpp
+++ b/client/gui-qt/fc_client.cpp
@@ -69,7 +69,7 @@ fc_client::fc_client() : QMainWindow(), current_file(QLatin1String(""))
   }
   fcFont::instance()->initFonts();
   read_settings();
-  QApplication::setFont(*fcFont::instance()->getFont(fonts::default_font));
+  QApplication::setFont(fcFont::instance()->getFont(fonts::default_font));
   QString path;
 
   central_wdg = new QWidget;
@@ -653,12 +653,12 @@ fc_corner::fc_corner(QMainWindow *qmw) : QWidget()
   QHBoxLayout *hb;
   QPushButton *qpb;
   int h;
-  QFont *f = fcFont::instance()->getFont(fonts::default_font);
+  QFont f = fcFont::instance()->getFont(fonts::default_font);
 
-  if (f->pointSize() > 0) {
-    h = f->pointSize();
+  if (f.pointSize() > 0) {
+    h = f.pointSize();
   } else {
-    h = f->pixelSize();
+    h = f.pixelSize();
   }
   mw = qmw;
   hb = new QHBoxLayout();

--- a/client/gui-qt/fonts.h
+++ b/client/gui-qt/fonts.h
@@ -30,21 +30,18 @@ class fcFont {
   Q_DISABLE_COPY(fcFont);
 
 private:
-  QMap<QString, QFont *> font_map;
+  QMap<QString, QFont> font_map;
   static fcFont *m_instance;
   explicit fcFont();
 
 public:
   static fcFont *instance();
   static void drop();
-  void setFont(const QString &name, QFont *qf);
+  void setFont(const QString &name, const QFont &qf);
   void setSizeAll(int);
-  QFont *getFont(const QString &name);
+  QFont getFont(const QString &name, double zoom = 1.0) const;
   void initFonts();
   void releaseFonts();
-  void getMapfontSize();
-  int city_fontsize{12};
-  int prod_fontsize{12};
 };
 
 void configure_fonts();

--- a/client/gui-qt/gui_main.cpp
+++ b/client/gui-qt/gui_main.cpp
@@ -282,23 +282,16 @@ void apply_sidebar(struct option *poption)
  */
 void gui_qt_apply_font(struct option *poption)
 {
-  QFont *f;
-  QFont *remove_old;
-  QString s;
-
   if (king()) {
-    f = new QFont;
-    s = option_font_get(poption);
-    f->fromString(s);
+    auto f = QFont();
+    auto s = option_font_get(poption);
+    f.fromString(s);
     s = option_name(poption);
-    remove_old = fcFont::instance()->getFont(s);
-    delete remove_old;
     fcFont::instance()->setFont(s, f);
     update_city_descriptions();
     queen()->infotab->chtwdg->update_font();
-    QApplication::setFont(*fcFont::instance()->getFont(fonts::default_font));
+    QApplication::setFont(fcFont::instance()->getFont(fonts::default_font));
     real_science_report_dialog_update(nullptr);
-    fcFont::instance()->getMapfontSize();
   }
   apply_help_font(poption);
 }
@@ -308,17 +301,11 @@ void gui_qt_apply_font(struct option *poption)
  */
 static void apply_help_font(struct option *poption)
 {
-  QFont *f;
-  QFont *remove_old;
-  QString s;
-
   if (king()) {
-    f = new QFont;
-    s = option_font_get(poption);
-    f->fromString(s);
+    auto f = QFont();
+    auto s = option_font_get(poption);
+    f.fromString(s);
     s = option_name(poption);
-    remove_old = fcFont::instance()->getFont(s);
-    delete remove_old;
     fcFont::instance()->setFont(s, f);
     update_help_fonts();
   }
@@ -381,17 +368,13 @@ void qtg_editgui_notify_object_created(int tag, int id) {}
  */
 void qtg_gui_update_font(const QString &font_name, const QString &font_value)
 {
-  QFont *f;
-  QFont *remove_old;
   QString fname;
 
   fname = "gui_qt_font_" + QString(font_name);
-  f = new QFont;
-  f->fromString(font_value);
-  remove_old = fcFont::instance()->getFont(fname);
-  delete remove_old;
+  auto f = QFont();
+  f.fromString(font_value);
+  auto remove_old = fcFont::instance()->getFont(fname);
   fcFont::instance()->setFont(fname, f);
-  fcFont::instance()->getMapfontSize();
 }
 
 void gui_update_allfonts()

--- a/client/gui-qt/helpdlg.cpp
+++ b/client/gui-qt/helpdlg.cpp
@@ -529,26 +529,25 @@ void help_widget::do_layout()
 void help_widget::update_fonts()
 {
   QList<QWidget *> l;
-  QFont *f;
 
   l = findChildren<QWidget *>();
 
-  f = fcFont::instance()->getFont(fonts::notify_label);
+  auto f = fcFont::instance()->getFont(fonts::notify_label);
   for (auto i : qAsConst(l)) {
     if (i->property(fonts::help_label).isValid()) {
-      i->setFont(*f);
+      i->setFont(f);
     }
   }
   f = fcFont::instance()->getFont(fonts::help_text);
   for (auto i : qAsConst(l)) {
     if (i->property(fonts::help_text).isValid()) {
-      i->setFont(*f);
+      i->setFont(f);
     }
   }
   f = fcFont::instance()->getFont(fonts::default_font);
   for (auto i : qAsConst(l)) {
     if (i->property(fonts::default_font).isValid()) {
-      i->setFont(*f);
+      i->setFont(f);
     }
   }
 }
@@ -1199,7 +1198,7 @@ static QLabel *make_helplabel(const QString &title, const QString &tooltip,
                               QHBoxLayout *layout)
 {
   QLabel *label;
-  QFont f = *fcFont::instance()->getFont(fonts::default_font);
+  QFont f = fcFont::instance()->getFont(fonts::default_font);
   label = new QLabel(title);
   layout->addWidget(label, Qt::AlignVCenter);
   label->setProperty(fonts::default_font, "true");
@@ -1217,7 +1216,6 @@ static void make_helppiclabel(QPixmap *spr, const QString &tooltip,
   QImage cropped_img;
   QRect crop;
   QPixmap pix;
-  QFont f;
   QFontMetrics *fm;
   int isize;
 
@@ -1225,7 +1223,7 @@ static void make_helppiclabel(QPixmap *spr, const QString &tooltip,
   crop = zealous_crop_rect(img);
   cropped_img = img.copy(crop);
   pix = QPixmap::fromImage(cropped_img);
-  f = *fcFont::instance()->getFont(fonts::help_text);
+  auto f = fcFont::instance()->getFont(fonts::help_text);
   fm = new QFontMetrics(f);
   isize = fm->height() * 7 / 8;
   label = new QLabel();

--- a/client/gui-qt/hudwidget.cpp
+++ b/client/gui-qt/hudwidget.cpp
@@ -68,8 +68,8 @@ hud_message_box::hud_message_box(QWidget *parent) : QMessageBox(parent)
   int size;
   setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog
                  | Qt::FramelessWindowHint);
-  f_text = *fcFont::instance()->getFont(fonts::default_font);
-  f_title = *fcFont::instance()->getFont(fonts::default_font);
+  f_text = fcFont::instance()->getFont(fonts::default_font);
+  f_title = fcFont::instance()->getFont(fonts::default_font);
 
   size = f_text.pointSize();
   if (size > 0) {
@@ -233,7 +233,7 @@ hud_text::hud_text(const QString &s, int time_secs, QWidget *parent)
   timeout = time_secs;
 
   setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
-  f_text = *fcFont::instance()->getFont(fonts::default_font);
+  f_text = fcFont::instance()->getFont(fonts::default_font);
   f_text.setBold(true);
   f_text.setCapitalization(QFont::SmallCaps);
   size = f_text.pointSize();
@@ -342,8 +342,8 @@ hud_input_box::hud_input_box(QWidget *parent) : QDialog(parent)
   setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog
                  | Qt::FramelessWindowHint);
 
-  f_text = *fcFont::instance()->getFont(fonts::default_font);
-  f_title = *fcFont::instance()->getFont(fonts::default_font);
+  f_text = fcFont::instance()->getFont(fonts::default_font);
+  f_title = fcFont::instance()->getFont(fonts::default_font);
 
   size = f_text.pointSize();
   if (size > 0) {
@@ -562,7 +562,7 @@ void hud_units::update_actions(unit_list *punits)
   int wwidth;
   int font_width;
   int expanded_unit_width;
-  QFont font = *fcFont::instance()->getFont(fonts::notify_label);
+  QFont font = fcFont::instance()->getFont(fonts::notify_label);
   QFontMetrics *fm;
   QImage cropped_img;
   QImage img;
@@ -1833,7 +1833,7 @@ void hud_unit_combat::paintEvent(QPaintEvent *event)
   QRect left, right;
   QColor c1, c2;
   QPen pen;
-  QFont f = *fcFont::instance()->getFont(fonts::default_font);
+  QFont f = fcFont::instance()->getFont(fonts::default_font);
   QString ahploss, dhploss;
 
   if (att_hp_loss > 0) {

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -624,7 +624,7 @@ void mapview_thaw()
 info_tile::info_tile(struct tile *ptile, QWidget *parent) : QLabel(parent)
 {
   setParent(parent);
-  info_font = *fcFont::instance()->getFont(fonts::notify_label);
+  info_font = fcFont::instance()->getFont(fonts::notify_label);
   itile = ptile;
   calc_size();
 }

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -2601,13 +2601,7 @@ void mr_menu::zoom_in()
  */
 void mr_menu::zoom_reset()
 {
-  QFont *qf;
-
   king()->map_scale = 1.0f;
-  qf = fcFont::instance()->getFont(fonts::city_names);
-  qf->setPointSize(fcFont::instance()->city_fontsize);
-  qf = fcFont::instance()->getFont(fonts::city_productions);
-  qf->setPointSize(fcFont::instance()->prod_fontsize);
   tilespec_reread(tileset_basename(tileset), true, king()->map_scale);
 }
 
@@ -2616,17 +2610,7 @@ void mr_menu::zoom_reset()
  */
 void mr_menu::zoom_scale_fonts()
 {
-  QFont *qf;
-
-  if (scale_fonts_status->isChecked()) {
-    gui_options.zoom_scale_fonts = true;
-  } else {
-    qf = fcFont::instance()->getFont(fonts::city_names);
-    qf->setPointSize(fcFont::instance()->city_fontsize);
-    qf = fcFont::instance()->getFont(fonts::city_productions);
-    qf->setPointSize(fcFont::instance()->prod_fontsize);
-    gui_options.zoom_scale_fonts = false;
-  }
+  gui_options.zoom_scale_fonts = scale_fonts_status->isChecked();
   update_city_descriptions();
 }
 

--- a/client/gui-qt/notifyreport.cpp
+++ b/client/gui-qt/notifyreport.cpp
@@ -41,7 +41,7 @@ notify_dialog::notify_dialog(const char *caption, const char *headline,
   qheadline = QString(headline);
   qlines = QString(lines);
   qlist = qlines.split(QStringLiteral("\n"));
-  small_font = *fcFont::instance()->getFont(
+  small_font = fcFont::instance()->getFont(
       QStringLiteral("gui_qt_font_notify_label"));
   x = 0;
   y = 0;

--- a/client/gui-qt/plrdlg.cpp
+++ b/client/gui-qt/plrdlg.cpp
@@ -161,7 +161,7 @@ QVariant plr_item::data(int column, int role) const
   pdc = &player_dlg_columns[column];
   switch (player_dlg_columns[column].type) {
   case COL_FLAG: {
-    auto f = *fcFont::instance()->getFont(fonts::default_font);
+    auto f = fcFont::instance()->getFont(fonts::default_font);
     auto fm = std::make_unique<QFontMetrics>(f);
     return get_nation_flag_sprite(tileset, nation_of_player(ipplayer))
         ->scaledToHeight(fm->height());

--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -68,16 +68,16 @@ sidebarWidget::sidebarWidget(QPixmap *pix, const QString &label,
   }
   scaled_pixmap = new QPixmap;
   final_pixmap = new QPixmap;
-  sfont = new QFont(*fcFont::instance()->getFont(fonts::notify_label));
+  sfont = fcFont::instance()->getFont(fonts::notify_label);
   setContextMenuPolicy(Qt::CustomContextMenu);
   timer = new QTimer;
   timer->setSingleShot(false);
   timer->setInterval(700);
-  sfont->setCapitalization(QFont::SmallCaps);
-  sfont->setItalic(true);
-  info_font = new QFont(*sfont);
-  info_font->setBold(true);
-  info_font->setItalic(false);
+  sfont.setCapitalization(QFont::SmallCaps);
+  sfont.setItalic(true);
+  info_font = QFont(sfont);
+  info_font.setBold(true);
+  info_font.setItalic(false);
   connect(timer, &QTimer::timeout, this, &sidebarWidget::sblink);
 }
 
@@ -91,8 +91,6 @@ sidebarWidget::~sidebarWidget()
   NFC_FREE(final_pixmap);
 
   delete timer;
-  delete sfont;
-  delete info_font;
 }
 
 /**
@@ -362,7 +360,7 @@ void sidebarWidget::updateFinalPixmap()
   }
 
   p.begin(final_pixmap);
-  p.setFont(*sfont);
+  p.setFont(sfont);
   pen.setColor(QColor(232, 255, 0));
   p.setPen(pen);
 
@@ -427,7 +425,7 @@ void sidebarWidget::updateFinalPixmap()
 
   p.setPen(palette().color(QPalette::Text));
   if (!custom_label.isEmpty()) {
-    p.setFont(*info_font);
+    p.setFont(info_font);
     p.drawText(0, 0, width(), height(), Qt::AlignLeft | Qt::TextWordWrap,
                custom_label);
   }

--- a/client/gui-qt/sidebar.h
+++ b/client/gui-qt/sidebar.h
@@ -81,8 +81,8 @@ private:
   pfcn wheel_down;
   pfcn wheel_up;
   pfcn_bool left_click;
-  QFont *sfont;
-  QFont *info_font;
+  QFont sfont;
+  QFont info_font;
   QPixmap *def_pixmap;
   QPixmap *final_pixmap;
   QPixmap *scaled_pixmap;

--- a/client/gui-qt/unitreport.cpp
+++ b/client/gui-qt/unitreport.cpp
@@ -148,7 +148,6 @@ unittype_item::unittype_item(QWidget *parent, struct unit_type *ut)
     : QFrame(parent)
 {
   int isize;
-  QFont f;
   QFontMetrics *fm;
   QHBoxLayout *hbox;
   QHBoxLayout *hbox_top;
@@ -170,7 +169,7 @@ unittype_item::unittype_item(QWidget *parent, struct unit_type *ut)
   init_img();
   unit_scroll = 0;
   setSizePolicy(size_fixed_policy);
-  f = *fcFont::instance()->getFont(fonts::default_font);
+  auto f = fcFont::instance()->getFont(fonts::default_font);
   fm = new QFontMetrics(f);
   isize = fm->height() * 2 / 3;
   vbox_main = new QVBoxLayout();

--- a/client/gui-qt/unitselect.cpp
+++ b/client/gui-qt/unitselect.cpp
@@ -44,7 +44,7 @@ units_select::units_select(struct tile *ptile, QWidget *parent)
   show_line = 0;
   highligh_num = -1;
   ufont.setItalic(true);
-  info_font = *fcFont::instance()->getFont(fonts::notify_label);
+  info_font = fcFont::instance()->getFont(fonts::notify_label);
   update_units();
   h_pix = NULL;
   create_pixmap();

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -68,4 +68,4 @@ GUI_FUNC_PROTO(void, canvas_put_text, QPixmap *pcanvas, int canvas_x,
                int canvas_y, enum client_font font, const QColor *pcolor,
                const QString &text)
 
-QFont *get_font(enum client_font font);
+QFont get_font(enum client_font font);


### PR DESCRIPTION
In a manner similar to #745, fonts in fcFonts were being modified from the
outside. Expose them only by value so this can't happen.

Closes #712.

Test plan: combination of zoom in, zoom out, enable and disable View > Scale fonts, and change fonts.