### PR TITLE
Hex corner terrain sprite type

### DIFF
--- a/client/layer_terrain.cpp
+++ b/client/layer_terrain.cpp
@@ -310,7 +310,6 @@ void layer_terrain::initialize_terrain(const terrain *terrain)
       break;
     }
     break;
-    break;
   case CELL_HEX_CORNER:
     if (tileset_topo_index(tileset()) != TS_TOPO_ISOHEX) {
       tileset_error(tileset(), LOG_ERROR,

--- a/client/layer_terrain.h
+++ b/client/layer_terrain.h
@@ -28,8 +28,9 @@ class layer_terrain : public layer {
 public:
   /// Indicates how many sprites are used to draw a tile.
   enum sprite_type {
-    CELL_WHOLE, ///< One sprite for the entire tile.
-    CELL_CORNER ///< One sprite for each corner of the tile.
+    CELL_WHOLE,      ///< One sprite for the entire tile.
+    CELL_CORNER,     ///< One sprite for each corner of the tile.
+    CELL_HEX_CORNER, ///< One sprite for each hexagonal corner of the tile.
   };
 
 private:
@@ -98,6 +99,8 @@ private:
                                          terrain_info &info);
   void initialize_cell_corner_match_full(const terrain *terrain,
                                          terrain_info &info);
+  void initialize_cell_hex_corner(const terrain *terrain,
+                                  terrain_info &info);
   void initialize_blending(const terrain *terrain, terrain_info &info);
 
   int terrain_group(const terrain *pterrain) const;

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -1500,6 +1500,9 @@ check_sprite_type(const char *sprite_type, const char *tile_section)
   if (fc_strcasecmp(sprite_type, "corner") == 0) {
     return freeciv::layer_terrain::CELL_CORNER;
   }
+  if (fc_strcasecmp(sprite_type, "hex_corner") == 0) {
+    return freeciv::layer_terrain::CELL_HEX_CORNER;
+  }
   if (fc_strcasecmp(sprite_type, "single") == 0) {
     return freeciv::layer_terrain::CELL_WHOLE;
   }

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -90,7 +90,7 @@
 
 #define TILESPEC_CAPSTR                                                     \
   "+Freeciv-tilespec-Devel-2019-Jul-03 duplicates_ok precise-hp-bars "      \
-  "unlimited-unit-select-frames unlimited-upkeep-sprites"
+  "unlimited-unit-select-frames unlimited-upkeep-sprites hex_corner"
 /*
  * Tilespec capabilities acceptable to this program:
  *
@@ -112,6 +112,8 @@
  * unlimited-upkeep-sprites
  *    - There is no limitation on the number of upkeep sprites
  *      (upkeep.unhappy*, upkeep.output*)
+ * hex_corner
+ *    - The sprite type "hex_corner" is supported
  */
 
 #define SPEC_CAPSTR "+Freeciv-spec-Devel-2019-Jul-03"

--- a/docs/Modding/Tilesets/compatibility.rst
+++ b/docs/Modding/Tilesets/compatibility.rst
@@ -41,3 +41,7 @@ The rest of this page lists the available flags and their meaning.
 
     The number of sprites used to display unit upkeep is no longer limited to 10
     (sprites ``upkeep.unhappy*``, ``upkeep.output*``).
+
+.. option:: hex_corner
+
+    Support for this option signals the availability of the new ``hex_corner`` sprite type for terrain.


### PR DESCRIPTION
The existing "corner" method doesn't work well in hexagonal mode because for N
matching groups ("match type"), it requires N^4 sprites. It gues without saying
that this explodes very quickly. In hexagonal mode, each corner is the meeting
point of only three tiles, making a O(N^3) method a better match.

This patch implements such a method, requiring 2 * N^3 sprites for N groups. It
is limited to ISO|HEX to prevent keep code complexity under control.

The sprite names take the following form:

    t.l[N].hex_cell_[left|right]_[g]_[g]_[g],

where the [g] are the first letters of the matching groups. It is expected that
the sprites are cut along the dotted lines in the following schema, which also
shows what `left` and `right` correspond to:

    ____
    .:..\...:.
     : R \__:_
    .:.../..:.
    _:__/ L :
    .:..\...:.
     : R \__:_
    .:.../..:.
    _:__/   :

Tested with Vectron dev version; shouldn't affect other modes in any way.