### PR TITLE
Add "unit" tests checking that shipped rulesets load

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,9 @@ jobs:
       - name: Build
         run: |
           cmake --build build
+      - name: Test
+        run: |
+          cmake --build build --target test
       - name: Install
         run: |
           DESTDIR=$PWD/build/install cmake --build build --target install
@@ -105,6 +108,9 @@ jobs:
       - name: Build
         run: |
           cmake --build build
+      - name: Test
+        run: |
+          cmake --build build --target test
       - name: Install
         run: |
           cmake --build build --target install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,10 @@ jobs:
       - name: Test
         run: |
           cmake --build build --target test
+      - name: Debug
+        if: failure()
+        run: |
+          cat build/Testing/Temporary/LastTest.log
       - name: Install
         run: |
           DESTDIR=$PWD/build/install cmake --build build --target install
@@ -111,6 +115,10 @@ jobs:
       - name: Test
         run: |
           cmake --build build --target test
+      - name: Debug
+        if: failure()
+        run: |
+          cat build/Testing/Temporary/LastTest.log
       - name: Install
         run: |
           cmake --build build --target install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,13 +112,6 @@ jobs:
       - name: Build
         run: |
           cmake --build build
-      - name: Test
-        run: |
-          cmake --build build --target test
-      - name: Debug
-        if: failure()
-        run: |
-          cat build/Testing/Temporary/LastTest.log
       - name: Install
         run: |
           cmake --build build --target install

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ cmake_install.cmake
 Makefile
 build.ninja
 *_autogen
+/Testing
 
 # Build directories
 /build*

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -164,3 +164,9 @@ endif()
 if (FREECIV_ENABLE_FCMP_CLI OR FREECIV_ENABLE_FCMP_QT)
   find_package(SQLite3 REQUIRED)
 endif()
+
+# Testing
+include(CTest)
+if (BUILD_TESTING)
+  find_package(Qt5Test REQUIRED)
+endif()

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -166,7 +166,9 @@ if (FREECIV_ENABLE_FCMP_CLI OR FREECIV_ENABLE_FCMP_QT)
 endif()
 
 # Testing
-include(CTest)
-if (BUILD_TESTING)
-  find_package(Qt5Test REQUIRED)
+if (NOT EMSCRIPTEN)
+  include(CTest)
+  if (BUILD_TESTING)
+    find_package(Qt5Test REQUIRED)
+  endif()
 endif()

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(RULESET_LIST)
+
 function(add_ruleset)
   cmake_parse_arguments(ARG "SERV_FILE" "NAME;README" "" ${ARGN})
   if (ARG_SERV_FILE)
@@ -12,6 +14,8 @@ function(add_ruleset)
       DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/${ARG_NAME}"
       COMPONENT freeciv21)
   endif()
+  list(APPEND RULESET_LIST ${ARG_NAME})
+  set(RULESET_LIST "${RULESET_LIST}" PARENT_SCOPE)
   install(
     FILES
     ${ARG_NAME}/buildings.ruleset
@@ -75,6 +79,13 @@ if (FREECIV_ENABLE_SERVER OR FREECIV_ENABLE_RULEDIT)
     FILES override/nation.ruleset
     DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/override"
     COMPONENT freeciv21)
+
+  # Ruleset tests
+  if (BUILD_TESTING AND FREECIV_ENABLE_SERVER)
+    # The stub ruleset isn't installed, but we test it
+    list(APPEND RULESET_LIST stub)
+    add_subdirectory(tests)
+  endif()
 endif()
 
 if (FREECIV_ENABLE_SERVER)

--- a/data/tests/CMakeLists.txt
+++ b/data/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(CMAKE_AUTOMOC ON)
+
+enable_testing(true)
+
+# Turn the list of rulesets into something C++ will understand
+list(JOIN RULESET_LIST "\", \"" ruleset_list_cpp)
+if (NOT ${ruleset_list_cpp} STREQUAL "")
+  set(ruleset_list_cpp "\"${ruleset_list_cpp}\"")
+endif()
+
+# Create the test file. This is ugly because we need to replace variables
+# and use generator expressions.
+configure_file(rulesets.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp.in)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp
+              INPUT ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp.in)
+
+add_executable(test_rulesets ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp)
+add_test(NAME test_rulesets COMMAND test_rulesets)
+target_link_libraries(test_rulesets PRIVATE Qt5::Test)

