### PR TITLE
Remove qtg_ indirection for remaining canvas functions

### DIFF
--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -133,43 +133,6 @@ void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
   p.drawPixmap(canvas_x, canvas_y, *psprite);
   p.end();
 }
-/**
-   Draw a filled-in colored rectangle onto canvas.
- */
-void qtg_canvas_put_rectangle(QPixmap *pcanvas, const QColor &color,
-                              int canvas_x, int canvas_y, int width,
-                              int height)
-{
-  QBrush brush(color);
-  QPen pen(color);
-  QPainter p;
-
-  p.begin(pcanvas);
-  p.setPen(pen);
-  p.setBrush(brush);
-  if (width == 1 && height == 1) {
-    p.drawPoint(canvas_x, canvas_y);
-  } else if (width == 1) {
-    p.drawLine(canvas_x, canvas_y, canvas_x, canvas_y + height - 1);
-  } else if (height == 1) {
-    p.drawLine(canvas_x, canvas_y, canvas_x + width - 1, canvas_y);
-  } else {
-    p.drawRect(canvas_x, canvas_y, width, height);
-  }
-
-  p.end();
-}
-
-/**
-   Fill the area covered by the sprite with the given color.
- */
-void qtg_canvas_fill_sprite_area(QPixmap *pcanvas, const QPixmap *psprite,
-                                 const QColor &color, int canvas_x,
-                                 int canvas_y)
-{
-  qtg_canvas_put_rectangle(pcanvas, color, canvas_x, canvas_y,
-                           psprite->width(), psprite->height());
-}
 
 /**
    Draw a 1-pixel-width colored line onto the canvas.

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -173,49 +173,6 @@ void qtg_canvas_put_line(QPixmap *pcanvas, const QColor &color,
 }
 
 /**
-   Draw a 1-pixel-width colored curved line onto the canvas.
- */
-void qtg_canvas_put_curved_line(QPixmap *pcanvas, const QColor &color,
-                                enum line_type ltype, int start_x,
-                                int start_y, int dx, int dy)
-{
-  QPen pen;
-  pen.setColor(color);
-  QPainter p;
-  QPainterPath path;
-
-  switch (ltype) {
-  case LINE_NORMAL:
-    pen.setWidth(1);
-    break;
-  case LINE_BORDER:
-    pen.setStyle(Qt::DashLine);
-    pen.setDashOffset(4);
-    pen.setWidth(2);
-    break;
-  case LINE_TILE_FRAME:
-    pen.setWidth(2);
-    break;
-  case LINE_GOTO:
-    pen.setWidth(2);
-    break;
-  default:
-    pen.setWidth(1);
-    break;
-  }
-
-  p.begin(pcanvas);
-  p.setRenderHints(QPainter::Antialiasing);
-  p.setPen(pen);
-
-  path.moveTo(start_x, start_y);
-  path.cubicTo(start_x + dx / 2, start_y, start_x, start_y + dy / 2,
-               start_x + dx, start_y + dy);
-  p.drawPath(path);
-  p.end();
-}
-
-/**
    Return the size of the given text in the given font.  This size should
    include the ascent and descent of the text.  Either of width or height
    may be NULL in which case those values simply shouldn't be filled out.

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -75,31 +75,6 @@ void image_copy(QImage *dest, const QImage *src, int src_x, int src_y,
 }
 
 /**
-   Draw some or all of a sprite onto the canvas.
- */
-void qtg_canvas_put_sprite(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                           const QPixmap *sprite, int offset_x, int offset_y,
-                           int width, int height)
-{
-  QPainter p;
-
-  p.begin(pcanvas);
-  p.drawPixmap(canvas_x, canvas_y, *sprite, offset_x, offset_y, width,
-               height);
-  p.end();
-}
-
-/**
-   Draw a full sprite onto the canvas.
- */
-void qtg_canvas_put_sprite_full(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                                const QPixmap *sprite)
-{
-  canvas_put_sprite(pcanvas, canvas_x, canvas_y, sprite, 0, 0,
-                    sprite->width(), sprite->height());
-}
-
-/**
    Draw a full sprite onto the canvas.  If "fog" is specified draw it with
    fog.
  */

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -135,48 +135,6 @@ void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
 }
 
 /**
-   Return the size of the given text in the given font.  This size should
-   include the ascent and descent of the text.  Either of width or height
-   may be NULL in which case those values simply shouldn't be filled out.
- */
-void qtg_get_text_size(int *width, int *height, enum client_font font,
-                       const QString &text)
-{
-  QFont afont = get_font(font);
-  QScopedPointer<QFontMetrics> fm(new QFontMetrics(afont));
-
-  if (width) {
-    *width = fm->horizontalAdvance(text);
-  }
-
-  if (height) {
-    *height = fm->height();
-  }
-}
-
-/**
-   Draw the text onto the canvas in the given color and font.  The canvas
-   position does not account for the ascent of the text; this function must
-   take care of this manually.  The text will not be NULL but may be empty.
- */
-void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                         enum client_font font, const QColor &color,
-                         const QString &text)
-{
-  QPainter p;
-  QPen pen;
-  QFont afont = get_font(font);
-  QScopedPointer<QFontMetrics> fm(new QFontMetrics(afont));
-
-  pen.setColor(color);
-  p.begin(pcanvas);
-  p.setPen(pen);
-  p.setFont(afont);
-  p.drawText(canvas_x, canvas_y + fm->ascent(), text);
-  p.end();
-}
-
-/**
    Returns given font
  */
 QFont get_font(client_font font)

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -135,44 +135,6 @@ void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
 }
 
 /**
-   Draw a 1-pixel-width colored line onto the canvas.
- */
-void qtg_canvas_put_line(QPixmap *pcanvas, const QColor &color,
-                         enum line_type ltype, int start_x, int start_y,
-                         int dx, int dy)
-{
-  QPen pen;
-  QPainter p;
-
-  pen.setColor(color);
-  switch (ltype) {
-  case LINE_NORMAL:
-    pen.setWidth(1);
-    break;
-  case LINE_BORDER:
-    pen.setStyle(Qt::DashLine);
-    pen.setDashOffset(4);
-    pen.setWidth(1);
-    break;
-  case LINE_TILE_FRAME:
-    pen.setWidth(2);
-    break;
-  case LINE_GOTO:
-    pen.setWidth(2);
-    break;
-  default:
-    pen.setWidth(1);
-    break;
-  }
-
-  p.begin(pcanvas);
-  p.setPen(pen);
-  p.setRenderHint(QPainter::Antialiasing);
-  p.drawLine(start_x, start_y, start_x + dx, start_y + dy);
-  p.end();
-}
-
-/**
    Return the size of the given text in the given font.  This size should
    include the ascent and descent of the text.  Either of width or height
    may be NULL in which case those values simply shouldn't be filled out.

--- a/client/gui-qt/canvas.cpp
+++ b/client/gui-qt/canvas.cpp
@@ -75,66 +75,6 @@ void image_copy(QImage *dest, const QImage *src, int src_x, int src_y,
 }
 
 /**
-   Draw a full sprite onto the canvas.  If "fog" is specified draw it with
-   fog.
- */
-void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
-                                  int canvas_y, const QPixmap *psprite,
-                                  bool fog, int fog_x, int fog_y)
-{
-  Q_UNUSED(fog_x)
-  Q_UNUSED(fog_y)
-
-  QPixmap temp(psprite->size());
-  temp.fill(Qt::transparent);
-  QPainter p(&temp);
-  p.setCompositionMode(QPainter::CompositionMode_Source);
-  p.drawPixmap(0, 0, *psprite);
-  p.setCompositionMode(QPainter::CompositionMode_SourceAtop);
-  p.fillRect(temp.rect(), QColor(0, 0, 0, 110));
-  p.end();
-
-  p.begin(pcanvas);
-  p.drawPixmap(canvas_x, canvas_y, temp);
-  p.end();
-}
-
-/*****************************************************************************
-   Draw fog outside city map when city is opened
- */
-void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
-                                    int canvas_y, const QPixmap *psprite,
-                                    bool fog, int fog_x, int fog_y)
-{
-  Q_UNUSED(fog_x)
-  Q_UNUSED(fog_y)
-  QPainter p;
-
-  p.begin(pcanvas);
-  p.setCompositionMode(QPainter::CompositionMode_Difference);
-  p.setOpacity(0.5);
-  p.drawPixmap(canvas_x, canvas_y, *psprite);
-  p.end();
-}
-
-/*****************************************************************************
-   Put unit in city area when city dialog is open
- */
-void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                            const QPixmap *psprite, bool fog, int fog_x,
-                            int fog_y)
-{
-  Q_UNUSED(fog_y)
-  Q_UNUSED(fog_x)
-  QPainter p;
-
-  p.begin(pcanvas);
-  p.setOpacity(0.7);
-  p.drawPixmap(canvas_x, canvas_y, *psprite);
-  p.end();
-}
-
-/**
    Returns given font
  */
 QFont get_font(client_font font)

