### PR TITLE
Remove broken empty reqs vectors

### DIFF
--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -599,13 +599,11 @@ value	= -100
 [effect_hp_regen_base]
 type    = "HP_Regen"
 value   = 10
-reqs    = {}
 
 ; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
 [effect_hp_regen_min_base]
 type    = "HP_Regen_Min"
 value   = 10
-reqs    = {}
 
 ; Units in cities regenerate at least 1/3 of their HP regardless
 [effect_hp_regen_min_city]

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -117,13 +117,11 @@ reqs	=
 [effect_hp_regen_base]
 type    = "HP_Regen"
 value   = 10
-reqs    = {}
 
 ; When hardcoded, effect_hp_regen_base was applied after the HP_Regen_Min
 [effect_hp_regen_min_base]
 type    = "HP_Regen_Min"
 value   = 10
-reqs    = {}
 
 ; Units in cities regenerate at least 1/3 of their HP regardless
 [effect_hp_regen_min_city]


### PR DESCRIPTION
These syntax errors in 'alien' and 'granularity' effects prevented
 loading those rulesets.

Fixes: 1afb74e570 ("HP regen softcoding for all other bundled rulesets")