### PR TITLE
More flexible trade revenue bonus

### DIFF
--- a/ai/default/daidomestic.cpp
+++ b/ai/default/daidomestic.cpp
@@ -327,8 +327,8 @@ static void dai_choose_trade_route(struct ai_type *ait, struct city *pcity,
   /* We pass a NULL pc2 to get_caravan_enter_city_trade_bonus() so
    * it assumes that we are creating trade route to city with 75% of
    * pcitys trade 10 squares away. */
-  income = get_caravan_enter_city_trade_bonus(pcity, NULL, NULL,
-      utype_can_do_action(unit_type, ACTION_TRADE_ROUTE));
+  income = get_caravan_enter_city_trade_bonus(
+      pcity, NULL, NULL, utype_can_do_action(unit_type, ACTION_TRADE_ROUTE));
 
   if (dest_city_nat_same_cont) {
     pct = trade_route_type_trade_pct(TRT_NATIONAL);

--- a/ai/default/daidomestic.cpp
+++ b/ai/default/daidomestic.cpp
@@ -178,7 +178,7 @@ static void dai_choose_trade_route(struct ai_type *ait, struct city *pcity,
   struct player *pplayer = city_owner(pcity);
   struct unit_type *unit_type;
   adv_want want;
-  int income, bonus;
+  int income;
   int trade_routes;
   int caravan_units;
   int unassigned_caravans;
@@ -193,7 +193,6 @@ static void dai_choose_trade_route(struct ai_type *ait, struct city *pcity,
   int pct = 0;
   int trader_trait;
   bool need_boat = false;
-  int trade_action;
 
   if (city_list_size(pplayer->cities) < 5) {
     /* Consider trade routes only if enough destination cities.
@@ -325,26 +324,11 @@ static void dai_choose_trade_route(struct ai_type *ait, struct city *pcity,
    * have four trade routes, if there already is route between them
    * or if the Establish Trade Route action is illegal. */
 
-  /* The calculations of get_caravan_enter_city_trade_bonus() have to be
-   * duplicated here because the city traded with is imaginary. */
-
-  /* We assume that we are creating trade route to city with 75% of
+  /* We pass a NULL pc2 to get_caravan_enter_city_trade_bonus() so
+   * it assumes that we are creating trade route to city with 75% of
    * pcitys trade 10 squares away. */
-  income = (10 + 10) * (1.75 * pcity->surplus[O_TRADE]) / 24;
-
-  /* A ruleset may use the Trade_Revenue_Bonus effect to reduce the one
-   * time bonus if no trade route is established. Make sure it gets the
-   * correct action. */
-  trade_action = utype_can_do_action(unit_type, ACTION_TRADE_ROUTE)
-                     ? ACTION_TRADE_ROUTE
-                     : ACTION_MARKETPLACE;
-  bonus = get_target_bonus_effects(
-      NULL, pplayer, NULL, pcity, NULL, city_tile(pcity), NULL, NULL, NULL,
-      NULL, action_by_number(trade_action), EFT_TRADE_REVENUE_BONUS);
-
-  // Be mercy full to players with small amounts. Round up.
-  income = ceil(static_cast<float>(income)
-                * pow(2.0, static_cast<double>(bonus) / 1000.0));
+  income = get_caravan_enter_city_trade_bonus(pcity, NULL, NULL,
+      utype_can_do_action(unit_type, ACTION_TRADE_ROUTE));
 
   if (dest_city_nat_same_cont) {
     pct = trade_route_type_trade_pct(TRT_NATIONAL);

--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -565,6 +565,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_OUTPUT_PENALTY_TILE:
   case EFT_OUTPUT_INC_TILE_CELEBRATE:
   case EFT_TRADE_REVENUE_BONUS:
+  case EFT_TRADE_REVENUE_EXPONENT:
   case EFT_TILE_WORKABLE:
   case EFT_COMBAT_ROUNDS:
   case EFT_ILLEGAL_ACTION_MOVE_COST:

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1161,6 +1161,11 @@ QString effect_type_unit_text(effect_type type, int value)
     int factor = 100 * std::pow(2.0, value / 1000.);
     return QString(PL_("%1%", "%1%", factor)).arg(factor);
   }
+  case EFT_TRADE_REVENUE_EXPONENT: {
+    // additive in the exponent, which means... compositive??
+    float factor = 1.0f + value / 1000.0f;
+    return QString(PL_("**%1", "**%1", factor)).arg(factor);
+  }
   case EFT_OUTPUT_WASTE_BY_DISTANCE:
     return QString(PL_("%1%/tile", "%1%/tile", value)).arg(value);
   case EFT_CITY_BUILD_SLOTS:

--- a/common/effects.h
+++ b/common/effects.h
@@ -305,6 +305,8 @@
 #define SPECENUM_VALUE129NAME "HP_Regen_Min"
 #define SPECENUM_VALUE130 EFT_BOMBARD_LIMIT_PCT
 #define SPECENUM_VALUE130NAME "Bombard_Limit_Pct"
+#define SPECENUM_VALUE131 EFT_TRADE_REVENUE_EXPONENT
+#define SPECENUM_VALUE131NAME "Trade_Revenue_Exponent"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/common/fc_types.h
+++ b/common/fc_types.h
@@ -752,6 +752,10 @@ BV_DEFINE(bv_startpos_nations, MAX_NUM_STARTPOS_NATIONS);
 #define SPECENUM_VALUE0NAME "Classic"
 #define SPECENUM_VALUE1 CBS_LOGARITHMIC
 #define SPECENUM_VALUE1NAME "Logarithmic"
+#define SPECENUM_VALUE2 CBS_LINEAR
+#define SPECENUM_VALUE2NAME "Linear"
+#define SPECENUM_VALUE3 CBS_DISTANCE
+#define SPECENUM_VALUE3NAME "Distance"
 #include "specenum_gen.h"
 
 // Used in the network protocol.

--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -484,6 +484,17 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
     tb = tb * pgood->onetime_pct / 100;
   }
 
+  // Trade_revenue_exponent (in milimes) bends the shape of the curve
+  bonus = get_target_bonus_effects(
+      NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL,
+      pc1, NULL, city_tile(pc1),
+      NULL, NULL, NULL, NULL,
+      action_by_number(establish_trade ? ACTION_TRADE_ROUTE
+                                       : ACTION_MARKETPLACE),
+      EFT_TRADE_REVENUE_EXPONENT);
+  tb = ceil(pow(static_cast<float>(tb),
+                1.0f + static_cast<float>(bonus) / 1000.0));
+
   // Trade_revenue_bonus increases revenue by power of 2 in milimes
   bonus = get_target_bonus_effects(
       NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL,

--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -463,6 +463,13 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
                     * 2,
                 2);
     tb = bonus;
+  } else if (game.info.caravan_bonus_style == CBS_LINEAR) {
+    // Linear bonus (like CLASSIC) but using max_trade_prod
+    tb = real_map_distance(pc1->tile, pc2->tile) + 10;
+    tb = (tb * (max_trade_prod(pc1) + max_trade_prod(pc2))) / 24;
+  } else if (game.info.caravan_bonus_style == CBS_DISTANCE) {
+    // Purely dependent on distance, ignore city trade
+    tb = real_map_distance(pc1->tile, pc2->tile) + 10;
   }
 
   if (pgood != NULL) {

--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -486,9 +486,8 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
 
   // Trade_revenue_exponent (in milimes) bends the shape of the curve
   bonus = get_target_bonus_effects(
-      NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL,
-      pc1, NULL, city_tile(pc1),
-      NULL, NULL, NULL, NULL,
+      NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL, pc1, NULL,
+      city_tile(pc1), NULL, NULL, NULL, NULL,
       action_by_number(establish_trade ? ACTION_TRADE_ROUTE
                                        : ACTION_MARKETPLACE),
       EFT_TRADE_REVENUE_EXPONENT);
@@ -497,8 +496,8 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
 
   // Trade_revenue_bonus increases revenue by power of 2 in milimes
   bonus = get_target_bonus_effects(
-      NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL,
-      pc1, NULL, city_tile(pc1),
+      NULL, city_owner(pc1), pc2 ? city_owner(pc2) : NULL, pc1, NULL,
+      city_tile(pc1),
       /* TODO: Should unit requirements be
        * allowed so stuff like moves left and
        * unit type can modify the bonus? */

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -569,6 +569,10 @@ Trade_Revenue_Bonus
     One time trade revenue bonus is multiplied by pow(2, amount/1000). The amount value is taken from the
     caravan's home city.
 
+Trade_Revenue_Exponent
+    One time trade revenue bonus is raised to the (1 + amount/1000) power.
+    This is applied before ``Trade_Revenue_Bonus``.
+
 Traderoute_Pct
     Percentage bonus for trade from traderoutes. This bonus applies after the value of the traderoute is
     already calculated. It affects one end of the traderoute only.

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -212,6 +212,8 @@ static const struct sset_val_name *caravanbonusstyle_name(int caravanbonus)
   switch (caravanbonus) {
     NAME_CASE(CBS_CLASSIC, "CLASSIC", N_("Classic Freeciv"));
     NAME_CASE(CBS_LOGARITHMIC, "LOGARITHMIC", N_("Log^2 N style"));
+    NAME_CASE(CBS_LINEAR, "LINEAR", N_("Linear max trade"));
+    NAME_CASE(CBS_DISTANCE, "DISTANCE", N_("Pure distance"));
   }
   return NULL;
 }
@@ -2116,7 +2118,10 @@ static struct setting settings[] = {
                 "CLASSIC bonuses are proportional to distance and trade of "
                 "source and destination with multipliers for overseas and "
                 "international destinations. LOGARITHMIC bonuses are "
-                "proportional to log^2(distance + trade)."),
+                "proportional to log^2(distance + trade). LINEAR bonuses "
+                "are similar to CLASSIC, but (like LOGARITHMIC) use the "
+                "max trade of the city rather than current. DISTANCE "
+                "bonuses are proportional only to distance."),
              NULL, NULL, NULL, caravanbonusstyle_name,
              GAME_DEFAULT_CARAVAN_BONUS_STYLE),
 


### PR DESCRIPTION
I've tested a game with `CBS_DISTANCE` and some Avi adjustments including `Trade_Revenue_Exponent -250`.  It seems to behave sensibly enough.