### PR TITLE
Improve zoom

### DIFF
--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -460,10 +460,8 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
     return QRect();
   }
 
-  // Select the tileset to grab stuff from
-  const auto t = (gui_options.zoom_scale_fonts || !unscaled_tileset)
-                     ? tileset
-                     : unscaled_tileset;
+  // Get the tileset to grab stuff from
+  const auto t = get_tileset();
 
   // Get some city properties
   const citybar_sprites *citybar = get_citybar_sprites(t);
@@ -621,10 +619,8 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   const bool should_draw_trade_routes =
       can_see_inside && gui_options.draw_city_trade_routes;
 
-  // Select the tileset to grab stuff from
-  const auto t = (gui_options.zoom_scale_fonts || !unscaled_tileset)
-                     ? tileset
-                     : unscaled_tileset;
+  // Get the tileset to grab stuff from
+  const auto t = get_tileset();
 
   // Get some city properties
   const citybar_sprites *citybar = get_citybar_sprites(t);

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -664,9 +664,6 @@ void client_exit()
   }
 
   overview_free();
-  if (unscaled_tileset != NULL) {
-    tileset_free(unscaled_tileset);
-  }
   tileset_free(tileset);
 
   ui_exit();

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -368,11 +368,10 @@ QFont get_font(client_font font)
 
   switch (font) {
   case FONT_CITY_NAME:
-    qf = fcFont::instance()->getFont(fonts::city_names, king()->map_scale);
+    qf = fcFont::instance()->getFont(fonts::city_names, 1);
     break;
   case FONT_CITY_PROD:
-    qf = fcFont::instance()->getFont(fonts::city_productions,
-                                     king()->map_scale);
+    qf = fcFont::instance()->getFont(fonts::city_productions, 1);
     break;
   case FONT_REQTREE_TEXT:
     qf = fcFont::instance()->getFont(fonts::reqtree_text);

--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -934,7 +934,7 @@ void city_label::set_type(int x) { type = x; }
 void city_label::mousePressEvent(QMouseEvent *event)
 {
   int citnum, i, num_citizens, nothing_width;
-  int w = tileset_small_sprite_width(tileset) / king()->map_scale;
+  int w = tileset_small_sprite_width(tileset);
 
   if (!pcity) {
     return;
@@ -2021,8 +2021,8 @@ void city_dialog::update_citizens()
   QPainter p;
   int num_citizens =
       get_city_citizen_types(pcity, FEELING_FINAL, categories);
-  int w = tileset_small_sprite_width(tileset) / king()->map_scale;
-  int h = tileset_small_sprite_height(tileset) / king()->map_scale;
+  int w = tileset_small_sprite_width(tileset);
+  int h = tileset_small_sprite_height(tileset);
 
   i = 1 + (num_citizens * 5 / 200);
   w = w / i;
@@ -2122,9 +2122,11 @@ void city_dialog::refresh()
   ui.production_combo_p->blockSignals(false);
   setUpdatesEnabled(true);
 
-  ui.middleSpacer->changeSize(
-      get_citydlg_canvas_width(), get_citydlg_canvas_height(),
-      QSizePolicy::Expanding, QSizePolicy::Expanding);
+  auto scale = queen()->mapview_wdg->scale();
+  ui.middleSpacer->changeSize(scale * get_citydlg_canvas_width(),
+                              scale * get_citydlg_canvas_height(),
+                              QSizePolicy::Expanding,
+                              QSizePolicy::Expanding);
 
   updateGeometry();
   update();

--- a/client/gui-qt/citydlg.cpp
+++ b/client/gui-qt/citydlg.cpp
@@ -592,14 +592,8 @@ static QImage create_unit_image(unit *punit, bool supported, int happy_cost)
   QImage img;
   QRect crop;
   QPixmap *unit_pixmap;
-  struct tileset *tmp;
   float isosize;
 
-  tmp = nullptr;
-  if (unscaled_tileset) {
-    tmp = tileset;
-    tileset = unscaled_tileset;
-  }
   isosize = 0.6;
   if (tileset_hex_height(tileset) > 0 || tileset_hex_width(tileset) > 0) {
     isosize = 0.45;
@@ -642,9 +636,6 @@ static QImage create_unit_image(unit *punit, bool supported, int happy_cost)
                                           Qt::SmoothTransformation);
   }
   canvas_free(unit_pixmap);
-  if (tmp != nullptr) {
-    tileset = tmp;
-  }
 
   return unit_img;
 }

--- a/client/gui-qt/citydlg.h
+++ b/client/gui-qt/citydlg.h
@@ -10,8 +10,8 @@
 #pragma once
 
 #include "fc_types.h"
+
 // Qt
-#include "fc_types.h"
 #include <QDialog>
 #include <QElapsedTimer>
 #include <QGroupBox>

--- a/client/gui-qt/dialogs.cpp
+++ b/client/gui-qt/dialogs.cpp
@@ -3309,8 +3309,7 @@ void popup_tileset_suggestion_dialog(void)
 
   QObject::connect(ask, &hud_message_box::accepted, [=]() {
     forced_tileset_name = game.control.preferred_tileset;
-    if (!tilespec_reread(game.control.preferred_tileset, true,
-                         king()->map_scale)) {
+    if (!tilespec_reread(game.control.preferred_tileset, true, 1)) {
       tileset_error(nullptr, LOG_ERROR,
                     _("Can't load requested tileset %s."),
                     game.control.preferred_tileset);

--- a/client/gui-qt/dialogs.cpp
+++ b/client/gui-qt/dialogs.cpp
@@ -3309,7 +3309,7 @@ void popup_tileset_suggestion_dialog(void)
 
   QObject::connect(ask, &hud_message_box::accepted, [=]() {
     forced_tileset_name = game.control.preferred_tileset;
-    if (!tilespec_reread(game.control.preferred_tileset, true, 1)) {
+    if (!tilespec_reread(game.control.preferred_tileset, true)) {
       tileset_error(nullptr, LOG_ERROR,
                     _("Can't load requested tileset %s."),
                     game.control.preferred_tileset);

--- a/client/gui-qt/fc_client.h
+++ b/client/gui-qt/fc_client.h
@@ -126,7 +126,6 @@ public:
   bool interface_locked{false};
   fc_corner *corner_wid;
   fc_settings qt_settings;
-  float map_scale{1.0f};
   mr_menu *menu_bar{nullptr};
   qfc_rally_list rallies;
   trade_generator trade_gen;

--- a/client/gui-qt/hudwidget.cpp
+++ b/client/gui-qt/hudwidget.cpp
@@ -577,7 +577,6 @@ void hud_units::update_actions(unit_list *punits)
   QPixmap *unit_pixmap;
   struct city *pcity;
   struct player *owner;
-  struct tileset *tmp;
   struct unit *punit;
 
   punit = head_of_units_in_focus();
@@ -599,11 +598,6 @@ void hud_units::update_actions(unit_list *punits)
 
   setUpdatesEnabled(false);
 
-  tmp = nullptr;
-  if (unscaled_tileset) {
-    tmp = tileset;
-    tileset = unscaled_tileset;
-  }
   owner = punit->owner;
   pcity = player_city_by_number(owner, punit->homecity);
   if (punit->name.isEmpty()) {
@@ -781,9 +775,6 @@ void hud_units::update_actions(unit_list *punits)
                 + qMax(unit_icons->update_actions() * (height() * 8) / 10,
                        text_label.width()));
   mw->put_to_corner();
-  if (tmp != nullptr) {
-    tileset = tmp;
-  }
   setUpdatesEnabled(true);
   updateGeometry();
   update();

--- a/client/gui-qt/mapctrl.cpp
+++ b/client/gui-qt/mapctrl.cpp
@@ -339,7 +339,7 @@ void map_view::shortcut_pressed(int key)
     sc = fc_shortcuts::sc()->get_shortcut(SC_RELOAD_TILESET);
     if (((key && key == sc->key) || bt == sc->mouse) && md == sc->mod) {
       QPixmapCache::clear();
-      tilespec_reread(tileset_basename(tileset), true, 1);
+      tilespec_reread(tileset_basename(tileset), true);
       return;
     }
 

--- a/client/gui-qt/mapctrl.cpp
+++ b/client/gui-qt/mapctrl.cpp
@@ -80,7 +80,8 @@ void create_line_at_mouse_pos(void)
   int x, y;
 
   global_pos = QCursor::pos();
-  local_pos = queen()->mapview_wdg->mapFromGlobal(global_pos);
+  local_pos = queen()->mapview_wdg->mapFromGlobal(global_pos)
+              / queen()->mapview_wdg->scale();
   x = local_pos.x();
   y = local_pos.y();
 
@@ -105,6 +106,8 @@ void map_view::keyPressEvent(QKeyEvent *event)
   Qt::KeyboardModifiers key_mod = QApplication::keyboardModifiers();
   bool is_shift = key_mod.testFlag(Qt::ShiftModifier);
 
+  auto scale = queen()->mapview_wdg->scale();
+
   if (C_S_RUNNING == client_state()) {
     if (is_shift) {
       switch (event->key()) {
@@ -121,7 +124,8 @@ void map_view::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Up:
     case Qt::Key_8:
       if (is_shift) {
-        recenter_button_pressed(queen()->mapview_wdg->width() / 2, 0);
+        recenter_button_pressed(queen()->mapview_wdg->width() / 2 / scale,
+                                0);
       } else {
         key_unit_move(DIR8_NORTH);
       }
@@ -129,7 +133,8 @@ void map_view::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Left:
     case Qt::Key_4:
       if (is_shift) {
-        recenter_button_pressed(0, queen()->mapview_wdg->height() / 2);
+        recenter_button_pressed(0,
+                                queen()->mapview_wdg->height() / 2 / scale);
       } else {
         key_unit_move(DIR8_WEST);
       }
@@ -137,8 +142,8 @@ void map_view::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Right:
     case Qt::Key_6:
       if (is_shift) {
-        recenter_button_pressed(queen()->mapview_wdg->width(),
-                                queen()->mapview_wdg->height() / 2);
+        recenter_button_pressed(queen()->mapview_wdg->width() / scale,
+                                queen()->mapview_wdg->height() / 2 / scale);
       } else {
         key_unit_move(DIR8_EAST);
       }
@@ -146,8 +151,8 @@ void map_view::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Down:
     case Qt::Key_2:
       if (is_shift) {
-        recenter_button_pressed(queen()->mapview_wdg->width() / 2,
-                                queen()->mapview_wdg->height());
+        recenter_button_pressed(queen()->mapview_wdg->width() / 2 / scale,
+                                queen()->mapview_wdg->height() / scale);
       } else {
         key_unit_move(DIR8_SOUTH);
       }
@@ -208,7 +213,7 @@ void map_view::shortcut_pressed(int key)
 
   md = QApplication::keyboardModifiers();
   bt = QApplication::mouseButtons();
-  pos = mapFromGlobal(QCursor::pos());
+  pos = mapFromGlobal(QCursor::pos()) / scale();
 
   ptile = canvas_pos_to_tile(pos.x(), pos.y());
   pcity = ptile ? tile_city(ptile) : nullptr;
@@ -220,7 +225,6 @@ void map_view::shortcut_pressed(int key)
   // Trade Generator - skip
   sc = fc_shortcuts::sc()->get_shortcut(SC_SELECT_BUTTON);
   if (bt == sc->mouse && md == sc->mod && king()->trade_gen.hover_city) {
-    ptile = canvas_pos_to_tile(pos.x(), pos.y());
     king()->trade_gen.add_tile(ptile);
     queen()->mapview_wdg->repaint();
     return;
@@ -230,7 +234,6 @@ void map_view::shortcut_pressed(int key)
   if (bt == sc->mouse && md == sc->mod && king()->rallies.hover_city) {
     char text[1024];
 
-    ptile = canvas_pos_to_tile(pos.x(), pos.y());
     if (tile_city(ptile)) {
       king()->rallies.hover_tile = true;
       king()->rallies.rally_city = tile_city(ptile);
@@ -270,7 +273,6 @@ void map_view::shortcut_pressed(int key)
   }
 
   if (bt == Qt::LeftButton && king()->menu_bar->delayed_order) {
-    ptile = canvas_pos_to_tile(pos.x(), pos.y());
     king()->menu_bar->set_tile_for_order(ptile);
     clear_hover_state();
     exit_goto_state();
@@ -282,7 +284,6 @@ void map_view::shortcut_pressed(int key)
     queen()->infotab->restore_chat();
   }
   if (bt == Qt::LeftButton && king()->menu_bar->quick_airlifting) {
-    ptile = canvas_pos_to_tile(pos.x(), pos.y());
     if (tile_city(ptile)) {
       multiairlift(tile_city(ptile), king()->menu_bar->airlift_type_id);
     } else {
@@ -338,7 +339,7 @@ void map_view::shortcut_pressed(int key)
     sc = fc_shortcuts::sc()->get_shortcut(SC_RELOAD_TILESET);
     if (((key && key == sc->key) || bt == sc->mouse) && md == sc->mod) {
       QPixmapCache::clear();
-      tilespec_reread(tileset_basename(tileset), true, king()->map_scale);
+      tilespec_reread(tileset_basename(tileset), true, 1);
       return;
     }
 
@@ -434,7 +435,7 @@ void map_view::shortcut_released(Qt::MouseButton bt)
   fc_shortcut *sc;
   Qt::KeyboardModifiers md;
   md = QApplication::keyboardModifiers();
-  pos = mapFromGlobal(QCursor::pos());
+  pos = mapFromGlobal(QCursor::pos()) / scale();
 
   sc = fc_shortcuts::sc()->get_shortcut(SC_POPUP_INFO);
   if (bt == sc->mouse && md == sc->mod) {
@@ -484,10 +485,11 @@ void map_view::mouseReleaseEvent(QMouseEvent *event)
  */
 void map_view::mouseMoveEvent(QMouseEvent *event)
 {
-  update_line(event->pos().x(), event->pos().y());
+  update_line(event->pos().x() / scale(), event->pos().y() / scale());
   if (keyboardless_goto_button_down && hover_state == HOVER_NONE) {
-    maybe_activate_keyboardless_goto(event->pos().x(), event->pos().y());
+    maybe_activate_keyboardless_goto(event->pos().x() / scale(),
+                                     event->pos().y() / scale());
   }
-  control_mouse_cursor(
-      canvas_pos_to_tile(event->pos().x(), event->pos().y()));
+  control_mouse_cursor(canvas_pos_to_tile(event->pos().x() / scale(),
+                                          event->pos().y() / scale()));
 }

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -218,6 +218,8 @@ void map_view::set_scale_now(double scale)
   // When zoomed in, we pretend that the canvas is smaller than it is. This
   // makes text look bad, but everything else is drawn correctly.
   map_canvas_resized(width() / m_scale, height() / m_scale);
+
+  emit scale_changed(m_scale);
 }
 
 /**

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -606,7 +606,7 @@ void tileset_changed(void)
       debugger != nullptr) {
     // When not zoomed in, unscaled_tileset is null
     // When zoomed in, unscaled_tileset is not null and holds the log
-    debugger->refresh(unscaled_tileset ? unscaled_tileset : tileset);
+    debugger->refresh(tileset);
   }
 
   update_unit_info_label(get_units_in_focus());

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -138,7 +138,9 @@ void draw_calculated_trade_routes(QPainter *painter)
 /**
    Constructor for map
  */
-map_view::map_view() : QWidget()
+map_view::map_view()
+    : QWidget(),
+      m_scale_animation(std::make_unique<QPropertyAnimation>(this, "scale"))
 {
   menu_click = false;
   cursor = -1;
@@ -199,6 +201,18 @@ void map_view::show_all_fcwidgets()
  * Sets the map scale.
  */
 void map_view::set_scale(double scale)
+{
+  m_scale_animation->stop();
+  m_scale_animation->setDuration(100);
+  m_scale_animation->setEndValue(scale);
+  m_scale_animation->setCurrentTime(0);
+  m_scale_animation->start();
+}
+
+/**
+ * Sets the map scale immediately without doing any animation.
+ */
+void map_view::set_scale_now(double scale)
 {
   m_scale = scale;
   // When zoomed in, we pretend that the canvas is smaller than it is. This

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -703,9 +703,6 @@ void info_tile::calc_size()
 {
   QFontMetrics fm(info_font);
   QString str;
-  int hh = tileset_tile_height(tileset);
-  int fin_x;
-  int fin_y;
   float x, y;
   int w = 0;
 
@@ -718,17 +715,17 @@ void info_tile::calc_size()
   setFixedHeight(str_list.count() * (fm.height() + 5));
   setFixedWidth(w + 10);
   if (tile_to_canvas_pos(&x, &y, itile)) {
-    fin_x = x;
-    fin_y = y;
+    x *= queen()->mapview_wdg->scale();
+    y *= queen()->mapview_wdg->scale();
     if (y - height() > 0) {
-      fin_y = y - height();
+      y -= height();
     } else {
-      fin_y = y + hh;
+      int hh = tileset_tile_height(tileset) * queen()->mapview_wdg->scale();
+      y += hh;
     }
-    if (x + width() > parentWidget()->width()) {
-      fin_x = parentWidget()->width() - width();
-    }
-    move(fin_x, fin_y);
+    // Make sure it's visible
+    x = std::clamp(int(x), 0, parentWidget()->width() - width());
+    move(x, y);
   }
 }
 

--- a/client/gui-qt/mapview.cpp
+++ b/client/gui-qt/mapview.cpp
@@ -196,7 +196,18 @@ void map_view::show_all_fcwidgets()
 }
 
 /**
- * Ppens the tileset debugger.
+ * Sets the map scale.
+ */
+void map_view::set_scale(double scale)
+{
+  m_scale = scale;
+  // When zoomed in, we pretend that the canvas is smaller than it is. This
+  // makes text look bad, but everything else is drawn correctly.
+  map_canvas_resized(width() / m_scale, height() / m_scale);
+}
+
+/**
+ * Opens the tileset debugger.
  */
 void map_view::show_debugger()
 {
@@ -295,7 +306,16 @@ void map_view::paintEvent(QPaintEvent *event)
  */
 void map_view::paint(QPainter *painter, QPaintEvent *event)
 {
-  painter->drawPixmap(event->rect(), *mapview.store, event->rect());
+  if (scale() != 1) {
+    painter->setRenderHint(QPainter::SmoothPixmapTransform);
+  }
+  auto widget_rect = QRectF(event->rect());
+  auto mapview_rect =
+      QRectF(widget_rect.left() / scale(), widget_rect.top() / scale(),
+             widget_rect.width() / scale(), widget_rect.height() / scale());
+  painter->drawPixmap(widget_rect, *mapview.store, mapview_rect);
+
+  painter->scale(1 / scale(), 1 / scale());
   draw_calculated_trade_routes(painter);
 }
 
@@ -460,8 +480,9 @@ void update_turn_done_button(bool do_restore)
 static void flush_mapcanvas(int canvas_x, int canvas_y, int pixel_width,
                             int pixel_height)
 {
-  queen()->mapview_wdg->repaint(canvas_x, canvas_y, pixel_width,
-                                pixel_height);
+  auto scale = queen()->mapview_wdg->scale();
+  queen()->mapview_wdg->repaint(canvas_x * scale, canvas_y * scale,
+                                pixel_width * scale, pixel_height * scale);
 }
 
 /**
@@ -505,8 +526,9 @@ void flush_dirty(void)
     return;
   }
   if (num_dirty_rects == MAX_DIRTY_RECTS) {
-    flush_mapcanvas(0, 0, queen()->mapview_wdg->width(),
-                    queen()->mapview_wdg->height());
+    flush_mapcanvas(
+        0, 0, queen()->mapview_wdg->width() / queen()->mapview_wdg->scale(),
+        queen()->mapview_wdg->height() / queen()->mapview_wdg->scale());
   } else {
     int i;
 

--- a/client/gui-qt/mapview.h
+++ b/client/gui-qt/mapview.h
@@ -63,9 +63,13 @@ public:
 
   bool menu_click;
 
+  double scale() const { return m_scale; }
+
   freeciv::tileset_debugger *debugger() const { return m_debugger; }
 
 public slots:
+  void set_scale(double scale);
+
   void show_debugger();
   void hide_debugger();
 
@@ -86,6 +90,7 @@ private:
   bool stored_autocenter;
   int cursor_frame{0};
   int cursor;
+  double m_scale = 1;
   QPointer<freeciv::tileset_debugger> m_debugger = nullptr;
   std::vector<fcwidget *> m_hidden_fcwidgets;
 };

--- a/client/gui-qt/mapview.h
+++ b/client/gui-qt/mapview.h
@@ -13,6 +13,7 @@
 #include <QFrame>
 #include <QLabel>
 #include <QPointer>
+#include <QPropertyAnimation>
 #include <QQueue>
 #include <QThread>
 #include <QTimer>
@@ -42,6 +43,7 @@ void draw_calculated_trade_routes(QPainter *painter);
 **************************************************************************/
 class map_view : public QWidget {
   Q_OBJECT
+  Q_PROPERTY(double scale READ scale WRITE set_scale_now);
 
   // Ought to be a private slot
   friend void debug_tile(tile *tile);
@@ -81,7 +83,9 @@ protected:
   void mouseMoveEvent(QMouseEvent *event) override;
   void focusOutEvent(QFocusEvent *event) override;
   void leaveEvent(QEvent *event) override;
+
 private slots:
+  void set_scale_now(double scale);
   void timer_event();
 
 private:
@@ -91,6 +95,7 @@ private:
   int cursor_frame{0};
   int cursor;
   double m_scale = 1;
+  std::unique_ptr<QPropertyAnimation> m_scale_animation;
   QPointer<freeciv::tileset_debugger> m_debugger = nullptr;
   std::vector<fcwidget *> m_hidden_fcwidgets;
 };

--- a/client/gui-qt/mapview.h
+++ b/client/gui-qt/mapview.h
@@ -43,7 +43,8 @@ void draw_calculated_trade_routes(QPainter *painter);
 **************************************************************************/
 class map_view : public QWidget {
   Q_OBJECT
-  Q_PROPERTY(double scale READ scale WRITE set_scale_now);
+  Q_PROPERTY(
+      double scale READ scale WRITE set_scale_now NOTIFY scale_changed);
 
   // Ought to be a private slot
   friend void debug_tile(tile *tile);
@@ -68,6 +69,9 @@ public:
   double scale() const { return m_scale; }
 
   freeciv::tileset_debugger *debugger() const { return m_debugger; }
+
+signals:
+  void scale_changed(double scale) const;
 
 public slots:
   void set_scale(double scale);

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -2591,18 +2591,13 @@ void mr_menu::slot_city_growth() { key_city_growth_toggle(); }
  */
 void mr_menu::zoom_in()
 {
-  king()->map_scale = king()->map_scale * 1.2f;
-  tilespec_reread(tileset_basename(tileset), true, king()->map_scale, true);
+  queen()->mapview_wdg->set_scale(1.2 * queen()->mapview_wdg->scale());
 }
 
 /**
    Action "RESET ZOOM TO DEFAULT"
  */
-void mr_menu::zoom_reset()
-{
-  king()->map_scale = 1.0f;
-  tilespec_reread(tileset_basename(tileset), true, king()->map_scale, true);
-}
+void mr_menu::zoom_reset() { queen()->mapview_wdg->set_scale(1); }
 
 /**
    Action "SCALE FONTS WHEN SCALING MAP"
@@ -2618,8 +2613,7 @@ void mr_menu::zoom_scale_fonts()
  */
 void mr_menu::zoom_out()
 {
-  king()->map_scale = king()->map_scale / 1.2f;
-  tilespec_reread(tileset_basename(tileset), true, king()->map_scale, true);
+  queen()->mapview_wdg->set_scale(queen()->mapview_wdg->scale() / 1.2);
 }
 
 /**
@@ -2828,7 +2822,7 @@ void mr_menu::load_new_tileset()
   but = qobject_cast<QPushButton *>(sender());
   tn_bytes = but->text().toLocal8Bit();
   tilespec_reread(tn_bytes.data(), true, 1.0f);
-  king()->map_scale = 1.0f;
+  queen()->mapview_wdg->set_scale(1.0);
   but->parentWidget()->close();
 }
 

--- a/client/gui-qt/menu.cpp
+++ b/client/gui-qt/menu.cpp
@@ -2821,7 +2821,7 @@ void mr_menu::load_new_tileset()
 
   but = qobject_cast<QPushButton *>(sender());
   tn_bytes = but->text().toLocal8Bit();
-  tilespec_reread(tn_bytes.data(), true, 1.0f);
+  tilespec_reread(tn_bytes.data(), true);
   queen()->mapview_wdg->set_scale(1.0);
   but->parentWidget()->close();
 }

--- a/client/gui-qt/page_game.cpp
+++ b/client/gui-qt/page_game.cpp
@@ -128,6 +128,8 @@ pageGame::pageGame(QWidget *parent)
   civ_status->show();
 
   city_overlay = new city_dialog(mapview_wdg);
+  connect(mapview_wdg, &map_view::scale_changed, city_overlay,
+          &city_dialog::refresh);
   city_overlay->hide();
   minimapview_wdg = new minimap_view(mapview_wdg);
   minimapview_wdg->setAttribute(Qt::WA_NoMousePropagation);

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -43,7 +43,7 @@ void qtg_get_sprite_dimensions(const QPixmap *sprite, int *width,
                                int *height);
 QPixmap *qtg_crop_sprite(const QPixmap *source, int x, int y, int width,
                          int height, const QPixmap *mask, int mask_offset_x,
-                         int mask_offset_y, float scale, bool smooth);
+                         int mask_offset_y);
 void qtg_free_sprite(QPixmap *s);
 
 QColor *qtg_color_alloc(int r, int g, int b);

--- a/client/gui-qt/sprite.cpp
+++ b/client/gui-qt/sprite.cpp
@@ -61,37 +61,24 @@ QPixmap *qtg_load_gfxfile(const char *filename)
  */
 QPixmap *qtg_crop_sprite(const QPixmap *source, int x, int y, int width,
                          int height, const QPixmap *mask, int mask_offset_x,
-                         int mask_offset_y, float scale, bool smooth)
+                         int mask_offset_y)
 {
   QPainter p;
   QRectF source_rect;
   QRectF dest_rect;
   QPixmap *cropped;
-  int widthzoom;
-  int heightzoom;
-  int hex = 0;
 
   fc_assert_ret_val(source, NULL);
 
   if (!width || !height) {
     return NULL;
   }
-  if (scale != 1.0f
-      && (tileset_hex_height(tileset) > 0
-          || tileset_hex_width(tileset) > 0)) {
-    hex = 1;
-  }
-  widthzoom = ceil(width * scale) + hex;
-  heightzoom = ceil(height * scale) + hex;
-  cropped = new QPixmap(widthzoom, heightzoom);
+  cropped = new QPixmap(width, height);
   cropped->fill(Qt::transparent);
   source_rect = QRectF(x, y, width, height);
-  dest_rect = QRectF(0, 0, widthzoom, heightzoom);
+  dest_rect = QRectF(0, 0, width, height);
 
   p.begin(cropped);
-  if (smooth) {
-    p.setRenderHint(QPainter::SmoothPixmapTransform);
-  }
   p.setRenderHint(QPainter::Antialiasing);
   p.drawPixmap(dest_rect, *source, source_rect);
   p.end();

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -129,10 +129,10 @@ void get_sprite_dimensions(const QPixmap *sprite, int *width, int *height)
  */
 QPixmap *crop_sprite(const QPixmap *source, int x, int y, int width,
                      int height, const QPixmap *mask, int mask_offset_x,
-                     int mask_offset_y, float scale, bool smooth)
+                     int mask_offset_y)
 {
   return funcs.crop_sprite(source, x, y, width, height, mask, mask_offset_x,
-                           mask_offset_y, scale, smooth);
+                           mask_offset_y);
 }
 
 /**

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -50,7 +50,7 @@ struct gui_funcs {
                                 int *height);
   QPixmap *(*crop_sprite)(const QPixmap *source, int x, int y, int width,
                           int height, const QPixmap *mask, int mask_offset_x,
-                          int mask_offset_y, float scale, bool smooth);
+                          int mask_offset_y);
   void (*free_sprite)(QPixmap *s);
 
   QColor *(*color_alloc)(int r, int g, int b);

--- a/client/include/sprite_g.h
+++ b/client/include/sprite_g.h
@@ -19,7 +19,7 @@ class QPixmap;
 GUI_FUNC_PROTO(QPixmap *, load_gfxfile, const char *filename)
 GUI_FUNC_PROTO(QPixmap *, crop_sprite, const QPixmap *source, int x, int y,
                int width, int height, const QPixmap *mask, int mask_offset_x,
-               int mask_offset_y, float scale, bool smooth)
+               int mask_offset_y)
 GUI_FUNC_PROTO(QPixmap *, create_sprite, int width, int height,
                const QColor *pcolor)
 GUI_FUNC_PROTO(void, get_sprite_dimensions, const QPixmap *sprite,

--- a/client/layer_background.cpp
+++ b/client/layer_background.cpp
@@ -64,10 +64,9 @@ void layer_background::initialize_player(const player *player)
   auto sprite = create_player_sprite(color);
 
   const auto id = player_index(player);
-  m_player_background.at(id) = std::unique_ptr<QPixmap>(
-      crop_sprite(sprite.get(), 0, 0, tileset_tile_width(tileset()),
-                  tileset_tile_height(tileset()), get_mask_sprite(tileset()),
-                  0, 0, tileset_scale(tileset()), false));
+  m_player_background.at(id) = std::unique_ptr<QPixmap>(crop_sprite(
+      sprite.get(), 0, 0, tileset_tile_width(tileset()),
+      tileset_tile_height(tileset()), get_mask_sprite(tileset()), 0, 0));
 }
 
 void layer_background::free_player(int player_id)
@@ -81,13 +80,9 @@ void layer_background::free_player(int player_id)
 std::unique_ptr<QPixmap>
 layer_background::create_player_sprite(const QColor &pcolor) const
 {
-  if (tileset_scale(tileset()) == 1.0f) {
-    return std::unique_ptr<QPixmap>(create_sprite(128, 64, &pcolor));
-  } else {
-    return std::unique_ptr<QPixmap>(
-        create_sprite(tileset_full_tile_width(tileset()),
-                      tileset_full_tile_height(tileset()), &pcolor));
-  }
+  return std::unique_ptr<QPixmap>(
+      create_sprite(tileset_full_tile_width(tileset()),
+                    tileset_full_tile_height(tileset()), &pcolor));
 }
 
 } // namespace freeciv

--- a/client/layer_terrain.cpp
+++ b/client/layer_terrain.cpp
@@ -333,7 +333,7 @@ void layer_terrain::initialize_cell_whole_match_none(const terrain *terrain,
                  .arg(m_number)
                  .arg(info.sprite_name)
                  .arg(i + 1);
-    auto sprite = load_sprite(tileset(), buffer, true, false);
+    auto sprite = load_sprite(tileset(), buffer);
     if (!sprite) {
       break;
     }
@@ -501,7 +501,7 @@ void layer_terrain::initialize_cell_corner_match_full(const terrain *terrain,
     auto buffer = QStringLiteral("t.l%1.cellgroup_%2_%3_%4_%5")
                       .arg(QString::number(m_number), n->name[0], e->name[0],
                            s->name[0], w->name[0]);
-    auto sprite = load_sprite(tileset(), buffer, true, false);
+    auto sprite = load_sprite(tileset(), buffer);
 
     if (sprite) {
       // Crop the sprite to separate this cell.
@@ -513,8 +513,7 @@ void layer_terrain::initialize_cell_corner_match_full(const terrain *terrain,
       int yo[4] = {H / 2, -H / 2, 0, 0};
 
       sprite = crop_sprite(sprite, x[dir], y[dir], W / 2, H / 2,
-                           get_mask_sprite(tileset()), xo[dir], yo[dir],
-                           1.0f, false);
+                           get_mask_sprite(tileset()), xo[dir], yo[dir]);
       // We allocated new sprite with crop_sprite. Store its address so we
       // can free it.
       m_allocated.emplace_back(sprite);
@@ -576,7 +575,7 @@ void layer_terrain::initialize_blending(const terrain *terrain,
   for (; dir < 4; dir++) {
     info.blend_sprites[dir] =
         crop_sprite(blender, offsets[dir][0], offsets[dir][1], W / 2, H / 2,
-                    get_dither_sprite(tileset()), 0, 0, 1.0f, false);
+                    get_dither_sprite(tileset()), 0, 0);
   }
 }
 
@@ -609,8 +608,7 @@ std::vector<drawn_sprite> layer_terrain::fill_sprite_array(
   // increases the refcount without limit.
   if (QPixmap * sprite;
       ptile->spec_sprite
-      && (sprite =
-              load_sprite(tileset(), ptile->spec_sprite, true, false))) {
+      && (sprite = load_sprite(tileset(), ptile->spec_sprite))) {
     if (m_number == 0) {
       sprites.emplace_back(tileset(), sprite);
     }

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -3225,7 +3225,7 @@ void handle_ruleset_control(const struct packet_ruleset_control *packet)
     if (strcmp(packet->preferred_tileset, tileset_basename(tileset))) {
       // It's not currently in use
       if (gui_options.autoaccept_tileset_suggestion) {
-        tilespec_reread(game.control.preferred_tileset, true, 1.0f);
+        tilespec_reread(game.control.preferred_tileset, true);
       } else {
         popup_tileset_suggestion_dialog();
       }

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -98,7 +98,6 @@ struct tileset_log_entry {
 struct tileset;
 
 extern struct tileset *tileset;
-extern struct tileset *unscaled_tileset;
 
 const QVector<QString> *get_tileset_list(const struct option *poption);
 
@@ -119,8 +118,7 @@ void finish_loading_sprites(struct tileset *t);
 
 bool tilespec_try_read(const char *tileset_name, bool verbose, int topo_id,
                        bool global_default);
-bool tilespec_reread(const char *tileset_name, bool game_fully_initialized,
-                     float scale, bool is_zoom = false);
+bool tilespec_reread(const char *tileset_name, bool game_fully_initialized);
 void tilespec_reread_callback(struct option *poption);
 void tilespec_reread_frozen_refresh(const char *tname);
 
@@ -147,8 +145,7 @@ bool tileset_layer_in_category(enum mapview_layer layer,
                                enum layer_category cat);
 
 // Gfx support
-QPixmap *load_sprite(struct tileset *t, const QString &tag_name,
-                     bool scale = true, bool smooth = true);
+QPixmap *load_sprite(struct tileset *t, const QString &tag_name);
 
 std::vector<drawn_sprite>
 fill_sprite_array(struct tileset *t, enum mapview_layer layer,
@@ -303,7 +300,6 @@ int tileset_small_sprite_width(const struct tileset *t);
 int tileset_small_sprite_height(const struct tileset *t);
 int tileset_citybar_offset_y(const struct tileset *t);
 int tileset_tilelabel_offset_y(const struct tileset *t);
-float tileset_scale(const struct tileset *t);
 const char *tileset_main_intro_filename(const struct tileset *t);
 int tileset_num_city_colors(const struct tileset *t);
 bool tileset_use_hard_coded_fog(const struct tileset *t);


### PR DESCRIPTION
It no longer reloads the tileset every time, resulting in much faster zooms. Instead, zoom is handled at the mapview level by pretending that the canvas is smaller (or larger) than it really is, and scaling the drawn canvas afterwards. The main drawback is that drawing the map when zoomed out is rather slow. It is, however, quite fast when zoomed in.

City names and production aren't as sharp as they used to be when zooming. Text layers will need to be taken into account when designing the next-gen renderer.

This started as a test to see how far it could go but it turned out to be rather easy so I went ahead.

Closes #295.
Closes #296.
Closes #729.
Closes #864
  (I think).

### Test plan

* Play with zoom in and zoom out.
* Watch out for possible offsets between the tile hovered with the mouse and the tile picked up by the client.
* Check trade route lines, in particular trade planner lines.