--- a/client/gui-qt/helpdlg.cpp
+++ b/client/gui-qt/helpdlg.cpp
@@ -27,6 +27,7 @@
 #include "specialist.h"
 #include "terrain.h"
 // client
+#include "canvas.h"
 #include "client_main.h"
 #include "helpdata.h"
 #include "mapview_common.h"

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -23,8 +23,6 @@ void setup_gui_funcs()
 
   funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
   funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
-  funcs->get_text_size = qtg_get_text_size;
-  funcs->canvas_put_text = qtg_canvas_put_text;
 
   funcs->set_rulesets = qtg_set_rulesets;
   funcs->options_extra_init = qtg_options_extra_init;

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -21,9 +21,6 @@ void setup_gui_funcs()
 {
   struct gui_funcs *funcs = get_gui_funcs();
 
-  funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
-  funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
-
   funcs->set_rulesets = qtg_set_rulesets;
   funcs->options_extra_init = qtg_options_extra_init;
   funcs->add_net_input = qtg_add_net_input;

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -24,7 +24,6 @@ void setup_gui_funcs()
   funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
   funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
   funcs->canvas_put_line = qtg_canvas_put_line;
-  funcs->canvas_put_curved_line = qtg_canvas_put_curved_line;
   funcs->get_text_size = qtg_get_text_size;
   funcs->canvas_put_text = qtg_canvas_put_text;
 

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -23,8 +23,6 @@ void setup_gui_funcs()
 
   funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
   funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
-  funcs->canvas_put_rectangle = qtg_canvas_put_rectangle;
-  funcs->canvas_fill_sprite_area = qtg_canvas_fill_sprite_area;
   funcs->canvas_put_line = qtg_canvas_put_line;
   funcs->canvas_put_curved_line = qtg_canvas_put_curved_line;
   funcs->get_text_size = qtg_get_text_size;

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -21,8 +21,6 @@ void setup_gui_funcs()
 {
   struct gui_funcs *funcs = get_gui_funcs();
 
-  funcs->canvas_put_sprite = qtg_canvas_put_sprite;
-  funcs->canvas_put_sprite_full = qtg_canvas_put_sprite_full;
   funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
   funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
   funcs->canvas_put_rectangle = qtg_canvas_put_rectangle;

--- a/client/gui-qt/qtg_cxxside.cpp
+++ b/client/gui-qt/qtg_cxxside.cpp
@@ -23,7 +23,6 @@ void setup_gui_funcs()
 
   funcs->canvas_put_sprite_fogged = qtg_canvas_put_sprite_fogged;
   funcs->canvas_put_sprite_citymode = qtg_canvas_put_sprite_citymode;
-  funcs->canvas_put_line = qtg_canvas_put_line;
   funcs->get_text_size = qtg_get_text_size;
   funcs->canvas_put_text = qtg_canvas_put_text;
 

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -30,9 +30,6 @@ void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
 void qtg_canvas_put_line(QPixmap *pcanvas, const QColor &color,
                          enum line_type ltype, int start_x, int start_y,
                          int dx, int dy);
-void qtg_canvas_put_curved_line(QPixmap *pcanvas, const QColor &color,
-                                enum line_type ltype, int start_x,
-                                int start_y, int dx, int dy);
 void qtg_get_text_size(int *width, int *height, enum client_font font,
                        const QString &);
 void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -27,9 +27,6 @@ void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
 void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
                                     int canvas_y, const QPixmap *psprite,
                                     bool fog, int fog_x, int fog_y);
-void qtg_canvas_put_line(QPixmap *pcanvas, const QColor &color,
-                         enum line_type ltype, int start_x, int start_y,
-                         int dx, int dy);
 void qtg_get_text_size(int *width, int *height, enum client_font font,
                        const QString &);
 void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -27,11 +27,6 @@ void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
 void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
                                     int canvas_y, const QPixmap *psprite,
                                     bool fog, int fog_x, int fog_y);