--- a/data/tests/CMakeLists.txt
+++ b/data/tests/CMakeLists.txt
@@ -15,5 +15,7 @@ file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp
               INPUT ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp.in)
 
 add_executable(test_rulesets ${CMAKE_CURRENT_BINARY_DIR}/rulesets.cpp)
-add_test(NAME test_rulesets COMMAND test_rulesets)
 target_link_libraries(test_rulesets PRIVATE Qt5::Test)
+add_test(NAME test_rulesets
+         COMMAND test_rulesets
+         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")

--- a/data/tests/rulesets.cpp.in
+++ b/data/tests/rulesets.cpp.in
@@ -51,9 +51,9 @@ void test_rulesets::load()
 
   QCOMPARE(p.state(), QProcess::NotRunning);
   if (exists) {
-    QCOMPARE(p.exitCode(), 0);
+    QCOMPARE(p.exitCode(), EXIT_SUCCESS);
   } else {
-    QCOMPARE(p.exitCode(), 1);
+    QCOMPARE(p.exitCode(), EXIT_FAILURE);
   }
 }
 

--- a/data/tests/rulesets.cpp.in
+++ b/data/tests/rulesets.cpp.in
@@ -49,6 +49,7 @@ void test_rulesets::load()
   p.closeWriteChannel();
   p.waitForFinished(5000);
 
