### PR TITLE
Break infinite update() loop in sidebar

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -1095,14 +1095,12 @@ double real_timer_callback()
 
   {
     double blink_time = blink_turn_done_button();
-
-    time_until_next_call = MIN(time_until_next_call, blink_time) / 1000;
+    time_until_next_call = std::min(time_until_next_call, blink_time / 1000);
   }
 
   if (get_num_units_in_focus() > 0) {
     double blink_time = blink_active_unit();
-
-    time_until_next_call = MIN(time_until_next_call, blink_time) / 1000;
+    time_until_next_call = std::min(time_until_next_call, blink_time / 1000);
   }
 
   /* It is possible to have current_turn_timeout() > 0 but !turndone_timer,
@@ -1113,7 +1111,7 @@ double real_timer_callback()
       update_timeout_label();
     }
 
-    time_until_next_call = MIN(time_until_next_call, 1.0);
+    time_until_next_call = std::min(time_until_next_call, 1.0);
   }
   if (waiting_turn_change) {
     double seconds =

--- a/client/gui-qt/diplodlg.cpp
+++ b/client/gui-qt/diplodlg.cpp
@@ -682,7 +682,7 @@ void diplo_wdg::restore_pixmap()
   queen()->sw_diplo->resizePixmap(queen()->sw_diplo->width(),
                                   queen()->sw_diplo->height());
   queen()->sw_diplo->setCustomLabels(QString());
-  queen()->sw_diplo->updateFinalPixmap();
+  queen()->sw_diplo->update();
 }
 
 /**
@@ -893,7 +893,7 @@ void handle_diplomacy_init_meeting(int counterpart, int initiated_from)
                                   queen()->sw_diplo->height());
   queen()->sw_diplo->setCustomLabels(
       QString(nation_plural_for_player(player_by_number(counterpart))));
-  queen()->sw_diplo->updateFinalPixmap();
+  queen()->sw_diplo->update();
   delete pix2;
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
     dd = new diplo_dlg(counterpart, initiated_from);

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -437,7 +437,7 @@ void update_mouse_cursor(enum cursor_type new_cursor_type)
 void qtg_update_timeout_label()
 {
   queen()->sw_endturn->setCustomLabels(QString(get_timeout_label_text()));
-  queen()->sw_endturn->updateFinalPixmap();
+  queen()->sw_endturn->update();
 }
 
 /**

--- a/client/gui-qt/page_game.cpp
+++ b/client/gui-qt/page_game.cpp
@@ -236,7 +236,7 @@ void pageGame::updateInfoLabelTimeout()
           .arg(calendar_text(), QString::number(game.info.turn));
 
   sw_map->setCustomLabels(s);
-  sw_map->updateFinalPixmap();
+  sw_map->update();
 
   if (client.conn.playing != NULL) {
     if (player_get_expected_income(client.conn.playing) > 0) {
@@ -256,9 +256,9 @@ void pageGame::updateInfoLabelTimeout()
   } else {
     sw_economy->setCustomLabels(QLatin1String(""));
   }
-  sw_indicators->updateFinalPixmap();
-  sw_tax->updateFinalPixmap();
-  sw_economy->updateFinalPixmap();
+  sw_indicators->update();
+  sw_tax->update();
+  sw_economy->update();
   FC_FREE(update_info_timer);
 }
 
@@ -552,7 +552,7 @@ void fc_game_tab_widget::current_changed(int index)
   }
 
   for (auto *sw : qAsConst(queen()->sidebar_wdg->objects)) {
-    sw->updateFinalPixmap();
+    sw->update();
   }
   currentWidget()->hide();
   widget(index)->show();

--- a/client/gui-qt/sciencedlg.cpp
+++ b/client/gui-qt/sciencedlg.cpp
@@ -565,7 +565,7 @@ void real_science_report_dialog_update(void *unused)
   } else {
     queen()->sw_science->keep_blinking = false;
     queen()->sw_science->setCustomLabels(str);
-    queen()->sw_science->updateFinalPixmap();
+    queen()->sw_science->update();
   }
   queen()->updateSidebarTooltips();
 

--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -86,9 +86,9 @@ sidebarWidget::sidebarWidget(QPixmap *pix, const QString &label,
  */
 sidebarWidget::~sidebarWidget()
 {
-  NFC_FREE(scaled_pixmap);
-  NFC_FREE(def_pixmap);
-  NFC_FREE(final_pixmap);
+  NFCN_FREE(scaled_pixmap);
+  NFCN_FREE(def_pixmap);
+  NFCN_FREE(final_pixmap);
 
   delete timer;
 }
