### PR TITLE
Add override statement for moveEvent

### DIFF
--- a/client/gui-qt/civstatus.h
+++ b/client/gui-qt/civstatus.h
@@ -25,7 +25,7 @@ private slots:
   void updateInfo();
 
 protected:
-  void moveEvent(QMoveEvent *event);
+  void moveEvent(QMoveEvent *event) override;
 
 private:
   move_widget *mw;


### PR DESCRIPTION
Clang gives a warning, this should silence it.
```
freeciv21/client/gui-qt/civstatus.h:28:8: warning: 'moveEvent' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void moveEvent(QMoveEvent *event);
       ^```