### PR TITLE
Try once again to fix stdin handling on Windows

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_AUTOMOC true)
+
 # Generate the packet handling code
 add_custom_command(
   OUTPUT

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -159,6 +159,10 @@ static void show_delegations(struct connection *caller);
 static const char horiz_line[] = "------------------------------------------"
                                  "------------------------------------";
 
+namespace {
+static bool static_should_quit = false;
+}
+
 static void remove_quotes(QStringList &str)
 {
   for (QString &a : str) {
@@ -4321,17 +4325,23 @@ static bool playernation_command(struct connection *caller, char *str,
   return true;
 }
 
-/**************************************************************************
-  Handle quit command
-**************************************************************************/
+/**
+ * Handle quit command
+ */
 static bool quit_game(struct connection *caller, bool check)
 {
   if (!check) {
     cmd_reply(CMD_QUIT, caller, C_OK, _("Goodbye."));
+    static_should_quit = true;
     QCoreApplication::quit();
   }
   return true;
 }
+
+/**
+ * Returns whether the server should exit after a command.
+ */
+bool should_quit() { return static_should_quit; }
 
 /**
    Main entry point for "command input".

--- a/server/stdinhand.h
+++ b/server/stdinhand.h
@@ -64,3 +64,5 @@ bool conn_is_kicked(struct connection *pconn, int *time_remaining);
 void set_running_game_access_level();
 
 char **freeciv_completion(const char *text, int start, int end);
+
+bool should_quit();


### PR DESCRIPTION
On Windows, there is apparently no unified non-blocking API to wait for 
input on stdin.  Thus, call the blocking API from a worker thread.

Tested the following use cases (*before rebasing*):

* Starting from the Windows console
* Starting from Windows Explorer (should be the same, but who knows)
* Starting from the client (I guess stdin is a named pipe in this case)
* Starting from the MSYS console (no idea what it uses, maybe a file)

The thread is only used on Windows, no reason for the extra overhead to
propagate to sane OSes.

Closes #850.

This should also be tested on Linux even though I don't expect differences there.