### PR TITLE
Fix a client crash when Enter Marketplace is possible

### DIFF
--- a/ai/default/daidomestic.cpp
+++ b/ai/default/daidomestic.cpp
@@ -328,7 +328,8 @@ static void dai_choose_trade_route(struct ai_type *ait, struct city *pcity,
    * it assumes that we are creating trade route to city with 75% of
    * pcitys trade 10 squares away. */
   income = get_caravan_enter_city_trade_bonus(
-      pcity, NULL, NULL, utype_can_do_action(unit_type, ACTION_TRADE_ROUTE));
+      pcity, NULL, pplayer, NULL,
+      utype_can_do_action(unit_type, ACTION_TRADE_ROUTE));
 
   if (dest_city_nat_same_cont) {
     pct = trade_route_type_trade_pct(TRT_NATIONAL);

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -1766,7 +1766,8 @@ const QString get_act_sel_action_custom_text(struct action *paction,
 
   if (action_has_result(paction, ACTRES_TRADE_ROUTE)) {
     int revenue = get_caravan_enter_city_trade_bonus(
-        actor_homecity, target_city, actor_unit->carrying, true);
+        actor_homecity, target_city, client_player(), actor_unit->carrying,
+        true);
 
     custom = QString(
                  /* TRANS: Estimated one time bonus and recurring revenue for
@@ -1777,7 +1778,8 @@ const QString get_act_sel_action_custom_text(struct action *paction,
                           actor_homecity, target_city)));
   } else if (action_has_result(paction, ACTRES_MARKETPLACE)) {
     int revenue = get_caravan_enter_city_trade_bonus(
-        actor_homecity, target_city, actor_unit->carrying, false);
+        actor_homecity, target_city, client_player(), actor_unit->carrying,
+        false);
 
     custom = QString(
                  /* TRANS: Estimated one time bonus for the Enter Marketplace

--- a/common/aicore/caravan.cpp
+++ b/common/aicore/caravan.cpp
@@ -208,8 +208,8 @@ static double windfall_benefit(const struct unit *caravan,
   } else {
     bool can_establish = (unit_can_do_action(caravan, ACTION_TRADE_ROUTE)
                           && can_establish_trade_route(src, dest));
-    int bonus =
-        get_caravan_enter_city_trade_bonus(src, dest, NULL, can_establish);
+    int bonus = get_caravan_enter_city_trade_bonus(
+        src, dest, unit_owner(caravan), NULL, can_establish);
 
     // bonus goes to both sci and gold.
     bonus *= 2;

--- a/common/traderoutes.h
+++ b/common/traderoutes.h
@@ -16,6 +16,7 @@
 
 struct city;
 struct city_list;
+struct player;
 
 /* What to do with previously established traderoutes that are now illegal.
  * Used in the network protocol. */
@@ -112,6 +113,7 @@ int trade_from_route(const struct city *pc1, const struct trade_route *route,
 int city_num_trade_routes(const struct city *pcity);
 int get_caravan_enter_city_trade_bonus(const struct city *pc1,
                                        const struct city *pc2,
+                                       const player *seen_as,
                                        struct goods_type *pgood,
                                        const bool establish_trade);
 int city_trade_removable(const struct city *pcity,

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -4812,8 +4812,8 @@ static bool do_unit_establish_trade(struct player *pplayer,
   // We now know for sure whether we can establish a trade route.
 
   // Calculate and announce initial revenue.
-  revenue = get_caravan_enter_city_trade_bonus(pcity_homecity, pcity_dest,
-                                               goods, can_establish);
+  revenue = get_caravan_enter_city_trade_bonus(
+      pcity_homecity, pcity_dest, nullptr, goods, can_establish);
 
   bonus_type = trade_route_settings_by_type(
                    cities_trade_route_type(pcity_homecity, pcity_dest))


### PR DESCRIPTION
When trying to calculate the bonus from doing Enter Marketplace, the client was
using code that assumed absolute knowledge of the target city.  Of course the
client doesn't have this for foreign cities, so it was crashing.

Closes #903.

@ec429 may find this useful to continue his game.