### PR TITLE
Fix integer overflow leading to division by zero

### DIFF
--- a/ai/default/daimilitary.cpp
+++ b/ai/default/daimilitary.cpp
@@ -1527,22 +1527,20 @@ struct adv_choice *military_advisor_choose_build(
     int num_defenders = unit_list_size(ptile->units);
     int wall_id, danger;
     bool build_walls = true;
-    // Use a long to avoid overflows
-    auto qdanger = static_cast<long>(city_data->danger) * city_data->danger;
 
     /* First determine the danger.  It is measured in percents of our
      * defensive strength, capped at 200 + urgency */
-    if (qdanger >= our_def) {
+    if (city_data->danger >= our_def) {
       if (urgency == 0) {
         // don't waste money
         danger = 100;
       } else if (our_def == 0) {
         danger = 200 + urgency;
       } else {
-        danger = MIN(200, 100 * qdanger / our_def) + urgency;
+        danger = MIN(200, 100 * city_data->danger / our_def) + urgency;
       }
     } else {
-      danger = 100 * qdanger / our_def;
+      danger = 100 * city_data->danger / our_def;
     }
     if (pcity->surplus[O_SHIELD] <= 0 && our_def != 0) {
       // Won't be able to support anything


### PR DESCRIPTION
Taking the square of danger creates too large numbers in some cases. The
previous workaround - casting to long - is not guaranteed to work by the
standard and indeed it doesn't work on Windows.

This reverts commit c67fc6a2058028582ecdaca48d847bfdb4db1112. The succint
commit message there says that making danger quadratic is in line with defense.
But danger is already quadratic in assess_danger, so I guess that commit was a
mistake. In the worst case this restores the 2.6 formula, and AI didn't behave
that bad there.