### PR TITLE
Allow @ in filenames and valid UTF letters in usernames

### DIFF
--- a/common/player.cpp
+++ b/common/player.cpp
@@ -16,6 +16,8 @@
 #endif
 
 #include <QBitArray>
+#include <QString>
+
 // utility
 #include "fcintl.h"
 #include "log.h"
@@ -1796,8 +1798,31 @@ int player_in_territory(const struct player *pplayer,
  */
 bool is_valid_username(const char *name)
 {
-  return (strlen(name) > 0 && !QChar::isDigit(name[0]) && is_ascii_name(name)
-          && fc_strcasecmp(name, ANON_USER_NAME) != 0);
+  QString username(name);
+
+  if (username.isEmpty()) {
+    return false;
+  }
+  if (username[0].isDigit()) {
+    return false;
+  }
+
+  if (!username.compare(QStringLiteral(ANON_USER_NAME),
+                        Qt::CaseInsensitive)) {
+    return false;
+  }
+
+  for (auto ch : username) {
+    if (ch.isLetterOrNumber()) {
+      continue;
+    }
+    if (ch == '#') {
+      continue;
+    }
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -225,7 +225,8 @@ bool is_safe_filename(const char *name)
   }
 
   for (; '\0' != name[i]; i++) {
-    if ('.' != name[i] && NULL == strchr(base64url, name[i])) {
+    if (NULL == strchr(".@", name[i])
+        && NULL == strchr(base64url, name[i])) {
       return false;
     }
   }


### PR DESCRIPTION
Testing plan:
* Try to use fancy usernames with any characters. Letters and numbers should be allowed, punctuation etc should not. Things like chat should still behave as expected.
* Try to copy a ruleset as `ruleset@abcd` and load it. Should work.