@@ -98,7 +98,7 @@ sidebarWidget::~sidebarWidget()
  */
 void sidebarWidget::setPixmap(QPixmap *pm)
 {
-  NFC_FREE(def_pixmap);
+  NFCN_FREE(def_pixmap);
   def_pixmap = pm;
 }
 
@@ -343,7 +343,7 @@ void sidebarWidget::updateFinalPixmap()
 
   resizePixmap(width(), height());
 
-  NFC_FREE(final_pixmap);
+  NFCN_FREE(final_pixmap);
 
   i = queen()->gimmeIndexOf(page);
   if (i == queen()->game_tab_widget->currentIndex()) {

--- a/client/gui-qt/sidebar.cpp
+++ b/client/gui-qt/sidebar.cpp
@@ -189,7 +189,6 @@ void sidebarWidget::enterEvent(QEvent *event)
 {
   if (!hover) {
     hover = true;
-    updateFinalPixmap();
     QWidget::enterEvent(event);
     update();
   }
@@ -202,7 +201,6 @@ void sidebarWidget::leaveEvent(QEvent *event)
 {
   if (hover) {
     hover = false;
-    updateFinalPixmap();
     QWidget::leaveEvent(event);
     update();
   }
@@ -215,7 +213,6 @@ void sidebarWidget::contextMenuEvent(QContextMenuEvent *event)
 {
   if (hover) {
     hover = false;
-    updateFinalPixmap();
     QWidget::contextMenuEvent(event);
     update();
   }
@@ -287,7 +284,7 @@ void sidebarWidget::sblink()
       timer->stop();
     }
   }
-  updateFinalPixmap();
+  update();
 }
 
 /**
@@ -457,7 +454,6 @@ void sidebarWidget::updateFinalPixmap()
   }
 
   p.end();
-  update();
 }
 
 /**
@@ -579,7 +575,7 @@ void sidebarDisableEndturn(bool do_restore)
     return;
   }
   queen()->sw_endturn->disabled = !do_restore;
-  queen()->sw_endturn->updateFinalPixmap();
+  queen()->sw_endturn->update();
 }
 
 /**
@@ -591,7 +587,7 @@ void sidebarBlinkEndturn(bool do_restore)
     return;
   }
   queen()->sw_endturn->blink = !do_restore;
-  queen()->sw_endturn->updateFinalPixmap();
+  queen()->sw_endturn->update();
 }
 
 /**

--- a/client/gui-qt/sidebar.h
+++ b/client/gui-qt/sidebar.h
@@ -55,7 +55,6 @@ public:
   void setTooltip(const QString &tooltip);
   void setWheelDown(pfcn func);
   void setWheelUp(pfcn func);
-  void updateFinalPixmap();
 
   bool blink;
   bool keep_blinking;
@@ -75,6 +74,7 @@ protected:
   void wheelEvent(QWheelEvent *event) override;
 
 private:
+  void updateFinalPixmap();
   void paint();
   bool hover;
   pfcn right_click;


### PR DESCRIPTION
Resulted from misuse of the Qt APIs. Use them more as intended.

Closes #782.

Test plan:
* Start game
* Check CPU usage (should be << 100%)
* Check that the sidebar still updates correctly