### PR TITLE
Unhardcode unit healing

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -425,6 +425,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
     v += unit_list_size(pcity->tile->units) * 2;
     break;
   case EFT_HP_REGEN:
+  case EFT_HP_REGEN_MIN:
     num = num_affected_units(peffect, adv);
     v += (5 * c + num);
     break;

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1079,6 +1079,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_SPY_RESISTANT:
   case EFT_VETERAN_COMBAT:
   case EFT_HP_REGEN:
+  case EFT_HP_REGEN_MIN:
   case EFT_TRADEROUTE_PCT:
   case EFT_DEFEND_BONUS:
   case EFT_CIVIL_WAR_CHANCE:

--- a/common/effects.h
+++ b/common/effects.h
@@ -301,6 +301,8 @@
 #define SPECENUM_VALUE125NAME "Illegal_Action_HP_Cost"
 #define SPECENUM_VALUE128 EFT_NUKE_IMPROVEMENT_PCT
 #define SPECENUM_VALUE128NAME "Nuke_Improvement_Pct"
+#define SPECENUM_VALUE129 EFT_HP_REGEN_MIN
+#define SPECENUM_VALUE129NAME "HP_Regen_Min"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -13,7 +13,7 @@
 
 [datafile]
 description="Alien World effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -594,6 +594,45 @@ reqs	=
 type	= "Pollu_Pop_Pct"
 value	= -100
 
+; Basic HP regen.
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    = {}
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    = {}
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
 [effect_hospital]
 type    = "HP_Regen"
 value	= 50

--- a/data/civ1/effects.ruleset
+++ b/data/civ1/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ1 effects data for Freeciv (approximate)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2/effects.ruleset
+++ b/data/civ2/effects.ruleset
@@ -369,6 +369,33 @@ reqs    =
       "OutputType", "gold", "Local"
     }
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
 
 ; Fortress HP regen
 [effect_fortress_hp_regen]
@@ -378,6 +405,23 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Fortress", "Tile"
       "UnitClass", "Land", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
     }
 
 ; Base vision range - radius of vision is sqrt(5) = 2.24

--- a/data/civ2/effects.ruleset
+++ b/data/civ2/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2 effects data for Freeciv (incomplete)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -245,6 +245,36 @@ reqs    =
       "Extra", "Airbase", "Local"
     }
 
+; Basic HP regen.  Not for helis or planes, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Air", "Local", FALSE
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Air", "Local", FALSE
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen (Every Land units)
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -261,6 +291,23 @@ reqs    =
       "UnitClass", "Helicopter", "Local", FALSE
       "UnitClass", "Air", "Local", FALSE
       "UnitClass", "Missile", "Local", FALSE
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
     }
 
 [effect_fort_defense]
@@ -309,11 +356,11 @@ reqs    =
     }
 
 ; Airbase HP regen: cumulative with airstrip
