### PR TITLE
Unhardcode sprite counts

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -1136,9 +1136,7 @@ double real_timer_callback()
     }
   }
 
-  /* Make sure we wait at least 50 ms, otherwise we may not give any other
-   * code time to run. */
-  return MAX(time_until_next_call, 0.05);
+  return std::max(time_until_next_call, 0.0);
 }
 
 /**

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -351,6 +351,7 @@ struct tileset {
   int activity_offset_y;
   int select_offset_x;
   int select_offset_y;
+  int select_step_ms = 100;
   int occupied_offset_x;
   int occupied_offset_y;
   int unit_upkeep_offset_y;
@@ -1937,6 +1938,9 @@ static struct tileset *tileset_read_toplevel(const char *tileset_name,
     tileset_stop_read(t, file, fname, sections, layer_order);
     return nullptr;
   }
+
+  t->select_step_ms = secfile_lookup_int_def_min_max(
+      file, 100, 1, 10000, "tilespec.select_step_ms");
 
   if (tileset_invalid_offsets(t, file)) {
     qCritical("Tileset \"%s\" invalid: %s", t->name, secfile_error());
@@ -5186,9 +5190,9 @@ void tileset_setup_city_tiles(struct tileset *t, int style)
 int get_focus_unit_toggle_timeout(const struct tileset *t)
 {
   if (t->sprites.unit.select.empty()) {
-    return 500;
-  } else {
     return 100;
+  } else {
+    return t->select_step_ms;
   }
 }
 

--- a/data/3d.tilespec
+++ b/data/3d.tilespec
@@ -57,6 +57,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/alio.tilespec
+++ b/data/alio.tilespec
@@ -65,6 +65,8 @@ activity_offset_y = 28
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 21
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 17

--- a/data/amplio.tilespec
+++ b/data/amplio.tilespec
@@ -56,6 +56,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -56,6 +56,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/cimpletoon.tilespec
+++ b/data/cimpletoon.tilespec
@@ -59,6 +59,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -59,6 +59,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 22
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -61,6 +61,8 @@ activity_offset_y = 28
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 21
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 17

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -59,6 +59,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -58,6 +58,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/data/toonhex.tilespec
+++ b/data/toonhex.tilespec
@@ -63,6 +63,8 @@ activity_offset_y = 28
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 21
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 17

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -57,6 +57,8 @@ activity_offset_y = 0
 ; offset of the selected unit sprites
 select_offset_x = 0
 select_offset_y = 0
+; delay between two consecutive images
+;select_step_ms = 100
 
 ; offset the cities by this amount
 city_offset_x = 0

--- a/docs/Modding/Tilesets/compatibility.rst
+++ b/docs/Modding/Tilesets/compatibility.rst
@@ -35,7 +35,7 @@ The rest of this page lists the available flags and their meaning.
 .. option:: unlimited-unit-select-frames
 
     The number of sprites used in the animation under the selected unit is no longer fixed to four
-    (sprites ``unit.select*``).
+    (sprites ``unit.select*``). Also introduces the setting ``select_step_ms``.
 
 .. option:: unlimited-upkeep-sprites
 

--- a/docs/Modding/Tilesets/compatibility.rst
+++ b/docs/Modding/Tilesets/compatibility.rst
@@ -1,0 +1,43 @@
+Tileset compatibility
+*********************
+
+The tileset format evolves when new Freeciv21 releases are published. As a rule of thumb, we try
+to maintain compatibility with tilesets designed for previous releases, or at least to make the
+update as straightforward as possible. When new features are introduced, we provide a flag that
+lets tilesets require them: a tileset using such a flag won't load in versions of Freeciv21 that
+don't have the feature. This lets tileset authors request the exact features needed by their
+tileset.
+
+Feature flags are requested by adding them to the ``options`` string in the main ``.tilespec``
+file. For instance, the following options require ``precise-hp-bars`` in addition to the main
+Freeciv21 capability:
+
+.. code-block:: ini
+
+   options = "+Freeciv-tilespec-Devel-2019-Jul-03 +precise-hp-bars"
+
+Notice the ``+`` in front of the flag name.
+
+The rest of this page lists the available flags and their meaning.
+
+.. option:: duplicates_ok
+
+    When a graphics tag is specified appears several times, the lattermost tag is used.
+
+.. option:: precise-hp-bars
+
+    Unit HP bars with a precision different from 10% can be used (sprites ``unit.hp_*``). The
+    sprites must still be equally spaced: for instance, providing the following set of sprites will work as
+    expected: ``unit.hp_0``, ``unit.hp_25``, ``unit.hp_50``, ``unit.hp_75``, ``unit.hp_100``.
+    On the other hand, specifying only the following sprites will give wrong results:
+    ``unit.hp_0``, ``unit.hp_90``, ``unit.hp_100``.
+
+.. option:: unlimited-unit-select-frames
+
+    The number of sprites used in the animation under the selected unit is no longer fixed to four
+    (sprites ``unit.select*``).
+
+.. option:: unlimited-upkeep-sprites
+
+    The number of sprites used to display unit upkeep is no longer limited to 10
+    (sprites ``upkeep.unhappy*``, ``upkeep.output*``).

--- a/docs/Modding/index.rst
+++ b/docs/Modding/index.rst
@@ -61,6 +61,7 @@ guides document specific aspects of tileset creation:
 .. toctree::
   Tilesets/graphics.rst
   Tilesets/debugger.rst
+  Tilesets/compatibility.rst
   :maxdepth: 1
 
 Soundsets


### PR DESCRIPTION
This closes #777.

I unhardcoded a few extra elements that happened to be defined nearby. Feature flags were added.

### Test plan

Edit `amplio2/select.spec` as follows:
```py
tiles = { "row", "column", "tag"
  0, 0, "unit.select0"
  0, 1, "unit.select1"
  0, 2, "unit.select2"
  0, 3, "unit.select3"
  0, 3, "unit.select4"
  0, 2, "unit.select5"
  0, 1, "unit.select6"
  0, 0, "unit.select7"
}
```

Uncomment the `select_step_ms` line in `amplio2.tilespec` and set it to something unreasonable (tested 1 and 1000).

Read the new documentation.

Ideally one would also test the other sprites.