### PR TITLE
Solve some warnings from #909

### DIFF
--- a/client/options.cpp
+++ b/client/options.cpp
@@ -2099,11 +2099,6 @@ client_option_next_valid(struct client_option *poption)
 {
   const struct client_option *const max =
       client_options + client_options_num;
-
-  while (poption < max) {
-    poption++;
-  }
-
   return (poption < max ? poption : NULL);
 }
 

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -347,6 +347,7 @@ void handle_server_join_reply(bool you_can_join, const char *message,
       set_client_page(PAGE_START);
     }
 
+    client_info._obsolete = 5; // Old value for gui_type(GUI_QT)
 #ifdef EMERGENCY_VERSION
     client_info.emerg_version = EMERGENCY_VERSION;
 #else


### PR DESCRIPTION
This solves the following:

* Options (harmful bug)
* `Trying to put 728194712 into 8 bits` (harmless apart from exposing one byte from the stack to a malicious server)

The following harmless warning is fixed in #888:

* `QObject::disconnect: Unexpected null parameter` (harmless)

I don't understand the warnings related to `mapview_unsafe_goto`.