### PR TITLE
Fix performing actions from the city screen

### DIFF
--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -750,7 +750,7 @@ bool unit_list_item::can_issue_orders() const
  */
 void unit_list_item::disband()
 {
-  if (!can_issue_orders()) {
+  if (can_issue_orders()) {
     auto *units = unit_list_new();
     unit_list_append(units, m_unit);
     popup_disband_dialog(units);
@@ -759,11 +759,11 @@ void unit_list_item::disband()
 }
 
 /**
-   Loads unit into some tranport
+   Loads unit into some transport
  */
 void unit_list_item::load()
 {
-  if (!can_issue_orders()) {
+  if (can_issue_orders()) {
     qtg_request_transport(m_unit, unit_tile(m_unit));
   }
 }
@@ -773,7 +773,7 @@ void unit_list_item::load()
  */
 void unit_list_item::unload()
 {
-  if (!can_issue_orders()) {
+  if (can_issue_orders()) {
     request_unit_unload(m_unit);
   }
 }
@@ -783,7 +783,7 @@ void unit_list_item::unload()
  */
 void unit_list_item::unload_all()
 {
-  if (!can_issue_orders()) {
+  if (can_issue_orders()) {
     request_unit_unload_all(m_unit);
   }
 }
@@ -793,7 +793,7 @@ void unit_list_item::unload_all()
  */
 void unit_list_item::upgrade()
 {
-  if (!can_issue_orders()) {
+  if (can_issue_orders()) {
     auto *units = unit_list_new();
     unit_list_append(units, m_unit);
     popup_upgrade_dialog(units);
@@ -802,7 +802,7 @@ void unit_list_item::upgrade()
 }
 
 /**
-   Changes homecity for given unit
+   Changes home city for given unit
  */
 void unit_list_item::change_homecity()
 {

--- a/client/gui-qt/citydlg.h
+++ b/client/gui-qt/citydlg.h
@@ -130,19 +130,6 @@ private:
 };
 
 /****************************************************************************
-  Pops up unit context menu
-****************************************************************************/
-class unit_list_event_filter : public QObject {
-  Q_OBJECT
-
-public:
-  explicit unit_list_event_filter(QObject *parent = nullptr);
-
-protected:
-  bool eventFilter(QObject *object, QEvent *event) override;
-};
-
-/****************************************************************************
   Single item on unit_info in city dialog representing one unit
 ****************************************************************************/
 class impr_item : public QLabel {


### PR DESCRIPTION
The condition in most if(can_issue_orders()) was reversed.
Closes #819.

------------

Remains to be seen if I'm the only one not getting the context menu at all. If not, I'll also add the fix to this PR.