### PR TITLE
Update the run-vcpkg action to the latest version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,7 +139,7 @@ jobs:
             gettext \
             create-dmg
           brew link gettext --force
-      - uses: lukka/run-vcpkg@v10.0
+      - uses: lukka/run-vcpkg@v10.1
         name: Install dependencies
         with:
           vcpkgGitCommitId: 50fd3d9957195575849a49fa591e645f1d8e7156


### PR DESCRIPTION
The Mac builds started taking very long (over 3 hours) because Qt is rebuilt
every time (#874). Meanwhile there was a new upstream release and caching is
mentioned in the release notes. Update, hoping that it will make things fast
again.

Tested in my fork, caching appears to work.