### PR TITLE
Rename deprecated QString::SkipEmptyParts to Qt:: SkipEmptyParts

### DIFF
--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -735,7 +735,7 @@ static bool create_command(struct connection *caller, const char *str,
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
 
   if (arg.count() == 1) {
     ai_type_name = default_ai_type_name();
@@ -1404,7 +1404,7 @@ static bool cmdlevel_command(struct connection *caller, char *str,
   struct connection *ptarget;
 
   arg = QString(str).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
 
   if (arg.count() == 0) {
     // No argument supplied; list the levels
@@ -1618,7 +1618,7 @@ static bool timeout_command(struct connection *caller, char *str, bool check)
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
 
   for (i = 0; i < arg.count(); i++) {
     if (!str_to_int(qUtf8Printable(arg.at(i)), timeouts[i])) {
@@ -2357,7 +2357,7 @@ static bool team_command(struct connection *caller, char *str, bool check)
   if (str != NULL || qstrlen(str) > 0) {
     sz_strlcpy(buf, str);
     arg = QString(buf).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
     remove_quotes(arg);
     for (const auto &a : qAsConst(arg)) {
       qInfo() << a;
@@ -2472,7 +2472,7 @@ static bool vote_command(struct connection *caller, char *str, bool check)
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
   remove_quotes(arg);
   if (arg.isEmpty()) {
     show_votes(caller);
@@ -2669,7 +2669,7 @@ static bool debug_command(struct connection *caller, char *str, bool check)
   if (str != NULL && qstrlen(str) > 0) {
     sz_strlcpy(buf, str);
     arg = QString(buf).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
     remove_quotes(arg);
   }
 
@@ -2924,7 +2924,7 @@ static bool set_command(struct connection *caller, char *str, bool check)
 
   // '=' is also a valid delimiter for this function.
   args = QString(str).split(QRegularExpression(REG_EXP),
-                            QString::SkipEmptyParts);
+                            Qt::SkipEmptyParts);
   remove_quotes(args);
 
   if (args.count() < 2) {
@@ -3257,7 +3257,7 @@ static bool observe_command(struct connection *caller, char *str, bool check)
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   // check syntax, only certain syntax if allowed depending on the caller
@@ -3404,7 +3404,7 @@ static bool take_command(struct connection *caller, char *str, bool check)
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   // check syntax
@@ -3585,7 +3585,7 @@ static bool detach_command(struct connection *caller, char *str, bool check)
 
   sz_strlcpy(buf, str);
   arg = QString(buf).split(QRegularExpression(REG_EXP),
-                           QString::SkipEmptyParts);
+                           Qt::SkipEmptyParts);
   remove_quotes(arg);
 
   if (!caller && arg.count() == 0) {
@@ -4113,7 +4113,7 @@ static bool playercolor_command(struct connection *caller, char *str,
   bool ret = true;
 
   token = QString(str).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() != 2) {
@@ -4204,7 +4204,7 @@ static bool playernation_command(struct connection *caller, char *str,
   QStringList token;
 
   token = QString(str).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() == 0) {
@@ -4914,7 +4914,7 @@ static bool lua_command(struct connection *caller, char *arg, bool check,
   bool ret = false;
 
   tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+                              Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() > 0) {
@@ -5109,7 +5109,7 @@ static bool delegate_command(struct connection *caller, char *arg,
   }
 
   tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+                              Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() > 0) {
@@ -5602,7 +5602,7 @@ static bool mapimg_command(struct connection *caller, char *arg, bool check)
   bool ret = true;
 
   token = QString(arg).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
   remove_quotes(token);
   if (token.count() > 0) {
     // match the argument
@@ -5830,7 +5830,7 @@ static bool aicmd_command(struct connection *caller, char *arg, bool check)
   bool ret = false;
 
   tokens = QString(arg).split(QRegularExpression(REG_EXP),
-                              QString::SkipEmptyParts);
+                              Qt::SkipEmptyParts);
   remove_quotes(tokens);
 
   if (tokens.count() < 1) {
@@ -5921,7 +5921,7 @@ static bool fcdb_command(struct connection *caller, char *arg, bool check)
   }
 
   token = QString(arg).split(QRegularExpression(REG_EXP),
-                             QString::SkipEmptyParts);
+                             Qt::SkipEmptyParts);
   remove_quotes(token);
 
   if (token.count() > 0) {

--- a/utility/astring.cpp
+++ b/utility/astring.cpp
@@ -66,7 +66,7 @@ QString qendl() { return QStringLiteral("\n"); }
 QString break_lines(const QString &src, int after)
 {
   QStringList broken =
-      src.split(QStringLiteral(" "), QString::SkipEmptyParts);
+      src.split(QStringLiteral(" "), Qt::SkipEmptyParts);
   QString dst;
 
   int clen = 0;

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -640,7 +640,7 @@ static QStringList base_get_dirs(const char *env_var)
     return {};
   } else if (qEnvironmentVariableIsSet(env_var)) {
     return QString(qEnvironmentVariable(env_var))
-        .split(QDir::listSeparator(), QString::SkipEmptyParts);
+        .split(QDir::listSeparator(), Qt::SkipEmptyParts);
   } else {
     return {};
   }


### PR DESCRIPTION
This was giving deprecation warnings.