+  QCOMPARE(p.state(), QProcess::NotRunning);
   if (exists) {
     QCOMPARE(p.exitCode(), 0);
   } else {

--- a/data/tests/rulesets.cpp.in
+++ b/data/tests/rulesets.cpp.in
@@ -1,0 +1,60 @@
+#include <QProcess>
+
+#include <QtTest>
+
+// Macro values replaced by cmake
+#define RULESETS "$<JOIN:${RULESET_LIST},", ">"
+#define SERVER_PATH "$<TARGET_FILE:freeciv21-server>"
+
+/**
+ * Ruleset-related tests
+ */
+class test_rulesets : public QObject {
+  Q_OBJECT
+
+private slots:
+  void load_data();
+  void load();
+};
+
+/**
+ * Generates test data for load()
+ */
+void test_rulesets::load_data()
+{
+  QTest::addColumn<QString>("name");
+  QTest::addColumn<bool>("exists");
+
+  const char *names[] = {"default", RULESETS};
+  for (auto &name : names) {
+    QTest::newRow(name) << name << true;
+  }
+
+  // A ruleset that doesn't exist
+  QTest::newRow("error") << "error" << false;
+}
+
+/**
+ * Tries to spawn a server with a ruleset.
+ */
+void test_rulesets::load()
+{
+  QFETCH(QString, name);
+  QFETCH(bool, exists);
+
+  QProcess p;
+  p.start(SERVER_PATH, {QStringLiteral("-r"), name});
+  p.waitForStarted();
+  p.write("quit\n");
+  p.closeWriteChannel();
+  p.waitForFinished(5000);
+
+  if (exists) {
+    QCOMPARE(p.exitCode(), 0);
+  } else {
+    QCOMPARE(p.exitCode(), 1);
+  }
+}
+
+QTEST_MAIN(test_rulesets)
+#include "rulesets.moc"

--- a/docs/Contributing/eval-pull-request.rst
+++ b/docs/Contributing/eval-pull-request.rst
@@ -46,6 +46,11 @@ This page assumes the user knows how to use :file:`git`, compile Freeciv21 and u
   $ cmake --build build --target install
   $ cmake --build build --target package      # MSys2 Only
 
+:strong:`Run tests`
+
+..code-block:: sh
+
+  $ cmake --build build --target test
 
 :strong:`Read The Issue's Notes`
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -116,3 +116,8 @@ add_dependencies(freeciv21-server freeciv_translations)
 install(TARGETS freeciv21-server
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT freeciv21)
+
+# Tests
+if (BUILD_TESTING AND FREECIV_ENABLE_SERVER)
+  add_subdirectory(tests)
+endif()

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -538,6 +538,8 @@ void server::input_on_stdin()
     // Read from the input
     QFile f;
     f.open(stdin, QIODevice::ReadOnly);
+    // Force it to try and read something.
+    f.peek(1);
     if (f.atEnd() && m_stdin_notifier != nullptr) {
       // QSocketNotifier gets mad after EOF. Turn it off.
       m_stdin_notifier->deleteLater();

--- a/server/server.h
+++ b/server/server.h
@@ -45,7 +45,7 @@ private slots:
   void send_pings();
 
   // Higher-level stuff
-  void prepare_game();
+  bool prepare_game();
   void begin_turn();
   void begin_phase();
   void end_phase();

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(CMAKE_AUTOMOC ON)
+
+# Create the test file. This is ugly because we need to replace variables
+# and use generator expressions.
+configure_file(cli.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/cli.cpp.in)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cli.cpp
+              INPUT ${CMAKE_CURRENT_BINARY_DIR}/cli.cpp.in)
+
+add_executable(test_server_cli ${CMAKE_CURRENT_BINARY_DIR}/cli.cpp)
+target_link_libraries(test_server_cli PRIVATE Qt5::Test)
+add_test(NAME test_server_cli
+         COMMAND test_server_cli
+         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")

--- a/server/tests/cli.cpp.in
+++ b/server/tests/cli.cpp.in
@@ -1,0 +1,64 @@
+#include <QProcess>
+
+#include <QtTest>
+
+// Macro values replaced by cmake
+#define DATA_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cli/"
+#define SERVER_PATH "$<TARGET_FILE:freeciv21-server>"
+
+/**
+ * Ruleset-related tests
+ */
+class test_cli : public QObject {
+  Q_OBJECT
+
+private slots:
+  void read_data();
+  void read();
+};
+
+/**
+ * Generates test data for read()
+ */
+void test_cli::read_data()
+{
+  QTest::addColumn<QString>("file");
+  QTest::addColumn<bool>("success");
+
+  // Empty files are allowed
+  QTest::newRow("empty") << "empty.serv" << true;
+  // Comments don't make it fail
+  QTest::newRow("comment") << "comment.serv" << true;
+  // The `set' command works
+  QTest::newRow("set") << "set.serv" << true;
+  // Re-reading the default ruleset works
+  QTest::newRow("reread") << "reread.serv" << true;
+  // Unknown commands are rejected
+  QTest::newRow("unknown") << "unknown.serv" << false;
+}
+
+/**
+ * Tests the -r option.
+ */
+void test_cli::read()
+{
+  QFETCH(QString, file);
+  QFETCH(bool, success);
+
+  QProcess p;
+  p.start(SERVER_PATH, {QStringLiteral("-r"), QStringLiteral(DATA_PATH) + file});
+  p.waitForStarted();
+  p.write("quit\n");
+  p.closeWriteChannel();
+  p.waitForFinished(5000);
+
+  QCOMPARE(p.state(), QProcess::NotRunning);
+  if (success) {
+    QCOMPARE(p.exitCode(), EXIT_SUCCESS);
+  } else {
+    QCOMPARE(p.exitCode(), EXIT_FAILURE);
+  }
+}
+
+QTEST_MAIN(test_cli)
+#include "cli.moc"

--- a/server/tests/cli/comment.serv
+++ b/server/tests/cli/comment.serv
@@ -1,0 +1,2 @@
+# This file only contains comments and empty lines
+# Note that unlike most files in Freeciv, .serv file don't accept ; comments

--- a/server/tests/cli/reread.serv
+++ b/server/tests/cli/reread.serv
@@ -1,1 +1,1 @@
-rulesetdir default
+read default

--- a/server/tests/cli/reread.serv
+++ b/server/tests/cli/reread.serv
@@ -1,0 +1,1 @@
+rulesetdir default

--- a/server/tests/cli/set.serv
+++ b/server/tests/cli/set.serv
@@ -1,0 +1,2 @@
+set unitwaittime 0
+/set unitwaittime 0

--- a/server/tests/cli/unknown.serv
+++ b/server/tests/cli/unknown.serv
@@ -1,0 +1,1 @@
+/unknown command


### PR DESCRIPTION
Also made me fix issues with the server CLI.

The tests pass on Windows when run from the MSYS terminal, but not in Github actions. The issue is that the server never reacts to the `quit` command sent by the test; `stdin` on Windows is a disaster.