### PR TITLE
Bombard limit effect

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -521,6 +521,11 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
                                     * active. Fortify bonus applies only in
                                     * special case that unit is fortified. */
     break;
+  case EFT_BOMBARD_LIMIT_PCT:
+    /* TODO: ideally should track bombard threats in adv */
+    num = num_affected_units(peffect, adv);
+    v += (num + 4) * amount / 250;
+    break;
   case EFT_GAIN_AI_LOVE:
     players_iterate(aplayer)
     {

--- a/common/effects.h
+++ b/common/effects.h
@@ -303,6 +303,8 @@
 #define SPECENUM_VALUE128NAME "Nuke_Improvement_Pct"
 #define SPECENUM_VALUE129 EFT_HP_REGEN_MIN
 #define SPECENUM_VALUE129NAME "HP_Regen_Min"
+#define SPECENUM_VALUE130 EFT_BOMBARD_LIMIT_PCT
+#define SPECENUM_VALUE130NAME "Bombard_Limit_Pct"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -13,7 +13,7 @@
 
 [datafile]
 description="Alien World effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -593,6 +593,10 @@ reqs	=
 [effect_pop_pollution]
 type	= "Pollu_Pop_Pct"
 value	= -100
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/civ1/effects.ruleset
+++ b/data/civ1/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ1 effects data for Freeciv (approximate)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -238,6 +238,10 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 [effect_trade_routes]
 type    = "Max_Trade_Routes"

--- a/data/civ2/effects.ruleset
+++ b/data/civ2/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2 effects data for Freeciv (incomplete)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -368,6 +368,10 @@ reqs    =
       "Specialist", "taxman", "Local"
       "OutputType", "gold", "Local"
     }
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -244,6 +244,10 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Airbase", "Local"
     }
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis or planes, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -117,6 +117,10 @@ reqs    =
 [effect_upkeep_tech_free]
 type    = "Tech_Upkeep_Free"
 value   = 3
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/experimental/effects.ruleset
+++ b/data/experimental/effects.ruleset
@@ -14,7 +14,7 @@
 
 [datafile]
 description="Experimental effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -131,6 +131,10 @@ reqs    =
 [effect_upkeep_tech_free]
 type    = "Tech_Upkeep_Free"
 value   = 3
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Granularity effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -111,6 +111,10 @@ reqs	=
     { "type", "name", "range"
       "Building", "Throne", "City"
     }
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -117,6 +117,10 @@ reqs    =
 [effect_upkeep_tech_free]
 type    = "Tech_Upkeep_Free"
 value   = 3
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -213,6 +213,10 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Airbase", "Local"
     }
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 [effect_hp_regen_base]

--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -244,6 +244,10 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Airbase", "Local"
     }
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis or planes, as they have hp_loss_pct=10
 ; All unit-types' hitpoints are divisible by 10, so no need to worry about rounding

--- a/data/stub/effects.ruleset
+++ b/data/stub/effects.ruleset
@@ -3,7 +3,7 @@
 
 [datafile]
 description="<modpack> effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/effects.ruleset
+++ b/data/webperimental/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Experimental web-client effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -117,6 +117,10 @@ reqs    =
 [effect_upkeep_tech_free]
 type    = "Tech_Upkeep_Free"
 value   = 3
+
+[effect_bomb_limit_base]
+type    = "Bombard_Limit_Pct"
+value   = 1
 
 ; Basic HP regen.  Not for helis, as they have hp_loss_pct=10
 [effect_hp_regen_base]

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -678,3 +678,11 @@ National_History
 Infra_Points
     City increases owner's infra points by value each turn. If overall points are negative after all cities
     have been processed, they are set to 0.
+
+Bombard_Limit_Pct
+    Bombardment may only reduce units to amount percent (rounded up) of their total hitpoints.  Unit
+    requirements on this effect are the defending unit itself.
+
+    .. note::
+        This effect is added automatically with a value of 1 and no reqs. This behavior can be turned
+        off by requiring the ``+Bombard_Limit_Pct`` option in ``effects.ruleset``.

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1128,6 +1128,25 @@ static void rscompat_optional_capabilities(rscompat_info *info)
     effect_req_append(effect, req_from_str("Activity", "Local", false, true,
                                            false, "Fortified"));
   }
+
+  if (!has_capabilities(info->cap_effects.data(),
+                        CAP_EFT_BOMBARD_LIMIT_PCT)) {
+    // Create new effect to replace the old hard-coded bombard limit
+
+    // 1% base bombard limit
+    effect_new(EFT_BOMBARD_LIMIT_PCT, 1, nullptr);
+    unit_type_iterate(putype)
+    {
+      if (putype->hp > 100) {
+        qCWarning(ruleset_category,
+                  "Ruleset has units (such as '%s"
+                  "') for which bombard limit changed as hp > 100",
+                  utype_name_translation(putype));
+        break;
+      }
+    }
+    unit_type_iterate_end;
+  }
 }
 
 /**

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -15,8 +15,10 @@
 #include <QLoggingCategory>
 
 #define CAP_EFT_HP_REGEN_MIN "HP_Regen_Min"
+#define CAP_EFT_BOMBARD_LIMIT_PCT "Bombard_Limit_Pct"
 #define RULESET_CAPABILITIES                                                \
-  "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN
+  "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN                \
+  " " CAP_EFT_BOMBARD_LIMIT_PCT
 /*
  * Ruleset capabilities acceptable to this program:
  *


### PR DESCRIPTION
Closes #731.

In my testing it appears that if there's no limit specified (so the min is 0), bombing a unit down to 0HP doesn't kill it immediately but it dies on the next TC (with the message "Your <unit_type> has run out of hitpoints").