### PR TITLE
Add killunhomed-is-game-info back to the network capstring

### DIFF
--- a/fc_version.in
+++ b/fc_version.in
@@ -56,7 +56,7 @@ DEFAULT_FOLLOW_TAG=S3_1
 #   - No new mandatory capabilities can be added to the release branch; doing
 #     so would break network capability of supposedly "compatible" releases.
 #
-NETWORK_CAPSTRING="+Freeciv21.21April13"
+NETWORK_CAPSTRING="+Freeciv21.21April13 killunhomed-is-game-info"
 
 FREECIV_DISTRIBUTOR=""
 


### PR DESCRIPTION
Was removed accidentally when implementing AutoRevision.

Closes #894.