### PR TITLE
Remove the web-compatible capability from rulesets

### DIFF
--- a/data/civ2civ3/buildings.ruleset
+++ b/data/civ2civ3/buildings.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Civ2Civ3 buildings data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2civ3/cities.ruleset
+++ b/data/civ2civ3/cities.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Civ2Civ3 cities data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2civ3/game.ruleset
+++ b/data/civ2civ3/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 game rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/civ2civ3/governments.ruleset
+++ b/data/civ2civ3/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Civ2Civ3 governments data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [governments]

--- a/data/civ2civ3/nations.ruleset
+++ b/data/civ2civ3/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Default nations data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/civ2civ3/styles.ruleset
+++ b/data/civ2civ3/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Nation theme data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/civ2civ3/techs.ruleset
+++ b/data/civ2civ3/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Civ2Civ3 technology data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/civ2civ3/terrain.ruleset
+++ b/data/civ2civ3/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Civ2Civ3 tile_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/civ2civ3/units.ruleset
+++ b/data/civ2civ3/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Civ2Civ3 unit_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/classic/buildings.ruleset
+++ b/data/classic/buildings.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Classic buildings data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/cities.ruleset
+++ b/data/classic/cities.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Classic cities data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/game.ruleset
+++ b/data/classic/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic game rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/classic/governments.ruleset
+++ b/data/classic/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Classic governments data for Freeciv (as Civ2, minus fundamentalism)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [governments]

--- a/data/classic/nations.ruleset
+++ b/data/classic/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Classic nations data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/classic/styles.ruleset
+++ b/data/classic/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Classic nation theme data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/classic/techs.ruleset
+++ b/data/classic/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Classic technology data for Freeciv (as Civ2, minus a few)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/classic/terrain.ruleset
+++ b/data/classic/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Classic tile_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/classic/units.ruleset
+++ b/data/classic/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Classic unit_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/multiplayer/buildings.ruleset
+++ b/data/multiplayer/buildings.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer buildings data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/cities.ruleset
+++ b/data/multiplayer/cities.ruleset
@@ -8,7 +8,7 @@
 
 [datafile]
 description="Cities data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/game.ruleset
+++ b/data/multiplayer/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer game rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/multiplayer/governments.ruleset
+++ b/data/multiplayer/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Multiplayer governments data for Freeciv (as Civ2, minus fundamentalism)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [governments]

--- a/data/multiplayer/nations.ruleset
+++ b/data/multiplayer/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Multiplayer nations data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/multiplayer/styles.ruleset
+++ b/data/multiplayer/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Nation theme data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/multiplayer/techs.ruleset
+++ b/data/multiplayer/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Multiplayer technology data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/multiplayer/terrain.ruleset
+++ b/data/multiplayer/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Multiplayer terrain data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/multiplayer/units.ruleset
+++ b/data/multiplayer/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Unit definitions for the multiplayer ruleset."
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/royale/buildings.ruleset
+++ b/data/royale/buildings.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Royale buildings data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/royale/cities.ruleset
+++ b/data/royale/cities.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Royale cities data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/royale/game.ruleset
+++ b/data/royale/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale game rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/royale/governments.ruleset
+++ b/data/royale/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Royale governments data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [governments]

--- a/data/royale/nations.ruleset
+++ b/data/royale/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Default nations data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/royale/styles.ruleset
+++ b/data/royale/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Nation theme data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/royale/techs.ruleset
+++ b/data/royale/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Royale technology data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/royale/terrain.ruleset
+++ b/data/royale/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Royale tile_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/royale/units.ruleset
+++ b/data/royale/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Royale unit_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/webperimental/buildings.ruleset
+++ b/data/webperimental/buildings.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Experimental web-client buildings data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/cities.ruleset
+++ b/data/webperimental/cities.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Experimental web-client city rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/effects.ruleset
+++ b/data/webperimental/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Experimental web-client effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/game.ruleset
+++ b/data/webperimental/game.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Experimental web-client game rules for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/webperimental/governments.ruleset
+++ b/data/webperimental/governments.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Experimental web-client governments data for Freeciv (as Civ2, minus fundamentalism)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [governments]

--- a/data/webperimental/nations.ruleset
+++ b/data/webperimental/nations.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Experimental web-client nations data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; This section contains meta information for freeciv-ruledit to recreate the ruleset

--- a/data/webperimental/styles.ruleset
+++ b/data/webperimental/styles.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Experimental web-client nation theme data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/techs.ruleset
+++ b/data/webperimental/techs.ruleset
@@ -9,7 +9,7 @@
 
 [datafile]
 description="Experimental web-client technology data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/webperimental/terrain.ruleset
+++ b/data/webperimental/terrain.ruleset
@@ -12,7 +12,7 @@
 
 [datafile]
 description="Experimental web-client tile_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]

--- a/data/webperimental/units.ruleset
+++ b/data/webperimental/units.ruleset
@@ -16,7 +16,7 @@
 
 [datafile]
 description="Experimental web-client unit_type data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 web-compatible"
+options="+Freeciv-ruleset-Devel-2017.Jan.02"
 format_version=20
 
 [control]


### PR DESCRIPTION
Our rules are not meant to be used with the JS client.

Closes #863.