-void qtg_get_text_size(int *width, int *height, enum client_font font,
-                       const QString &);
-void qtg_canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                         enum client_font font, const QColor &color,
-                         const QString &text);
 
 void qtg_set_rulesets(int num_rulesets, QStringList rulesets);
 void qtg_options_extra_init();

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -27,12 +27,6 @@ void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
 void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
                                     int canvas_y, const QPixmap *psprite,
                                     bool fog, int fog_x, int fog_y);
-void qtg_canvas_put_rectangle(QPixmap *pcanvas, const QColor &color,
-                              int canvas_x, int canvas_y, int width,
-                              int height);
-void qtg_canvas_fill_sprite_area(QPixmap *pcanvas, const QPixmap *psprite,
-                                 const QColor &color, int canvas_x,
-                                 int canvas_y);
 void qtg_canvas_put_line(QPixmap *pcanvas, const QColor &color,
                          enum line_type ltype, int start_x, int start_y,
                          int dx, int dy);

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -21,11 +21,6 @@ class QTcpSocket;
 
 void setup_gui_funcs();
 
-void qtg_canvas_put_sprite(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                           const QPixmap *sprite, int offset_x, int offset_y,
-                           int width, int height);
-void qtg_canvas_put_sprite_full(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                                const QPixmap *sprite);
 void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
                                   int canvas_y, const QPixmap *psprite,
                                   bool fog, int fog_x, int fog_y);

--- a/client/gui-qt/qtg_cxxside.h
+++ b/client/gui-qt/qtg_cxxside.h
@@ -14,19 +14,11 @@
 // client
 #include "tilespec.h"
 // gui-qt
-#include "canvas.h"
 #include "pages_g.h"
 
 class QTcpSocket;
 
 void setup_gui_funcs();
-
-void qtg_canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x,
-                                  int canvas_y, const QPixmap *psprite,
-                                  bool fog, int fog_x, int fog_y);
-void qtg_canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x,
-                                    int canvas_y, const QPixmap *psprite,
-                                    bool fog, int fog_x, int fog_y);
 
 void qtg_set_rulesets(int num_rulesets, QStringList rulesets);
 void qtg_options_extra_init();

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -70,17 +70,6 @@ void canvas_put_line(QPixmap *pcanvas, const QColor &color,
 }
 
 /**
-   Call canvas_put_curved_line callback
- */
-void canvas_put_curved_line(QPixmap *pcanvas, const QColor &color,
-                            enum line_type ltype, int start_x, int start_y,
-                            int dx, int dy)
-{
-  funcs.canvas_put_curved_line(pcanvas, color, ltype, start_x, start_y, dx,
-                               dy);
-}
-
-/**
    Call get_text_size callback
  */
 void get_text_size(int *width, int *height, enum client_font font,

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -58,24 +58,6 @@ void canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x, int canvas_y,
                                    fog_x, fog_y);
 }
 
-/**
-   Call canvas_put_rectangle callback
- */
-void canvas_put_rectangle(QPixmap *pcanvas, const QColor &color,
-                          int canvas_x, int canvas_y, int width, int height)
-{
-  funcs.canvas_put_rectangle(pcanvas, color, canvas_x, canvas_y, width,
-                             height);
-}
-
-/**
-   Call canvas_fill_sprite_area callback
- */
-void canvas_fill_sprite_area(QPixmap *pcanvas, QPixmap *psprite,
-                             const QColor &color, int canvas_x, int canvas_y)
-{
-  funcs.canvas_fill_sprite_area(pcanvas, psprite, color, canvas_x, canvas_y);
-}
 
 /**
    Call canvas_put_line callback

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -59,25 +59,6 @@ void canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x, int canvas_y,
 }
 
 /**
-   Call get_text_size callback
- */
-void get_text_size(int *width, int *height, enum client_font font,
-                   const QString &text)
-{
-  funcs.get_text_size(width, height, font, text);
-}
-
-/**
-   Call canvas_put_text callback
- */
-void canvas_put_text(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                     enum client_font font, const QColor &color,
-                     const QString &text)
-{
-  funcs.canvas_put_text(pcanvas, canvas_x, canvas_y, font, color, text);
-}
-
-/**
    Call set_rulesets callback
  */
 void set_rulesets(int num_rulesets, QStringList rulesets)

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -58,17 +58,6 @@ void canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x, int canvas_y,
                                    fog_x, fog_y);
 }
 
