### PR TITLE
Fix a possible null pointer dereference in sidebar.cpp

### DIFF
--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -155,7 +155,7 @@ void sidebarWidget::setLabel(const QString &str) { desc = str; }
  */
 void sidebarWidget::resizePixmap(int width, int height)
 {
-  if (def_pixmap) {
+  if (def_pixmap && scaled_pixmap) {
     *scaled_pixmap =
         def_pixmap->scaledToWidth(width, Qt::SmoothTransformation);
   }


### PR DESCRIPTION
See Coverity CID 1466477
See Issue #388

Test plan: No-op change, only checks that a pointer is not null before dereferencing it. A null pointer would have lead to a crash, which I didn't see.