### PR TITLE
Fix sol2 code and interoperability with tolua

### DIFF
--- a/common/scriptcore/CMakeLists.txt
+++ b/common/scriptcore/CMakeLists.txt
@@ -47,5 +47,5 @@ target_include_directories(scriptcore PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(scriptcore PUBLIC common)
 target_link_libraries(scriptcore PUBLIC tolua)
-target_link_libraries(scriptcore PRIVATE sol2)
+target_link_libraries(scriptcore PUBLIC sol2)
 target_link_libraries(scriptcore PRIVATE Qt5::Core)

--- a/dependencies/sol2/CMakeLists.txt
+++ b/dependencies/sol2/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(sol2 INTERFACE)
-target_compile_definitions(sol2 INTERFACE SOL_ALL_SAFETIES_ON)
+target_compile_definitions(sol2 INTERFACE SOL_ALL_SAFETIES_ON=1)
 target_include_directories(sol2 INTERFACE "${CMAKE_CURRENT_LIST_DIR}")

--- a/server/scripting/CMakeLists.txt
+++ b/server/scripting/CMakeLists.txt
@@ -25,4 +25,3 @@ target_include_directories(scripting PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(scripting PUBLIC server)
 target_link_libraries(scripting PUBLIC tolua)
-target_link_libraries(scripting PRIVATE sol2)

--- a/server/scripting/script_fcdb.cpp
+++ b/server/scripting/script_fcdb.cpp
@@ -25,7 +25,6 @@
 #include "log.h"
 
 /* common/scriptcore */
-#define SOL_COMPATIBLE
 #include "luascript.h"
 #include "luascript_types.h"
 #include "tolua_common_a_gen.h"

--- a/server/scripting/script_fcdb.cpp
+++ b/server/scripting/script_fcdb.cpp
@@ -282,11 +282,12 @@ bool script_fcdb_do_string(struct connection *caller, const char *str)
  */
 static bool script_fcdb_database_init()
 {
-  try {
-    const sol::protected_function database_init = (*fcl)["database_init"];
-    return database_init().valid();
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function database_init = (*fcl)["database_init"];
+  auto result = database_init();
+  if (result.valid()) {
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -296,11 +297,12 @@ static bool script_fcdb_database_init()
  */
 static bool script_fcdb_database_free()
 {
-  try {
-    const sol::protected_function database_free = (*fcl)["database_free"];
-    return database_free().valid();
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function database_free = (*fcl)["database_free"];
+  auto result = database_free();
+  if (result.valid()) {
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -311,17 +313,14 @@ static bool script_fcdb_database_free()
 bool script_fcdb_user_delegate_to(connection *pconn, player *pplayer,
                                   const char *delegate, bool &success)
 {
-  try {
-    const sol::protected_function user_delegate_to =
-        (*fcl)["user_delegate_to"];
-    const sol::optional<bool> result =
-        user_delegate_to(pconn, pplayer, delegate);
-    if (result) {
-      success = *result;
-      return true;
-    }
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function user_delegate_to =
+      (*fcl)["user_delegate_to"];
+  auto result = user_delegate_to(pconn, pplayer, delegate);
+  if (result.valid()) {
+    success = result;
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -331,15 +330,13 @@ bool script_fcdb_user_delegate_to(connection *pconn, player *pplayer,
  */
 bool script_fcdb_user_exists(connection *pconn, bool &exists)
 {
-  try {
-    const sol::protected_function user_exists = (*fcl)["user_exists"];
-    const sol::optional<bool> result = user_exists(pconn);
-    if (result) {
-      exists = *result;
-      return true;
-    }
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function user_exists = (*fcl)["user_exists"];
+  auto result = user_exists(pconn);
+  if (result.valid()) {
+    exists = result;
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -349,11 +346,12 @@ bool script_fcdb_user_exists(connection *pconn, bool &exists)
  */
 bool script_fcdb_user_save(connection *pconn, const char *password)
 {
-  try {
-    const sol::protected_function user_save = (*fcl)["user_save"];
-    return user_save(pconn, password).valid();
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function user_save = (*fcl)["user_save"];
+  auto result = user_save(pconn, password);
+  if (result.valid()) {
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -364,16 +362,13 @@ bool script_fcdb_user_save(connection *pconn, const char *password)
 bool script_fcdb_user_take(connection *requester, connection *taker,
                            player *player, bool will_observe, bool &success)
 {
-  try {
-    const sol::protected_function user_take = (*fcl)["user_take"];
-    const sol::optional<bool> result =
-        user_take(requester, taker, player, will_observe);
-    if (result) {
-      success = *result;
-      return true;
-    }
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function user_take = (*fcl)["user_take"];
+  auto result = user_take(requester, taker, player, will_observe);
+  if (result.valid()) {
+    success = result;
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
   }
   return false;
 }
@@ -384,15 +379,14 @@ bool script_fcdb_user_take(connection *requester, connection *taker,
 bool script_fcdb_user_verify(connection *pconn, const char *username,
                              bool &success)
 {
-  try {
-    const sol::protected_function user_verify = (*fcl)["user_verify"];
-    const sol::optional<bool> result = user_verify(pconn, username);
-    if (result) {
-      success = *result;
-      return true;
-    }
-  } catch (const std::exception &e) {
-    qCritical() << e.what();
+  const sol::protected_function user_verify = (*fcl)["user_verify"];
+  auto result = user_verify(pconn, username);
+  if (result.valid()) {
+    success = result;
+    return true;
+  } else {
+    qCritical() << sol::error(result).what();
+    success = false;
   }
   return false;
 }


### PR DESCRIPTION
Closes #810.

**Test plan:**
1. Try to reproduce #810
2. Don't reproduce #810 with the patch
3. Generate a lua error by doing something illegal, for instance `variable_that_doesnt_exist[0]`
4. Check that the error is printed to stderr