### PR TITLE
Rewrite cm.{h,cpp} for more memory safety

### DIFF
--- a/ai/default/aihand.cpp
+++ b/ai/default/aihand.cpp
@@ -461,7 +461,7 @@ static void dai_manage_taxes(struct ai_type *ait, struct player *pplayer)
     // Check if we celebrate - the city state must be restored at the end!
     city_list_iterate(pplayer->cities, pcity)
     {
-      struct cm_result *cmr = cm_result_new(pcity);
+      auto cmr = cm_result_new(pcity);
       struct ai_city *city_data = def_ai_city_data(pcity, ait);
 
       cm_query_result(pcity, &cmp, cmr, false); // burn some CPU
@@ -476,7 +476,6 @@ static void dai_manage_taxes(struct ai_type *ait, struct player *pplayer)
       } else {
         city_data->celebrate = false;
       }
-      cm_result_destroy(cmr);
     }
     city_list_iterate_end;
 
@@ -646,7 +645,7 @@ static void dai_manage_taxes(struct ai_type *ait, struct player *pplayer)
 
     city_list_iterate(pplayer->cities, pcity)
     {
-      struct cm_result *cmr = cm_result_new(pcity);
+      auto cmr = cm_result_new(pcity);
 
       if (def_ai_city_data(pcity, ait)->celebrate) {
         log_base(LOGLEVEL_TAX, "setting %s to celebrate",
@@ -662,7 +661,6 @@ static void dai_manage_taxes(struct ai_type *ait, struct player *pplayer)
           CITY_LOG(LOG_ERROR, pcity, "has NO valid state!");
         }
       }
-      cm_result_destroy(cmr);
     }
     city_list_iterate_end;
   } else if (celebrate == AI_CELEBRATION_NO) {

--- a/common/aicore/cm.h
+++ b/common/aicore/cm.h
@@ -32,16 +32,17 @@ struct cm_result {
   int surplus[O_LAST];
 
   int city_radius_sq;
-  bool *worker_positions;
+  std::vector<bool> worker_positions;
   citizens specialists[SP_MAX];
+
+  ~cm_result() = default;
 };
 
 void cm_init();
 void cm_init_citymap();
 void cm_free();
 
-struct cm_result *cm_result_new(struct city *pcity);
-void cm_result_destroy(struct cm_result *result);
+std::unique_ptr<cm_result> cm_result_new(struct city *pcity);
 
 /*
  * Will try to meet the requirements and fill out the result. Caller
@@ -50,7 +51,7 @@ void cm_result_destroy(struct cm_result *result);
  */
 void cm_query_result(struct city *pcity,
                      const struct cm_parameter *const parameter,
-                     struct cm_result *result, bool negative_ok);
+                     std::unique_ptr<cm_result> &result, bool negative_ok);
 
 /***************** utility methods *************************************/
 bool operator==(const struct cm_parameter &p1,
@@ -61,11 +62,11 @@ void cm_init_parameter(struct cm_parameter *dest);
 void cm_init_emergency_parameter(struct cm_parameter *dest);
 
 void cm_print_city(const struct city *pcity);
-void cm_print_result(const struct cm_result *result);
+void cm_print_result(const std::unique_ptr<cm_result> &result);
 
-int cm_result_citizens(const struct cm_result *result);
-int cm_result_specialists(const struct cm_result *result);
-int cm_result_workers(const struct cm_result *result);
+int cm_result_citizens(const std::unique_ptr<cm_result> &result);
+int cm_result_specialists(const std::unique_ptr<cm_result> &result);
+int cm_result_workers(const std::unique_ptr<cm_result> &result);
 
-void cm_result_from_main_map(struct cm_result *result,
+void cm_result_from_main_map(std::unique_ptr<cm_result> &result,
                              const struct city *pcity);

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -282,7 +282,8 @@ void remove_obsolete_buildings(struct player *pplayer)
   Rearrange workers according to a cm_result struct.  The caller must make
   sure that the result is valid.
 **************************************************************************/
-void apply_cmresult_to_city(struct city *pcity, const struct cm_result *cmr)
+void apply_cmresult_to_city(struct city *pcity,
+                            const std::unique_ptr<cm_result> &cmr)
 {
   struct tile *pcenter = city_tile(pcity);
 
@@ -367,7 +368,6 @@ static void set_default_city_manager(struct cm_parameter *cmp,
 void auto_arrange_workers(struct city *pcity)
 {
   struct cm_parameter cmp;
-  struct cm_result *cmr;
 
   /* See comment in freeze_workers(): we can't rearrange while
    * workers are frozen (i.e. multiple updates need to be done). */
@@ -403,7 +403,7 @@ void auto_arrange_workers(struct city *pcity)
 
   /* This must be after city_refresh() so that the result gets created for
    * the right city radius */
-  cmr = cm_result_new(pcity);
+  auto cmr = cm_result_new(pcity);
   cm_query_result(pcity, &cmp, cmr, false);
 
   if (!cmr->found_a_valid) {
@@ -461,7 +461,6 @@ void auto_arrange_workers(struct city *pcity)
   }
   sanity_check_city(pcity);
 
-  cm_result_destroy(cmr);
   TIMING_LOG(AIT_CITIZEN_ARRANGE, TIMER_STOP);
 }
 

--- a/server/cityturn.h
+++ b/server/cityturn.h
@@ -25,7 +25,8 @@ void city_refresh_queue_add(struct city *pcity);
 void city_refresh_queue_processing();
 
 void auto_arrange_workers(struct city *pcity); // will arrange the workers
-void apply_cmresult_to_city(struct city *pcity, const struct cm_result *cmr);
+void apply_cmresult_to_city(struct city *pcity,
+                            const std::unique_ptr<cm_result> &cmr);
 
 bool city_change_size(struct city *pcity, citizens new_size,
                       struct player *nationality, const char *reason);


### PR DESCRIPTION
Use std::unique_ptr to prevent memory leaks or double free (there was a double
free in result_came_from_server). Also don't trust that the server sends CMA
results before PACKET_PROCESSING_FINISHED.

Closes #803.