-
-/**
-   Call canvas_put_line callback
- */
-void canvas_put_line(QPixmap *pcanvas, const QColor &color,
-                     enum line_type ltype, int start_x, int start_y, int dx,
-                     int dy)
-{
-  funcs.canvas_put_line(pcanvas, color, ltype, start_x, start_y, dx, dy);
-}
-
 /**
    Call get_text_size callback
  */

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -40,25 +40,6 @@ static struct gui_funcs funcs;
 struct gui_funcs *get_gui_funcs() { return &funcs; }
 
 /**
-   Call canvas_put_sprite_fogged callback
- */
-void canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                              const QPixmap *psprite, bool fog, int fog_x,
-                              int fog_y)
-{
-  funcs.canvas_put_sprite_fogged(pcanvas, canvas_x, canvas_y, psprite, fog,
-                                 fog_x, fog_y);
-}
-
-void canvas_put_sprite_citymode(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                                const QPixmap *psprite, bool fog, int fog_x,
-                                int fog_y)
-{
-  funcs.canvas_put_sprite_citymode(pcanvas, canvas_x, canvas_y, psprite, fog,
-                                   fog_x, fog_y);
-}
-
-/**
    Call set_rulesets callback
  */
 void set_rulesets(int num_rulesets, QStringList rulesets)