-; 10 + 24 = 34% (this approximation to 1/3 is exact for units <50HP;
+; 10 + 23 = 33% (this approximation to 1/3 is exact for units <100HP;
 ; 1/3 is equivalent to a city without Airport)
 [effect_airbase_hp_regen]
 type    = "HP_Regen"
-value   = 24
+value   = 23
 reqs    =
     { "type", "name", "range", "present"
       "Extra", "Airbase", "Local", TRUE

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -118,6 +118,34 @@ reqs    =
 type    = "Tech_Upkeep_Free"
 value   = 3
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 34
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -131,6 +159,23 @@ reqs    =
 [effect_fortified]
 type    = "Fortify_Defense_Bonus"
 value   = 50
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
 reqs    =
     { "type", "name", "range"
       "Activity", "Fortified", "Local"

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -140,7 +140,7 @@ reqs    =
 ; Units in cities regenerate at least 1/3 of their HP regardless
 [effect_hp_regen_min_city]
 type    = "HP_Regen_Min"
-value   = 34
+value   = 33
 reqs    =
     { "type", "name", "range"
       "CityTile", "Center", "Local"

--- a/data/experimental/effects.ruleset
+++ b/data/experimental/effects.ruleset
@@ -14,7 +14,7 @@
 
 [datafile]
 description="Experimental effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/experimental/effects.ruleset
+++ b/data/experimental/effects.ruleset
@@ -132,6 +132,34 @@ reqs    =
 type    = "Tech_Upkeep_Free"
 value   = 3
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen
 [effect_fortress_hp_regen_land]
 type    = "HP_Regen"
@@ -149,6 +177,23 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Fortress", "Tile"
       "UnitClass", "Big Land", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
     }
 
 [effect_fortified]

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -112,9 +112,48 @@ reqs	=
       "Building", "Throne", "City"
     }
 
+; Basic HP regen.
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    = {}
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    = {}
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 [effect_fortified]
 type    = "Fortify_Defense_Bonus"
 value   = 50
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
 reqs    =
     { "type", "name", "range"
       "Activity", "Fortified", "Local"

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Granularity effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -118,6 +118,34 @@ reqs    =
 type    = "Tech_Upkeep_Free"
 value   = 3
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -131,6 +159,23 @@ reqs    =
 [effect_fortified]
 type    = "Fortify_Defense_Bonus"
 value   = 50
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
 reqs    =
     { "type", "name", "range"
       "Activity", "Fortified", "Local"

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -214,6 +214,33 @@ reqs    =
       "Extra", "Airbase", "Local"
     }
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen (Every Land units)
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -231,6 +258,23 @@ reqs    =
       "UnitClass", "Helicopter", "Local", FALSE
       "UnitClass", "Air", "Local", FALSE
       "UnitClass", "Missile", "Local", FALSE
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
     }
 
 ; No defense bonus from Pre-Fortress, Fortress only helps against Land and Sea units
@@ -254,11 +298,11 @@ reqs    =
 
 
 
-; Airbase HP regen: 34% (this approximation to 1/3 is exact for units <50HP;
+; Airbase HP regen: 33% (this approximation to 1/3 is exact for units <100HP;
 ; 1/3 is equivalent to a city without Airport)
 [effect_airbase_hp_regen]
 type    = "HP_Regen"
-value   = 34
+value   = 33
 reqs    =
     { "type", "name", "range", "present"
       "Extra", "Airbase", "Local", TRUE

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -245,6 +245,36 @@ reqs    =
       "Extra", "Airbase", "Local"
     }
 
+; Basic HP regen.  Not for helis or planes, as they have hp_loss_pct=10
+; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Air", "Local", FALSE
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Air", "Local", FALSE
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen (Every Land units)
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -261,6 +291,23 @@ reqs    =
       "UnitClass", "Helicopter", "Local", FALSE
       "UnitClass", "Air", "Local", FALSE
       "UnitClass", "Missile", "Local", FALSE
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
     }
 
 [effect_fort_defense]
@@ -309,11 +356,11 @@ reqs    =
     }
 
 ; Airbase HP regen: cumulative with airstrip
-; 10 + 24 = 34% (this approximation to 1/3 is exact for units <50HP;
+; 10 + 24 = 33% (this approximation to 1/3 is exact for units <100HP;
 ; 1/3 is equivalent to a city without Airport)
 [effect_airbase_hp_regen]
 type    = "HP_Regen"
-value   = 24
+value   = 23
 reqs    =
     { "type", "name", "range", "present"
       "Extra", "Airbase", "Local", TRUE

--- a/data/stub/effects.ruleset
+++ b/data/stub/effects.ruleset
@@ -3,7 +3,7 @@
 
 [datafile]
 description="<modpack> effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/effects.ruleset
+++ b/data/webperimental/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Experimental web-client effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/effects.ruleset
+++ b/data/webperimental/effects.ruleset
@@ -118,6 +118,33 @@ reqs    =
 type    = "Tech_Upkeep_Free"
 value   = 3
 
+; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
+[effect_hp_regen_base]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
+[effect_hp_regen_min_base]
+type    = "HP_Regen_Min"
+value   = 10
+reqs    =
+    { "type", "name", "range", "present"
+      "UnitClass", "Helicopter", "Local", FALSE
+    }
+
+; Units in cities regenerate at least 1/3 of their HP regardless
+[effect_hp_regen_min_city]
+type    = "HP_Regen_Min"
+value   = 33
+reqs    =
+    { "type", "name", "range"
+      "CityTile", "Center", "Local"
+    }
+
 ; Fortress HP regen
 [effect_fortress_hp_regen]
 type    = "HP_Regen"
@@ -131,6 +158,23 @@ reqs    =
 [effect_fortified]
 type    = "Fortify_Defense_Bonus"
 value   = 50
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+[effect_fortified_hp_regen]
+type    = "HP_Regen"
+value   = 10
+reqs    =
+    { "type", "name", "range"
+      "Activity", "Fortified", "Local"
+    }
+
+; When hardcoded, effect_fortified_hp_regen was applied after the HP_Regen_Min
+[effect_fortified_hp_regen_min]
+type    = "HP_Regen_Min"
+value   = 10
 reqs    =
     { "type", "name", "range"
       "Activity", "Fortified", "Local"

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -466,8 +466,16 @@ Combat_Rounds
 HP_Regen
     Units that do not move recover amount percentage (rounded up) of their full hitpoints per turn.
 
+    .. note::
+        This effect is added automatically to implement HP recovery in cities. This behavior can be turned
+        off by requiring the ``+HP_Regen_Min`` option in ``effects.ruleset``.
+
 HP_Regen_Min
     Lower limit on "HP_Regen".  That is, the recovery percentage is the larger of "HP_Regen" and "HP_Regen_Min".
+
+    .. note::
+        This effect is added automatically to implement HP recovery in cities. This behavior can be turned
+        off by requiring the ``+HP_Regen_Min`` option in ``effects.ruleset``.
 
 City_Vision_Radius_Sq
     Increase city vision radius in squared distance by amount tiles.
@@ -627,7 +635,7 @@ Unit_Buy_Cost_Pct
 
 Nuke_Improvement_Pct
     Percentage chance that an improvement would be destroyed while nuking the city
-    Only regular improvements (not wonders) are affected. Improvements protected from Sabotage (Eg: City Walls) 
+    Only regular improvements (not wonders) are affected. Improvements protected from Sabotage (Eg: City Walls)
     aren't affected.
 
 Shield2Gold_Factor

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -464,7 +464,10 @@ Combat_Rounds
     continues until either side dies.
 
 HP_Regen
-    Units that do not move recover amount percentage of their full hitpoints per turn.
+    Units that do not move recover amount percentage (rounded up) of their full hitpoints per turn.
+
+HP_Regen_Min
+    Lower limit on "HP_Regen".  That is, the recovery percentage is the larger of "HP_Regen" and "HP_Regen_Min".
 
 City_Vision_Radius_Sq
     Increase city vision radius in squared distance by amount tiles.

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -49,14 +49,6 @@ struct new_flags {
 #define TER_LAST_USER_FLAG_3_0 TER_USER_8
 
 /**
-   Initialize rscompat information structure
- */
-void rscompat_init_info(struct rscompat_info *info)
-{
-  memset(info, 0, sizeof(*info));
-}
-
-/**
    Ruleset files should have a capabilities string datafile.options
    This checks the string and that the required capabilities are satisfied.
  */

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -48,6 +48,8 @@ struct new_flags {
 #define UCF_LAST_USER_FLAG_3_0 UCF_USER_FLAG_8
 #define TER_LAST_USER_FLAG_3_0 TER_USER_8
 
+static void rscompat_optional_capabilities(rscompat_info *info);
+
 /**
    Ruleset files should have a capabilities string datafile.options
    This checks the string and that the required capabilities are satisfied.
@@ -643,17 +645,13 @@ bool rscompat_old_effect_3_1(const char *type, struct section_file *file,
  */
 void rscompat_postprocess(struct rscompat_info *info)
 {
-  if (!info->compat_mode) {
-    /* There isn't anything here that should be done outside of compat
-     * mode. */
-    return;
+  if (info->compat_mode) {
+    /* Upgrade existing effects. Done before new effects are added to
+     * prevent the new effects from being upgraded by accident. */
+    iterate_effect_cache(effect_list_compat_cb, info);
   }
 
-  /* Upgrade existing effects. Done before new effects are added to prevent
-   * the new effects from being upgraded by accident. */
-  iterate_effect_cache(effect_list_compat_cb, info);
-
-  if (info->ver_effects < 20) {
+  if (info->compat_mode && info->ver_effects < 20) {
     struct effect *peffect;
 
     /* Post successful action move fragment loss for "Bombard"
@@ -784,7 +782,7 @@ void rscompat_postprocess(struct rscompat_info *info)
                                             false, "Upgrade Unit"));
   }
 
-  if (info->ver_game < 20) {
+  if (info->compat_mode && info->ver_game < 20) {
     // New enablers
     struct action_enabler *enabler;
     struct requirement e_req;
@@ -1066,6 +1064,8 @@ void rscompat_postprocess(struct rscompat_info *info)
     }
   }
 
+  rscompat_optional_capabilities(info);
+
   /* The ruleset may need adjustments it didn't need before compatibility
    * post processing.
    *
@@ -1073,6 +1073,61 @@ void rscompat_postprocess(struct rscompat_info *info)
    * the rules risks bad rules. A user that saves the ruleset rather than
    * using it risks an unexpected change on the next load and save. */
   autoadjust_ruleset_data();
+}
+
+/**
+ * Handles compatibility with older versions when the new behavior is
+ * tied to the presence of an optional ruleset capability.
+ */
+static void rscompat_optional_capabilities(rscompat_info *info)
+{
+  if (!has_capabilities(info->cap_effects.data(), CAP_EFT_HP_REGEN_MIN)) {
+    // Create new effects to replace the old hard-coded minimum HP
+    // recovery.
+
+    // 1- 10% base recovery for units without hp_loss_pct
+    auto effect = effect_new(EFT_HP_REGEN, 10, nullptr);
+    unit_class_iterate(uclass)
+    {
+      if (uclass->hp_loss_pct > 0) {
+        effect_req_append(effect,
+                          req_from_str("UnitClass", "Local", false, false,
+                                       false, uclass_rule_name(uclass)));
+      }
+    }
+    unit_class_iterate_end;
+
+    // 2- 10% base recovery for fortified units
+    effect = effect_new(EFT_HP_REGEN, 10, nullptr);
+    effect_req_append(effect, req_from_str("Activity", "Local", false, true,
+                                           false, "Fortified"));
+
+    // 3- At least one third in cities
+    effect = effect_new(EFT_HP_REGEN_MIN, 33, nullptr);
+    effect_req_append(effect, req_from_str("CityTile", "Local", false, true,
+                                           false, "Center"));
+
+    // 4- 10% more for units in cities without hp_loss_pct
+    effect = effect_new(EFT_HP_REGEN_MIN, 10, nullptr);
+    effect_req_append(effect, req_from_str("CityTile", "Local", false, true,
+                                           false, "Center"));
+    unit_class_iterate(uclass)
+    {
+      if (uclass->hp_loss_pct > 0) {
+        effect_req_append(effect,
+                          req_from_str("UnitClass", "Local", false, false,
+                                       false, uclass_rule_name(uclass)));
+      }
+    }
+    unit_class_iterate_end;
+
+    // 5- 10% more for units fortified in cities
+    effect = effect_new(EFT_HP_REGEN_MIN, 10, nullptr);
+    effect_req_append(effect, req_from_str("CityTile", "Local", false, true,
+                                           false, "Center"));
+    effect_req_append(effect, req_from_str("Activity", "Local", false, true,
+                                           false, "Fortified"));
+  }
 }
 
 /**

--- a/server/rscompat.h
+++ b/server/rscompat.h
@@ -21,21 +21,20 @@
 #define RULESET_COMPAT_CAP "+Freeciv-3.0-ruleset"
 
 struct rscompat_info {
-  bool compat_mode;
-  rs_conversion_logger log_cb;
-  int ver_buildings;
-  int ver_cities;
-  int ver_effects;
-  int ver_game;
-  int ver_governments;
-  int ver_nations;
-  int ver_styles;
-  int ver_techs;
-  int ver_terrain;
-  int ver_units;
+  bool compat_mode = false;
+  rs_conversion_logger log_cb = nullptr;
+  int ver_buildings = 0;
+  int ver_cities = 0;
+  int ver_effects = 0;
+  int ver_game = 0;
+  int ver_governments = 0;
+  int ver_nations = 0;
+  int ver_styles = 0;
+  int ver_techs = 0;
+  int ver_terrain = 0;
+  int ver_units = 0;
+  QByteArray cap_effects;
 };
-
-void rscompat_init_info(struct rscompat_info *info);
 
 int rscompat_check_capabilities(struct section_file *file,
                                 const char *filename,

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -5750,6 +5750,9 @@ static bool load_ruleset_effects(struct section_file *file,
   if (compat->ver_effects <= 0) {
     return false;
   }
+
+  compat->cap_effects = secfile_lookup_str(file, "datafile.options");
+
   (void) secfile_entry_by_path(file, "datafile.description"); // unused
   (void) secfile_entry_by_path(file, "datafile.ruledit");     // unused
 
@@ -8608,7 +8611,6 @@ static bool load_rulesetdir(const char *rsdir, bool compat_mode,
 
   qInfo(_("Loading rulesets."));
 
-  rscompat_init_info(&compat_info);
   compat_info.compat_mode = compat_mode;
   compat_info.log_cb = logger;
 

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -14,7 +14,9 @@
 
 #include <QLoggingCategory>
 
-#define RULESET_CAPABILITIES "+Freeciv-ruleset-Devel-2017.Jan.02"
+#define CAP_EFT_HP_REGEN_MIN "HP_Regen_Min"
+#define RULESET_CAPABILITIES                                                \
+  "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN
 /*
  * Ruleset capabilities acceptable to this program:
  *
@@ -23,6 +25,9 @@
  *
  * +Freeciv-ruleset-Devel-YYYY.MMM.DD
  *    - ruleset of the development version at the given data
+ *
+ * HP_Regen_Min (optional)
+ *    - Hard-coded HP regeneration rules in cities moved to effects.ruleset
  */
 
 Q_DECLARE_LOGGING_CATEGORY(ruleset_category)

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -707,23 +707,15 @@ void finalize_unit_phase_beginning(struct player *pplayer)
  */
 static int hp_gain_coord(struct unit *punit)
 {
-  int hp = 0;
+  int bonus, hp;
   const int base = unit_type_get(punit)->hp;
 
   // Includes barracks (100%), fortress (25%), etc.
-  hp += base * get_unit_bonus(punit, EFT_HP_REGEN) / 100;
-
-  if (tile_city(unit_tile(punit))) {
-    hp = MAX(hp, base / 3);
-  }
-
-  if (!unit_class_get(punit)->hp_loss_pct) {
-    hp += (base + 9) / 10;
-  }
-
-  if (punit->activity == ACTIVITY_FORTIFIED) {
-    hp += (base + 9) / 10;
-  }
+  bonus = get_unit_bonus(punit, EFT_HP_REGEN);
+  bonus = MAX(bonus, get_unit_bonus(punit, EFT_HP_REGEN_MIN));
+  if (bonus <= 0)
+    return 0;
+  hp = (base - 1) * bonus / 100 + 1; // rounds up
 
   return MAX(hp, 0);
 }


### PR DESCRIPTION
Replace the hardcoded extra healing in `hp_gain_coord()` with a new bonus `EFT_HP_REGEN_MIN`, which supplies the minimum (as a percentage of unittype's HP) to clamp to.
This PR currently includes updates to the Classic ruleset to replicate the old hardcoded behaviour, but does not (yet) update the other rulesets, nor touch ruleup.
Testing: build only so far.

Closes longturn#593.