### PR TITLE
Solve layout issues in the city screen right panel

### DIFF
--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -1161,7 +1161,7 @@ void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
                          + "</pre>");
     }
   }
-  // handjob
+
   ciil->updateTooltip(0, buf[FOOD + 1]);
   ciil->updateTooltip(2, buf[SHIELD + 1]);
   ciil->updateTooltip(4, buf[GOLD + 1]);

--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -91,27 +91,6 @@ QSize icon_list::viewportSizeHint() const
 }
 
 /**
-   Reimplemented virtual method.
- */
-int icon_list::heightForWidth(int width) const
-{
-  int height = 0, line_height = 0, line_width = 0;
-  for (int i = 0; i < count(); ++i) {
-    auto hint = sizeHintForIndex(indexFromItem(item(i)));
-    if (line_width + hint.width() > width) {
-      // New line
-      height += line_height;
-      line_width = 0;
-      line_height = 0;
-    }
-    line_width += hint.width();
-    line_height = qMax(line_height, hint.height());
-  }
-  // Add the last line and some extra room to make sure there's no scroll bar
-  return height + line_height + 5;
-}
-
-/**
    Custom progressbar constructor
  */
 progress_bar::progress_bar(QWidget *parent) : QProgressBar(parent)
@@ -2320,9 +2299,7 @@ void city_dialog::update_units()
   }
 
   ui.supported_units->clear();
-  if (unit_list_size(units) == 0) {
-    ui.supported_units->hide();
-  } else {
+  if (unit_list_size(units) > 0) {
     QSize icon_size;
     unit_list_iterate(units, punit)
     {
@@ -2335,7 +2312,6 @@ void city_dialog::update_units()
       ui.supported_units->addItem(item);
     }
     unit_list_iterate_end;
-    ui.supported_units->show();
     ui.supported_units->setGridSize(icon_size);
     ui.supported_units->setIconSize(icon_size);
   }

--- a/client/gui-qt/citydlg.h
+++ b/client/gui-qt/citydlg.h
@@ -61,8 +61,6 @@ class QPixmap;
 class icon_list : public QListWidget {
 public:
   explicit icon_list(QWidget *parent = nullptr);
-  bool hasHeightForWidth() const override { return true; }
-  int heightForWidth(int width) const override;
   QSize viewportSizeHint() const override;
   bool oneliner;
 };

--- a/client/gui-qt/citydlg.ui
+++ b/client/gui-qt/citydlg.ui
@@ -487,7 +487,7 @@
            <attribute name="title">
             <string>Output</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
+           <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,0,1">
             <item>
              <widget class="city_info" name="info_wdg" native="true">
               <property name="sizePolicy">
@@ -577,19 +577,6 @@
                <enum>QListView::IconMode</enum>
               </property>
              </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </widget>

--- a/client/helpdata.cpp
+++ b/client/helpdata.cpp
@@ -484,7 +484,6 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
                         "directories for data files:");
     data_dirs_info += "\n\n";
     for (const auto &path : qAsConst(get_data_dirs())) {
-      qCritical() << path;
       QFileInfo info(path + "/");
       data_dirs_info += "* " + info.absolutePath() + " ";
       if (!info.exists()) {

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -1921,7 +1921,7 @@ static struct tileset *tileset_read_toplevel(const char *tileset_name,
   }
   t->small_sprite_width = t->small_sprite_width * t->scale;
   t->small_sprite_height = t->small_sprite_height * t->scale;
-  qDebug("tile sizes %dx%d, %d%d unit, %d%d small", t->normal_tile_width,
+  qDebug("tile sizes %dx%d, %dx%d unit, %dx%d small", t->normal_tile_width,
          t->normal_tile_height, t->full_tile_width, t->full_tile_height,
          t->small_sprite_width, t->small_sprite_height);
 


### PR DESCRIPTION
The core of this PR is a fix for #665 in the third commit:

heightForWidth() was reporting inconsistent results. Turns out it's not needed:
drop it.

Closes #665.
The symptoms described there (overlapping QLabels) sill happen when the window
is resized to a size too small for the contents, but this will be solved later
when we get rid of absolute positioning.  (This time, I hope, for good.)

Other commits are small fixes here and there that aren't worth commenting IMHO.

Test plan:
* Make a save with many units owned by the same city
* Reproduce #665
* Apply patch
* Observe that #665 is harder to reproduce