--- a/client/gui_interface.cpp
+++ b/client/gui_interface.cpp
@@ -40,26 +40,6 @@ static struct gui_funcs funcs;
 struct gui_funcs *get_gui_funcs() { return &funcs; }
 
 /**
-   Call canvas_put_sprite callback
- */
-void canvas_put_sprite(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                       const QPixmap *psprite, int offset_x, int offset_y,
-                       int width, int height)
-{
-  funcs.canvas_put_sprite(pcanvas, canvas_x, canvas_y, psprite, offset_x,
-                          offset_y, width, height);
-}
-
-/**
-   Call canvas_put_sprite_full callback
- */
-void canvas_put_sprite_full(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                            const QPixmap *psprite)
-{
-  funcs.canvas_put_sprite_full(pcanvas, canvas_x, canvas_y, psprite);
-}
-
-/**
    Call canvas_put_sprite_fogged callback
  */
 void canvas_put_sprite_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -35,9 +35,6 @@ struct gui_funcs {
   void (*canvas_put_sprite_citymode)(QPixmap *pcanvas, int canvas_x,
                                      int canvas_y, const QPixmap *psprite,
                                      bool fog, int fog_x, int fog_y);
-  void (*canvas_put_line)(QPixmap *pcanvas, const QColor &color,
-                          enum line_type ltype, int start_x, int start_y,
-                          int dx, int dy);
   void (*get_text_size)(int *width, int *height, enum client_font font,
                         const QString &text);
   void (*canvas_put_text)(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -29,11 +29,6 @@ class QTcpSocket;
 #include "tilespec.h"
 
 struct gui_funcs {
-  void (*canvas_put_sprite)(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                            const QPixmap *psprite, int offset_x,
-                            int offset_y, int width, int height);
-  void (*canvas_put_sprite_full)(QPixmap *pcanvas, int canvas_x,
-                                 int canvas_y, const QPixmap *psprite);
   void (*canvas_put_sprite_fogged)(QPixmap *pcanvas, int canvas_x,
                                    int canvas_y, const QPixmap *psprite,
                                    bool fog, int fog_x, int fog_y);

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -38,9 +38,6 @@ struct gui_funcs {
   void (*canvas_put_line)(QPixmap *pcanvas, const QColor &color,
                           enum line_type ltype, int start_x, int start_y,
                           int dx, int dy);
-  void (*canvas_put_curved_line)(QPixmap *pcanvas, const QColor &color,
-                                 enum line_type ltype, int start_x,
-                                 int start_y, int dx, int dy);
   void (*get_text_size)(int *width, int *height, enum client_font font,
                         const QString &text);
   void (*canvas_put_text)(QPixmap *pcanvas, int canvas_x, int canvas_y,

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -29,13 +29,6 @@ class QTcpSocket;
 #include "tilespec.h"
 
 struct gui_funcs {
-  void (*canvas_put_sprite_fogged)(QPixmap *pcanvas, int canvas_x,
-                                   int canvas_y, const QPixmap *psprite,
-                                   bool fog, int fog_x, int fog_y);
-  void (*canvas_put_sprite_citymode)(QPixmap *pcanvas, int canvas_x,
-                                     int canvas_y, const QPixmap *psprite,
-                                     bool fog, int fog_x, int fog_y);
-
   void (*set_rulesets)(int num_rulesets, QStringList rulesets);
   void (*options_extra_init)();
   void (*add_net_input)(QTcpSocket *sock);

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -35,11 +35,6 @@ struct gui_funcs {
   void (*canvas_put_sprite_citymode)(QPixmap *pcanvas, int canvas_x,
                                      int canvas_y, const QPixmap *psprite,
                                      bool fog, int fog_x, int fog_y);
-  void (*get_text_size)(int *width, int *height, enum client_font font,
-                        const QString &text);
-  void (*canvas_put_text)(QPixmap *pcanvas, int canvas_x, int canvas_y,
-                          enum client_font font, const QColor &color,
-                          const QString &);
 
   void (*set_rulesets)(int num_rulesets, QStringList rulesets);
   void (*options_extra_init)();

--- a/client/gui_interface.h
+++ b/client/gui_interface.h
@@ -35,12 +35,6 @@ struct gui_funcs {
   void (*canvas_put_sprite_citymode)(QPixmap *pcanvas, int canvas_x,
                                      int canvas_y, const QPixmap *psprite,
                                      bool fog, int fog_x, int fog_y);
-  void (*canvas_put_rectangle)(QPixmap *pcanvas, const QColor &color,
-                               int canvas_x, int canvas_y, int width,
-                               int height);
-  void (*canvas_fill_sprite_area)(QPixmap *pcanvas, const QPixmap *psprite,
-                                  const QColor &color, int canvas_x,
-                                  int canvas_y);
   void (*canvas_put_line)(QPixmap *pcanvas, const QColor &color,
                           enum line_type ltype, int start_x, int start_y,
                           int dx, int dy);

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -19,8 +19,6 @@ class QFont;
 class QPixmap; // opaque type, real type is gui-dep
 class QString;
 
-enum line_type { LINE_NORMAL, LINE_BORDER, LINE_TILE_FRAME, LINE_GOTO };
-
 // Drawing functions
 GUI_FUNC_PROTO(void, canvas_put_sprite_fogged, QPixmap *pcanvas,
                int canvas_x, int canvas_y, const QPixmap *psprite, bool fog,
@@ -28,9 +26,6 @@ GUI_FUNC_PROTO(void, canvas_put_sprite_fogged, QPixmap *pcanvas,
 GUI_FUNC_PROTO(void, canvas_put_sprite_citymode, QPixmap *pcanvas,
                int canvas_x, int canvas_y, const QPixmap *psprite, bool fog,
                int fog_x, int fog_y)
-GUI_FUNC_PROTO(void, canvas_put_line, QPixmap *pcanvas, const QColor &color,
-               enum line_type ltype, int start_x, int start_y, int dx,
-               int dy)
 void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
                             const QPixmap *psprite, bool fog, int fog_x,
                             int fog_y);

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -36,10 +36,5 @@ enum client_font {
   FONT_REQTREE_TEXT,
   FONT_COUNT
 };
-GUI_FUNC_PROTO(void, get_text_size, int *width, int *height,
-               enum client_font font, const QString &text)
-GUI_FUNC_PROTO(void, canvas_put_text, QPixmap *pcanvas, int canvas_x,
-               int canvas_y, enum client_font font, const QColor &color,
-               const QString &text)
 
 QFont get_font(enum client_font font);

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -28,12 +28,6 @@ GUI_FUNC_PROTO(void, canvas_put_sprite_fogged, QPixmap *pcanvas,
 GUI_FUNC_PROTO(void, canvas_put_sprite_citymode, QPixmap *pcanvas,
                int canvas_x, int canvas_y, const QPixmap *psprite, bool fog,
                int fog_x, int fog_y)
-GUI_FUNC_PROTO(void, canvas_put_rectangle, QPixmap *pcanvas,
-               const QColor &pcolor, int canvas_x, int canvas_y, int width,
-               int height)
-GUI_FUNC_PROTO(void, canvas_fill_sprite_area, QPixmap *pcanvas,
-               QPixmap *psprite, const QColor &color, int canvas_x,
-               int canvas_y)
 GUI_FUNC_PROTO(void, canvas_put_line, QPixmap *pcanvas, const QColor &color,
                enum line_type ltype, int start_x, int start_y, int dx,
                int dy)

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -22,11 +22,6 @@ class QString;
 enum line_type { LINE_NORMAL, LINE_BORDER, LINE_TILE_FRAME, LINE_GOTO };
 
 // Drawing functions
-GUI_FUNC_PROTO(void, canvas_put_sprite, QPixmap *pcanvas, int canvas_x,
-               int canvas_y, const QPixmap *sprite, int offset_x,
-               int offset_y, int width, int height);
-GUI_FUNC_PROTO(void, canvas_put_sprite_full, QPixmap *pcanvas, int canvas_x,
-               int canvas_y, const QPixmap *sprite)
 GUI_FUNC_PROTO(void, canvas_put_sprite_fogged, QPixmap *pcanvas,
                int canvas_x, int canvas_y, const QPixmap *psprite, bool fog,
                int fog_x, int fog_y)

--- a/client/include/canvas_g.h
+++ b/client/include/canvas_g.h
@@ -31,9 +31,6 @@ GUI_FUNC_PROTO(void, canvas_put_sprite_citymode, QPixmap *pcanvas,
 GUI_FUNC_PROTO(void, canvas_put_line, QPixmap *pcanvas, const QColor &color,
                enum line_type ltype, int start_x, int start_y, int dx,
                int dy)
-GUI_FUNC_PROTO(void, canvas_put_curved_line, QPixmap *pcanvas,
-               const QColor &color, enum line_type ltype, int start_x,
-               int start_y, int dx, int dy)
 void canvas_put_unit_fogged(QPixmap *pcanvas, int canvas_x, int canvas_y,
                             const QPixmap *psprite, bool fog, int fog_x,
                             int fog_y);

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1366,9 +1366,10 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
    *
    * Of course it's necessary to draw to the whole area to cover up any old
    * drawing that was done there. */
-  canvas_put_rectangle(mapview.store,
-                       get_color(tileset, COLOR_MAPVIEW_UNKNOWN), canvas_x,
-                       canvas_y, width, height);
+  QPainter p(mapview.store);
+  p.fillRect(canvas_x, canvas_y, width, height,
+             get_color(tileset, COLOR_MAPVIEW_UNKNOWN));
+  p.end();
 
   for (const auto &layer : tileset_get_layers(tileset)) {
     if (layer->type() == LAYER_TILELABEL) {
@@ -2686,9 +2687,7 @@ bool map_canvas_resized(int width, int height)
       delete mapview.tmp_store;
     }
     mapview.store = new QPixmap(full_width, full_height);
-    canvas_put_rectangle(mapview.store,
-                         get_color(tileset, COLOR_MAPVIEW_UNKNOWN), 0, 0,
-                         full_width, full_height);
+    mapview.store->fill(get_color(tileset, COLOR_MAPVIEW_UNKNOWN));
 
     mapview.tmp_store = new QPixmap(full_width, full_height);
   }
@@ -2777,11 +2776,9 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
   spr = get_spaceship_sprite(t, SPACESHIP_HABITATION);
   const int w = spr->width(), h = spr->height();
 
-  canvas_put_rectangle(pcanvas,
-                       get_color(tileset, COLOR_SPACESHIP_BACKGROUND), 0, 0,
-                       w * 7, h * 7);
-
   QPainter p(pcanvas);
+  p.fillRect(0, 0, w * 7, h * 7,
+             get_color(tileset, COLOR_SPACESHIP_BACKGROUND));
 
   for (i = 0; i < NUM_SS_MODULES; i++) {
     const int j = i / 3;

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -960,10 +960,11 @@ void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
                                canvas_x, canvas_y);
     } else {
       /* We avoid calling canvas_put_sprite_fogged, even though it
-       * should be a valid thing to do, because gui-gtk-2.0 doesn't have
+       * should be a valid thing to do, because gui-gtk-2.0 didn't have
        * a full implementation. */
-      canvas_put_sprite_full(pcanvas, canvas_x + s.offset_x,
-                             canvas_y + s.offset_y, s.sprite);
+      QPainter p(pcanvas);
+      p.drawPixmap(canvas_x + s.offset_x, canvas_y + s.offset_y, *s.sprite);
+      p.end();
     }
   }
 }
@@ -1081,9 +1082,11 @@ void put_unit_city_overlays(struct unit *punit, QPixmap *pcanvas,
                             int canvas_x, int canvas_y, int *upkeep_cost,
                             int happy_cost)
 {
+  QPainter p(pcanvas);
+
   auto sprite = get_unit_unhappy_sprite(tileset, punit, happy_cost);
   if (sprite) {
-    canvas_put_sprite_full(pcanvas, canvas_x, canvas_y, sprite);
+    p.drawPixmap(canvas_x, canvas_y, *sprite);
   }
 
   output_type_iterate(o)
@@ -1091,10 +1094,12 @@ void put_unit_city_overlays(struct unit *punit, QPixmap *pcanvas,
     sprite = get_unit_upkeep_sprite(tileset, static_cast<Output_type_id>(o),
                                     punit, upkeep_cost);
     if (sprite) {
-      canvas_put_sprite_full(pcanvas, canvas_x, canvas_y, sprite);
+      p.drawPixmap(canvas_x, canvas_y, *sprite);
     }
   }
   output_type_iterate_end;
+
+  p.end();
 }
 
 /*
@@ -1166,7 +1171,9 @@ void put_nuke_mushroom_pixmaps(struct tile *ptile)
    * the screen and wait 1 second. */
   unqueue_mapview_updates(false);
 
-  canvas_put_sprite_full(mapview.store, canvas_x, canvas_y, mysprite);
+  QPainter p(mapview.store);
+  p.drawPixmap(canvas_x, canvas_y, *mysprite);
+  p.end();
   dirty_rect(canvas_x, canvas_y, mysprite->width(), mysprite->height());
 
   flush_dirty();
@@ -1707,12 +1714,11 @@ void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
       p.drawPixmap(canvas_x, canvas_y, *mapview.tmp_store, canvas_x,
                    canvas_y, tileset_tile_width(tileset),
                    tileset_tile_height(tileset));
-      p.end();
-      canvas_put_sprite_full(
-          mapview.store,
+      p.drawPixmap(
           canvas_x + tileset_tile_width(tileset) / 2 - sprite->width() / 2,
           canvas_y + tileset_tile_height(tileset) / 2 - sprite->height() / 2,
-          sprite);
+          *sprite);
+      p.end();
       dirty_rect(canvas_x, canvas_y, tileset_tile_width(tileset),
                  tileset_tile_height(tileset));
 
@@ -2775,6 +2781,8 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
                        get_color(tileset, COLOR_SPACESHIP_BACKGROUND), 0, 0,
                        w * 7, h * 7);
 
+  QPainter p(pcanvas);
+
   for (i = 0; i < NUM_SS_MODULES; i++) {
     const int j = i / 3;
     const int k = i % 3;
@@ -2790,7 +2798,7 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
     spr = (k == 0   ? get_spaceship_sprite(t, SPACESHIP_HABITATION)
            : k == 1 ? get_spaceship_sprite(t, SPACESHIP_LIFE_SUPPORT)
                     : get_spaceship_sprite(t, SPACESHIP_SOLAR_PANEL));
-    canvas_put_sprite_full(pcanvas, x, y, spr);
+    p.drawPixmap(x, y, *spr);
   }
 
   for (i = 0; i < NUM_SS_COMPONENTS; i++) {
@@ -2806,11 +2814,11 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
     spr = ((k == 0) ? get_spaceship_sprite(t, SPACESHIP_FUEL)
                     : get_spaceship_sprite(t, SPACESHIP_PROPULSION));
 
-    canvas_put_sprite_full(pcanvas, x, y, spr);
+    p.drawPixmap(x, y, *spr);
 
     if (k && ship->state == SSHIP_LAUNCHED) {
       spr = get_spaceship_sprite(t, SPACESHIP_EXHAUST);
-      canvas_put_sprite_full(pcanvas, x + w, y, spr);
+      p.drawPixmap(x + w, y, *spr);
     }
   }
 
@@ -2822,8 +2830,10 @@ void put_spaceship(QPixmap *pcanvas, int canvas_x, int canvas_y,
     y = structurals_info[i].y * h / 4 - h / 2;
 
     spr = get_spaceship_sprite(t, SPACESHIP_STRUCTURAL);
-    canvas_put_sprite_full(pcanvas, x, y, spr);
+    p.drawPixmap(x, y, *spr);
   }
+
+  p.end();
 }
 
 /****************************************************************************

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1509,11 +1509,15 @@ static void show_tile_label(QPixmap *pcanvas, int canvas_x, int canvas_y,
   canvas_x += tileset_tile_width(tileset) / 2;
   canvas_y += tileset_tilelabel_offset_y(tileset);
 
-  get_text_size(width, height, FONT_TILE_LABEL, ptile->label);
+  QPainter p(pcanvas);
+  p.setFont(get_font(FONT_TILE_LABEL));
+  p.setPen(get_color(tileset, COLOR_MAPVIEW_TILELABEL));
 
-  canvas_put_text(pcanvas, (canvas_x - *width / 2), canvas_y,
-                  FONT_TILE_LABEL,
-                  get_color(tileset, COLOR_MAPVIEW_TILELABEL), ptile->label);
+  auto fm = p.fontMetrics();
+  auto rect = fm.boundingRect(ptile->label);
+
+  p.drawText((canvas_x - rect.width() / 2), canvas_y + fm.ascent(),
+             ptile->label);
 #undef COLOR_MAPVIEW_TILELABEL
 }
 

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1264,13 +1264,21 @@ static void draw_trade_route_line(const struct tile *ptile1,
     ptile2 = tmp;
   }
 
+  QPen pen;
+  pen.setColor(get_color(tileset, color));
+  pen.setStyle(Qt::DashLine);
+  pen.setDashOffset(4);
+  pen.setWidth(1);
+
+  QPainter p(mapview.store);
+  p.setPen(pen);
   line_count = trade_route_to_canvas_lines(ptile1, ptile2, lines);
   for (i = 0; i < line_count; i++) {
-    canvas_put_line(mapview.store, get_color(tileset, color), LINE_BORDER,
-                    lines[i].x + tileset_tile_width(tileset) / 2,
-                    lines[i].y + tileset_tile_height(tileset) / 2,
-                    lines[i].width, lines[i].height);
+    int x = lines[i].x + tileset_tile_width(tileset) / 2;
+    int y = lines[i].y + tileset_tile_height(tileset) / 2;
+    p.drawLine(x, y, x + lines[i].width, y + lines[i].height);
   }
+  p.end();
 }
 
 /**
@@ -1637,10 +1645,12 @@ void draw_segment(struct tile *src_tile, enum direction8 dir, bool safe)
                     DIR_DY[dir]);
 
   // Draw the segment.
-  canvas_put_line(mapview.store,
-                  get_color(tileset, safe ? COLOR_MAPVIEW_GOTO
-                                          : COLOR_MAPVIEW_UNSAFE_GOTO),
-                  LINE_GOTO, canvas_x, canvas_y, canvas_dx, canvas_dy);
+  QPainter p(mapview.store);
+  p.setPen(QPen(get_color(tileset, safe ? COLOR_MAPVIEW_GOTO
+                                        : COLOR_MAPVIEW_UNSAFE_GOTO),
+                2));
+  p.drawLine(canvas_x, canvas_y, canvas_x + canvas_dx, canvas_y + canvas_dy);
+  p.end();
 
   /* The actual area drawn will extend beyond the base rectangle, since
    * the goto lines have width. */
@@ -2951,25 +2961,20 @@ static void link_mark_draw(const struct link_mark *pmark)
   y_top = canvas_y + yd;
   y_bottom = canvas_y + height - yd;
 
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_left, y_top, xlen,
-                  0);
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_left, y_top, 0,
-                  ylen);
+  QPainter p(mapview.store);
+  p.setPen(QPen(color, 2));
+  p.drawLine(x_left, y_top, x_left + xlen, y_top);
+  p.drawLine(x_left, y_top, x_left, y_top + ylen);
 
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_right, y_top,
-                  -xlen, 0);
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_right, y_top, 0,
-                  ylen);
+  p.drawLine(x_right, y_top, x_right - xlen, y_top);
+  p.drawLine(x_right, y_top, x_right, y_top + ylen);
 
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_left, y_bottom,
-                  xlen, 0);
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_left, y_bottom, 0,
-                  -ylen);
+  p.drawLine(x_left, y_bottom, x_left + xlen, y_bottom);
+  p.drawLine(x_left, y_bottom, x_left, y_bottom - ylen);
 
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_right, y_bottom,
-                  -xlen, 0);
-  canvas_put_line(mapview.store, color, LINE_TILE_FRAME, x_right, y_bottom,
-                  0, -ylen);
+  p.drawLine(x_right, y_bottom, x_right - xlen, y_bottom);
+  p.drawLine(x_right, y_bottom, x_right, y_bottom - ylen);
+  p.end();
 }
 
 /**

--- a/client/overview_common.cpp
+++ b/client/overview_common.cpp
@@ -212,16 +212,17 @@ static void redraw_overview()
   gui_to_overview_pos(tileset, &x[3], &y[3], mapview.gui_x0,
                       mapview.gui_y0 + mapview.height);
 
+  QPainter p(gui_options.overview.window);
+  p.setPen(QPen(get_color(tileset, COLOR_OVERVIEW_VIEWRECT), 2));
   for (i = 0; i < 4; i++) {
     int src_x = x[i];
     int src_y = y[i];
     int dst_x = x[(i + 1) % 4];
     int dst_y = y[(i + 1) % 4];
 
-    canvas_put_line(gui_options.overview.window,
-                    get_color(tileset, COLOR_OVERVIEW_VIEWRECT), LINE_NORMAL,
-                    src_x, src_y, dst_x - src_x, dst_y - src_y);
+    p.drawLine(src_x, src_y, dst_x, dst_y);
   }
+  p.end();
 
   update_minimap();
 

--- a/client/overview_common.cpp
+++ b/client/overview_common.cpp
@@ -370,11 +370,12 @@ static void put_overview_tile_area(QPixmap *pcanvas, struct tile *ptile,
                                    int x, int y, int w, int h)
 {
   canvas_put_rectangle(pcanvas, overview_tile_color(ptile), x, y, w, h);
+  QPainter p(pcanvas);
   if (gui_options.overview.fog
       && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile)) {
-    canvas_put_sprite(pcanvas, x, y, get_basic_fog_sprite(tileset), 0, 0, w,
-                      h);
+    p.drawPixmap(x, y, w, h, *get_basic_fog_sprite(tileset));
   }
+  p.end();
 }
 
 /**

--- a/client/overview_common.cpp
+++ b/client/overview_common.cpp
@@ -369,8 +369,8 @@ void refresh_overview_canvas()
 static void put_overview_tile_area(QPixmap *pcanvas, struct tile *ptile,
                                    int x, int y, int w, int h)
 {
-  canvas_put_rectangle(pcanvas, overview_tile_color(ptile), x, y, w, h);
   QPainter p(pcanvas);
+  p.fillRect(x, y, w, h, overview_tile_color(ptile));
   if (gui_options.overview.fog
       && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile)) {
     p.drawPixmap(x, y, w, h, *get_basic_fog_sprite(tileset));
@@ -463,9 +463,7 @@ void calculate_overview_dimensions()
       new QPixmap(gui_options.overview.width, gui_options.overview.height);
   gui_options.overview.window =
       new QPixmap(gui_options.overview.width, gui_options.overview.height);
-  canvas_put_rectangle(
-      gui_options.overview.map, get_color(tileset, COLOR_OVERVIEW_UNKNOWN),
-      0, 0, gui_options.overview.width, gui_options.overview.height);
+  gui_options.overview.map->fill(get_color(tileset, COLOR_OVERVIEW_UNKNOWN));
 
   update_minimap();
   if (can_client_change_view()) {

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -1131,7 +1131,6 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
           }
           governments_iterate_end;
         }
-
       }
 
       // Draw all outgoing edges

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -35,6 +35,7 @@
 #include "sprite_g.h"
 
 // Qt
+#include <QPainter>
 #include <QPixmap>
 #include <QRect>
 
@@ -1038,6 +1039,7 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
         icon_startx = startx + 5;
 
         if (gui_options.reqtree_show_icons) {
+          QPainter p(pcanvas);
           unit_type_iterate(unit)
           {
             if (advance_number(unit->require_advance) != node->tech) {
@@ -1053,11 +1055,10 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
                       sprite->width(), sprite->height());
             rttp->tunit = unit;
             tt_help->append(rttp);
-            canvas_put_sprite_full(
-                pcanvas, icon_startx,
-                starty + text_h + 4
-                    + (height - text_h - 4 - sprite->height()) / 2,
-                sprite);
+            p.drawPixmap(icon_startx,
+                         starty + text_h + 4
+                             + (height - text_h - 4 - sprite->height()) / 2,
+                         *sprite);
             icon_startx += sprite->width() + 2;
           }
           unit_type_iterate_end;
@@ -1080,11 +1081,11 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
                       sprite->width(), sprite->height());
                   rttp->timpr = pimprove;
                   tt_help->append(rttp);
-                  canvas_put_sprite_full(
-                      pcanvas, icon_startx,
-                      starty + text_h + 4
-                          + (height - text_h - 4 - sprite->height()) / 2,
-                      sprite);
+                  p.drawPixmap(icon_startx,
+                               starty + text_h + 4
+                                   + (height - text_h - 4 - sprite->height())
+                                         / 2,
+                               *sprite);
                   icon_startx += sprite->width() + 2;
                 }
               }
@@ -1109,17 +1110,19 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
                           sprite->width(), sprite->height());
                 rttp->tgov = gov;
                 tt_help->append(rttp);
-                canvas_put_sprite_full(
-                    pcanvas, icon_startx,
-                    starty + text_h + 4
-                        + (height - text_h - 4 - sprite->height()) / 2,
-                    sprite);
+                p.drawPixmap(icon_startx,
+                             starty + text_h + 4
+                                 + (height - text_h - 4 - sprite->height())
+                                       / 2,
+                             *sprite);
                 icon_startx += sprite->width() + 2;
               }
             }
             requirement_vector_iterate_end;
           }
           governments_iterate_end;
+
+          p.end();
         }
       }
 
@@ -1143,6 +1146,7 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
       }
     }
   }
+
   return tt_help;
 }
 

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -1016,11 +1016,12 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
         int text_w, text_h;
         int icon_startx;
 
-        canvas_put_rectangle(pcanvas, get_diag_color(10), startx, starty,
-                             width, height);
-        // Print color rectangle with text inside.
-        canvas_put_rectangle(pcanvas, node_color(node), startx + 1,
-                             starty + 1, width - 2, height - 2);
+        QPainter p(pcanvas);
+        p.setBrush(node_color(node));
+        p.setPen(QPen(get_diag_color(10), 1));
+        p.drawRect(startx, starty, width - 2, height - 2);
+        p.end();
+
         /* The following code is similar to the one in
          * node_rectangle_minimum_size(). If you change something here,
          * change also node_rectangle_minimum_size().
@@ -1038,8 +1039,9 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
                         get_color(tileset, COLOR_REQTREE_TEXT), text);
         icon_startx = startx + 5;
 
+        p.begin(pcanvas);
+
         if (gui_options.reqtree_show_icons) {
-          QPainter p(pcanvas);
           unit_type_iterate(unit)
           {
             if (advance_number(unit->require_advance) != node->tech) {
@@ -1121,9 +1123,9 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
             requirement_vector_iterate_end;
           }
           governments_iterate_end;
-
-          p.end();
         }
+
+        p.end();
       }
 
       // Draw all outgoing edges


### PR DESCRIPTION
This brings `QPainter` into the core drawing code, removing the indirection layer and shaving another 400 lines of code.

The affected areas in the clients are:

* The main map (sprites, goto lines, trade routes, … virtually everything but city names)
* The minimap (visible area polygon)
* The tech tree (everything)
* The spaceship report