### PR TITLE
Unit subsurface vision (sonar)

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -836,6 +836,7 @@ bool dai_can_requirement_be_met_in_city(const struct requirement *preq,
   case VUT_ACTION:
   case VUT_GOOD:
   case VUT_MINCALFRAG:
+  case VUT_VISIONLAYER:
   case VUT_COUNT:
     // No sensible implementation possible with data available.
     break;

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -691,7 +691,8 @@ int get_player_bonus(const struct player *pplayer,
 /**
    Returns the effect bonus at a city.
  */
-int get_city_bonus(const struct city *pcity, enum effect_type effect_type)
+int get_city_bonus(const struct city *pcity, enum effect_type effect_type,
+		   enum vision_layer vlayer)
 {
   if (!initialized) {
     return 0;
@@ -699,7 +700,7 @@ int get_city_bonus(const struct city *pcity, enum effect_type effect_type)
 
   return get_target_bonus_effects(
       nullptr, city_owner(pcity), nullptr, pcity, nullptr, city_tile(pcity),
-      nullptr, nullptr, nullptr, nullptr, nullptr, effect_type);
+      nullptr, nullptr, nullptr, nullptr, nullptr, effect_type, vlayer);
 }
 
 /**

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -692,7 +692,7 @@ int get_player_bonus(const struct player *pplayer,
    Returns the effect bonus at a city.
  */
 int get_city_bonus(const struct city *pcity, enum effect_type effect_type,
-		   enum vision_layer vlayer)
+                   enum vision_layer vlayer)
 {
   if (!initialized) {
     return 0;
@@ -843,10 +843,9 @@ int get_unittype_bonus(const struct player *pplayer,
     pcity = nullptr;
   }
 
-  return get_target_bonus_effects(nullptr, pplayer, nullptr, pcity, nullptr,
-                                  ptile, nullptr, punittype, nullptr,
-                                  nullptr, nullptr, effect_type,
-                                  vision_layer);
+  return get_target_bonus_effects(
+      nullptr, pplayer, nullptr, pcity, nullptr, ptile, nullptr, punittype,
+      nullptr, nullptr, nullptr, effect_type, vision_layer);
 }
 
 /**

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -621,7 +621,8 @@ int get_target_bonus_effects(
     const struct unit *target_unit, const struct unit_type *target_unittype,
     const struct output_type *target_output,
     const struct specialist *target_specialist,
-    const struct action *target_action, enum effect_type effect_type)
+    const struct action *target_action, enum effect_type effect_type,
+    enum vision_layer vision_layer)
 {
   int bonus = 0;
 
@@ -632,7 +633,8 @@ int get_target_bonus_effects(
     if (are_reqs_active(target_player, other_player, target_city,
                         target_building, target_tile, target_unit,
                         target_unittype, target_output, target_specialist,
-                        target_action, &peffect->reqs, RPT_CERTAIN)) {
+                        target_action, &peffect->reqs, RPT_CERTAIN,
+                        vision_layer)) {
       /* This code will add value of effect. If there's multiplier for
        * effect and target_player aren't null, then value is multiplied
        * by player's multiplier factor. */
@@ -823,7 +825,8 @@ int get_building_bonus(const struct city *pcity,
 int get_unittype_bonus(const struct player *pplayer,
                        const struct tile *ptile,
                        const struct unit_type *punittype,
-                       enum effect_type effect_type)
+                       enum effect_type effect_type,
+                       enum vision_layer vision_layer)
 {
   struct city *pcity;
 
@@ -841,7 +844,8 @@ int get_unittype_bonus(const struct player *pplayer,
 
   return get_target_bonus_effects(nullptr, pplayer, nullptr, pcity, nullptr,
                                   ptile, nullptr, punittype, nullptr,
-                                  nullptr, nullptr, effect_type);
+                                  nullptr, nullptr, effect_type,
+                                  vision_layer);
 }
 
 /**

--- a/common/effects.h
+++ b/common/effects.h
@@ -368,7 +368,8 @@ bool is_building_replaced(const struct city *pcity,
 // functions to know the bonuses a certain effect is granting
 int get_world_bonus(enum effect_type effect_type);
 int get_player_bonus(const struct player *plr, enum effect_type effect_type);
-int get_city_bonus(const struct city *pcity, enum effect_type effect_type);
+int get_city_bonus(const struct city *pcity, enum effect_type effect_type,
+                   enum vision_layer vlayer = V_COUNT);
 int get_city_specialist_output_bonus(const struct city *pcity,
                                      const struct specialist *pspecialist,
                                      const struct output_type *poutput,

--- a/common/effects.h
+++ b/common/effects.h
@@ -392,7 +392,8 @@ int get_building_bonus(const struct city *pcity,
 int get_unittype_bonus(const struct player *pplayer,
                        const struct tile *ptile, // pcity is implied
                        const struct unit_type *punittype,
-                       enum effect_type effect_type);
+                       enum effect_type effect_type,
+                       enum vision_layer vision_layer = V_COUNT);
 int get_unit_bonus(const struct unit *punit, enum effect_type effect_type);
 int get_tile_bonus(const struct tile *ptile, const struct unit *punit,
                    enum effect_type etype);
@@ -415,7 +416,8 @@ int get_target_bonus_effects(
     const struct unit *target_unit, const struct unit_type *target_unittype,
     const struct output_type *target_output,
     const struct specialist *target_specialist,
-    const struct action *target_action, enum effect_type effect_type);
+    const struct action *target_action, enum effect_type effect_type,
+    enum vision_layer vision_layer = V_COUNT);
 
 bool building_has_effect(const struct impr_type *pimprove,
                          enum effect_type effect_type);

--- a/common/fc_types.h
+++ b/common/fc_types.h
@@ -517,6 +517,17 @@ typedef int Unit_Class_id;
 #define SPECENUM_COUNT IG_COUNT
 #include "specenum_gen.h"
 
+// Used in the network protocol.
+#define SPECENUM_NAME vision_layer
+#define SPECENUM_VALUE0 V_MAIN
+#define SPECENUM_VALUE0NAME "Main"
+#define SPECENUM_VALUE1 V_INVIS
+#define SPECENUM_VALUE1NAME "Stealth"
+#define SPECENUM_VALUE2 V_SUBSURFACE
+#define SPECENUM_VALUE2NAME "Subsurface"
+#define SPECENUM_COUNT V_COUNT
+#include "specenum_gen.h"
+
 // A server setting + its value.
 typedef int ssetv;
 
@@ -554,6 +565,7 @@ typedef union {
   enum ai_level ai_level;
   enum citytile_type citytile;
   enum citystatus_type citystatus;
+  enum vision_layer vlayer;
   int minsize;
   int minculture;
   int minforeignpct;
@@ -685,6 +697,8 @@ typedef union {
 #define SPECENUM_VALUE44NAME "MinForeignPct"
 #define SPECENUM_VALUE45 VUT_ACTIVITY
 #define SPECENUM_VALUE45NAME "Activity"
+#define SPECENUM_VALUE46 VUT_VISIONLAYER
+#define SPECENUM_VALUE46NAME "VisionLayer"
 // Keep this last.
 #define SPECENUM_COUNT VUT_COUNT
 #include "specenum_gen.h"
@@ -1083,17 +1097,6 @@ enum spaceship_place_type {
 #define SPECENUM_VALUE1NAME "Mixed"
 #define SPECENUM_VALUE2 GOLD_UPKEEP_NATION
 #define SPECENUM_VALUE2NAME "Nation"
-#include "specenum_gen.h"
-
-// Used in the network protocol.
-#define SPECENUM_NAME vision_layer
-#define SPECENUM_VALUE0 V_MAIN
-#define SPECENUM_VALUE0NAME "Main"
-#define SPECENUM_VALUE1 V_INVIS
-#define SPECENUM_VALUE1NAME "Stealth"
-#define SPECENUM_VALUE2 V_SUBSURFACE
-#define SPECENUM_VALUE2NAME "Subsurface"
-#define SPECENUM_COUNT V_COUNT
 #include "specenum_gen.h"
 
 typedef float adv_want;

--- a/common/metaknowledge.cpp
+++ b/common/metaknowledge.cpp
@@ -613,7 +613,8 @@ static bool is_req_knowable(
     }
   }
 
-  if (req->source.kind == VUT_ACTION || req->source.kind == VUT_OTYPE) {
+  if (req->source.kind == VUT_ACTION || req->source.kind == VUT_OTYPE
+      || req->source.kind == VUT_VISIONLAYER) {
     // This requirement type is intended to specify the situation.
     return true;
   }

--- a/common/reqtext.cpp
+++ b/common/reqtext.cpp
@@ -2836,6 +2836,28 @@ bool req_text_insert(char *buf, size_t bufsz, struct player *pplayer,
       }
     }
 
+  case VUT_VISIONLAYER:
+    switch (preq->range) {
+    case REQ_RANGE_LOCAL:
+      fc_strlcat(buf, prefix, bufsz);
+      if (preq->present) {
+        cat_snprintf(buf, bufsz, _("Applies to the \"%s\" vision layer."),
+                     qUtf8Printable(vision_layer_translated_name(
+                         preq->source.value.vlayer)));
+      } else {
+        cat_snprintf(buf, bufsz,
+                     _("Doesn't apply to the \"%s\""
+                       " vision layer."),
+                     qUtf8Printable(vision_layer_translated_name(
+                         preq->source.value.vlayer)));
+      }
+      return true;
+    default:
+      // Not supported.
+      break;
+    }
+    break;
+
   case VUT_COUNT:
     break;
   }

--- a/common/requirements.h
+++ b/common/requirements.h
@@ -107,7 +107,8 @@ bool is_req_active(
     const struct output_type *target_output,
     const struct specialist *target_specialist,
     const struct action *target_action, const struct requirement *req,
-    const enum req_problem_type prob_type);
+    const enum req_problem_type prob_type,
+    const enum vision_layer vision_layer = V_COUNT);
 bool are_reqs_active(const struct player *target_player,
                      const struct player *other_player,
                      const struct city *target_city,
@@ -119,7 +120,8 @@ bool are_reqs_active(const struct player *target_player,
                      const struct specialist *target_specialist,
                      const struct action *target_action,
                      const struct requirement_vector *reqs,
-                     const enum req_problem_type prob_type);
+                     const enum req_problem_type prob_type,
+                     const enum vision_layer vision_layer = V_COUNT);
 
 bool is_req_unchanging(const struct requirement *req);
 

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -328,16 +328,14 @@ static bool reqs_may_activate(const struct player *target_player,
  */
 static bool research_allowed(
     const struct research *presearch, Tech_type_id tech,
-    bool (*reqs_eval)(const struct player *tplr, const struct player *oplr,
-                      const struct city *tcity, const struct impr_type *tbld,
-                      const struct tile *ttile, const struct unit *tunit,
-                      const struct unit_type *tutype,
-                      const struct output_type *top,
-                      const struct specialist *tspe,
-                      const struct action *tact,
-                      const struct requirement_vector *reqs,
-                      const enum req_problem_type ptype,
-                      const enum vision_layer vlayer))
+    bool (*reqs_eval)(
+        const struct player *tplr, const struct player *oplr,
+        const struct city *tcity, const struct impr_type *tbld,
+        const struct tile *ttile, const struct unit *tunit,
+        const struct unit_type *tutype, const struct output_type *top,
+        const struct specialist *tspe, const struct action *tact,
+        const struct requirement_vector *reqs,
+        const enum req_problem_type ptype, const enum vision_layer vlayer))
 {
   struct advance *adv;
 

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -299,7 +299,8 @@ static bool reqs_may_activate(const struct player *target_player,
                               const struct specialist *target_specialist,
                               const struct action *target_action,
                               const struct requirement_vector *reqs,
-                              const enum req_problem_type prob_type)
+                              const enum req_problem_type prob_type,
+                              const enum vision_layer vision_layer)
 {
   requirement_vector_iterate(reqs, preq)
   {
@@ -307,7 +308,7 @@ static bool reqs_may_activate(const struct player *target_player,
         && !is_req_active(target_player, other_player, target_city,
                           target_building, target_tile, target_unit,
                           target_unittype, target_output, target_specialist,
-                          target_action, preq, prob_type)) {
+                          target_action, preq, prob_type, vision_layer)) {
       return false;
     }
   }
@@ -335,7 +336,8 @@ static bool research_allowed(
                       const struct specialist *tspe,
                       const struct action *tact,
                       const struct requirement_vector *reqs,
-                      const enum req_problem_type ptype))
+                      const enum req_problem_type ptype,
+                      const enum vision_layer vlayer))
 {
   struct advance *adv;
 
@@ -350,7 +352,7 @@ static bool research_allowed(
   {
     if (reqs_eval(pplayer, nullptr, nullptr, nullptr, nullptr, nullptr,
                   nullptr, nullptr, nullptr, nullptr, &(adv->research_reqs),
-                  RPT_CERTAIN)) {
+                  RPT_CERTAIN, V_COUNT)) {
       /* It is enough that one player that shares research is allowed to
        * research it.
        * Reasoning: Imagine a tech with that requires a nation in the

--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -13,7 +13,7 @@
 
 [datafile]
 description="Alien World effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -84,6 +84,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_base_unit_upkeep]
 type    = "Upkeep_Factor"
@@ -665,6 +678,7 @@ value   = 21
 reqs	=
     { "type", "name", "range"
       "Building", "Radar Tower", "City"
+      "VisionLayer", "Main", "Local"
     }
 
 [effect_archive]

--- a/data/civ1/effects.ruleset
+++ b/data/civ1/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ1 effects data for Freeciv (approximate)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -238,6 +238,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_bomb_limit_base]
 type    = "Bombard_Limit_Pct"

--- a/data/civ2/effects.ruleset
+++ b/data/civ2/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2 effects data for Freeciv (incomplete)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -432,6 +432,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_trade_routes]
 type    = "Max_Trade_Routes"

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -233,6 +233,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "Local"
       "Tech", "Astronomy", "Player"
     }
@@ -242,6 +243,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Airbase", "Local"
     }
 
@@ -437,6 +439,19 @@ value   = 100
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 ; 5 + 5 = 10
 [effect_city_vision_1]
@@ -444,6 +459,7 @@ type    = "City_Vision_Radius_Sq"
 value   = 5
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Tech", "Electricity", "Player"
     }
 
@@ -453,6 +469,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 4
 reqs    =
     { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local"
       "Terrain", "Mountains", "Local", TRUE
 ;      "UnitClass", "Land", "Local", FALSE
 ;      "UnitClass", "Small Land", "Local", FALSE

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -108,6 +108,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "tile"
       "Tech", "Invention", "player"
       "UnitClass", "Land", "Local"
@@ -200,6 +201,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_trade_routes_base]
 type    = "Max_Trade_Routes"

--- a/data/experimental/effects.ruleset
+++ b/data/experimental/effects.ruleset
@@ -14,7 +14,7 @@
 
 [datafile]
 description="Experimental effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -111,6 +111,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "tile"
       "Tech", "Invention", "player"
       "UnitClass", "Land", "Local"
@@ -122,6 +123,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "tile"
       "Tech", "Invention", "player"
       "UnitClass", "Big Land", "Local"
@@ -2626,7 +2628,7 @@ reqs	=
 type    = "Conquest_Tech_Pct"
 value   = 100
 
-; Base vision range - radius of vision is sqrt(2) = 1.41
+; Base vision range - radius of vision is sqrt(2) = 1.41 for all layers
 [effect_city_vision_0]
 type    = "City_Vision_Radius_Sq"
 value   = 2
@@ -2648,12 +2650,13 @@ reqs    =
       "MinSize", "3", "City"
     }
 
-; City radius 2 - radius of vision is sqrt(2+3) = 2.24
+; City radius 2 - radius of Main vision is sqrt(2+3) = 2.24
 [effect_city_vision_1]
 type    = "City_Vision_Radius_Sq"
 value   = 3
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "MinSize", "3", "City"
     }
 
@@ -2676,12 +2679,13 @@ reqs    =
       "Tech", "Railroad", "Player"
     }
 
-; City radius 3 - radius of vision is sqrt(2+3+5) = 3.16
+; City radius 3 - radius of Main vision is sqrt(2+3+5) = 3.16
 [effect_city_vision_2]
 type    = "City_Vision_Radius_Sq"
 value   = 5
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "MinSize", "10", "City"
       "Tech", "Railroad", "Player"
     }
@@ -2719,12 +2723,13 @@ reqs    =
       "Building", "Super Highways", "City"
     }
 
-; City radius 4 - radius of vision is sqrt(2+3+5+7) = 4.12
+; City radius 4 - radius of Main vision is sqrt(2+3+5+7) = 4.12
 [effect_city_vision_3]
 type    = "City_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "MinSize", "30", "City"
       "Tech", "Railroad", "Player"
       "Building", "Mass Transit", "City"

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Granularity effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -36,6 +36,19 @@ format_version=20
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_base_unit_upkeep]
 type	= "Upkeep_Factor"

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -108,6 +108,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "tile"
       "Tech", "Invention", "player"
       "UnitClass", "Land", "Local"
@@ -200,6 +201,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 [effect_conquest_tech]
 type    = "Conquest_Tech_Pct"

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -202,6 +202,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 18
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "Local"
       "Tech", "Astronomy", "Player"
     }
@@ -211,6 +212,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 18
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Airbase", "Local"
     }
 
@@ -369,7 +371,20 @@ value   = 0
 ; Base vision range - radius of vision is sqrt(5) = 2.24 - this is intentionally smaller than the city working area
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
-value   = 18
+value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 ; 5 + 5 = 10
 [effect_city_vision_1]
@@ -377,6 +392,7 @@ type    = "City_Vision_Radius_Sq"
 value   = 15
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Tech", "Electricity", "Player"
     }
 
@@ -386,6 +402,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 18
 reqs    =
     { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local"
       "Terrain", "Mountains", "Local", TRUE
 ;      "UnitClass", "Land", "Local", FALSE
 ;      "UnitClass", "Small Land", "Local", FALSE

--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -233,6 +233,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "Local"
       "Tech", "Astronomy", "Player"
     }
@@ -242,6 +243,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Airbase", "Local"
     }
 
@@ -441,6 +443,19 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 ; 5 + 5 = 10
 [effect_city_vision_1]
@@ -448,6 +463,7 @@ type    = "City_Vision_Radius_Sq"
 value   = 5
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Tech", "Electricity", "Player"
     }
 
@@ -457,6 +473,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 4
 reqs    =
     { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local"
       "Terrain", "Mountains", "Local", TRUE
 ;      "UnitClass", "Land", "Local", FALSE
 ;      "UnitClass", "Small Land", "Local", FALSE

--- a/data/stub/effects.ruleset
+++ b/data/stub/effects.ruleset
@@ -3,7 +3,7 @@
 
 [datafile]
 description="<modpack> effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings

--- a/data/webperimental/effects.ruleset
+++ b/data/webperimental/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Experimental web-client effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -108,6 +108,7 @@ type    = "Unit_Vision_Radius_Sq"
 value   = 8
 reqs    =
     { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
       "Extra", "Fortress", "tile"
       "Tech", "Invention", "player"
       "UnitClass", "Land", "Local"
@@ -199,15 +200,29 @@ reqs    =
 [effect_city_vision]
 type    = "City_Vision_Radius_Sq"
 value   = 5
+reqs    =
+    { "type", "name", "range"
+      "VisionLayer", "Main", "Local"
+    }
+
+; Stealth or Subsurface can only be seen when adjacent
+[effect_city_vision_layers]
+type    = "City_Vision_Radius_Sq"
+value   = 2
+reqs    =
+    { "type", "name", "range", "present"
+      "VisionLayer", "Main", "Local", FALSE
+    }
 
 ; Vision benefit from mountains (for every land unit)
 [effect_mountains_vision]
 type    = "Unit_Vision_Radius_Sq"
 value   = 4
 reqs    =
-    { "type",      "name",      "range"
-      "Terrain",   "Mountains", "Local"
-      "UnitClass", "Land",      "Local"
+    { "type",        "name",      "range"
+      "VisionLayer", "Main",      "Local"
+      "Terrain",     "Mountains", "Local"
+      "UnitClass",   "Land",      "Local"
     }
 
 [effect_trade_routes_base]

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -97,6 +97,7 @@ Requirement          Supported ranges
 ``MinMoveFrags``     ``Local``
 ``MinVeteran``       ``Local``
 ``MinHitPoints``     ``Local``
+``VisionLayer``      ``Local``
 ==================== ================
 
 * MinSize is the minimum size of a city required.
@@ -480,8 +481,25 @@ HP_Regen_Min
 City_Vision_Radius_Sq
     Increase city vision radius in squared distance by amount tiles.
 
+    .. note::
+        This effect is added automatically for VisionLayers other than Main,
+        with a value of 2, and a VisionLayer=Main requirement is added to any
+        existing instances of this effect.
+        This behaviour can be turned off by requiring the ``+VisionLayer``
+        option in ``effects.ruleset``, allowing you to use VisionLayer
+        requirements to specify which layer (Main, Stealth or Subsurface)
+        the effect applies to.
+
 Unit_Vision_Radius_Sq
     Increase unit vision radius in squared distance by amount tiles.
+
+    .. note::
+        A VisionLayer=Main requirement is added automatically to any
+        existing instances of this effect.
+        This behaviour can be turned off by requiring the ``+VisionLayer``
+        option in ``effects.ruleset``, allowing you to use VisionLayer
+        requirements to specify which layer (Main, Stealth or Subsurface)
+        the effect applies to.
 
 Defend_Bonus
     Increases defensive bonuses of units. Any unit requirements on this effect will be applied to the

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -3249,7 +3249,10 @@ void city_landlocked_sell_coastal_improvements(struct tile *ptile)
 void city_refresh_vision(struct city *pcity)
 {
   v_radius_t vision_radius_sq = V_RADIUS(
-      (short) get_city_bonus(pcity, EFT_CITY_VISION_RADIUS_SQ), 2, 2);
+      (short) get_city_bonus(pcity, EFT_CITY_VISION_RADIUS_SQ, V_MAIN),
+      (short) get_city_bonus(pcity, EFT_CITY_VISION_RADIUS_SQ, V_INVIS),
+      (short) get_city_bonus(pcity, EFT_CITY_VISION_RADIUS_SQ,
+                             V_SUBSURFACE));
 
   vision_change_sight(pcity->server.vision, vision_radius_sq);
   ASSERT_VISION(pcity->server.vision);

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -1761,6 +1761,7 @@ static bool worklist_item_postpone_req_vec(struct universal *target,
       case VUT_TERRAINALTER: // XXX could do this in principle
       case VUT_CITYTILE:
       case VUT_CITYSTATUS:
+      case VUT_VISIONLAYER:
         // Will only happen with a bogus ruleset.
         qCritical("worklist_change_build_target() has bogus preq");
         break;

--- a/server/maphand.cpp
+++ b/server/maphand.cpp
@@ -627,7 +627,7 @@ void send_tile_info(struct conn_list *dest, struct tile *ptile,
 static bool unit_is_visible_on_layer(const struct unit *punit,
                                      enum vision_layer vlayer)
 {
-  return XOR(vlayer == V_MAIN, is_hiding_unit(punit));
+  return vlayer == unit_type_get(punit)->vlayer;
 }
 
 /**

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1081,12 +1081,11 @@ void rscompat_postprocess(struct rscompat_info *info)
 /**
  * Adds <VisionLayer, Main, Local, True> req to all unit/city vision reqs,
  * as compat for missing CAP_VUT_VISIONLAYER
+ *
+ * @data is a struct rscompat_info *.
  */
 static bool rscompat_vision_effect_cb(struct effect *peffect, void *data)
 {
-  struct rscompat_info [[maybe_unused]] *info =
-      static_cast<struct rscompat_info *>(data);
-
   if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ
       || peffect->type == EFT_CITY_VISION_RADIUS_SQ) {
     effect_req_append(peffect, req_from_str("VisionLayer", "Local", false,

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1079,7 +1079,7 @@ void rscompat_postprocess(struct rscompat_info *info)
 }
 
 /**
- * Adds <VisionLayer, Main, Local, True> req to all unit vision reqs,
+ * Adds <VisionLayer, Main, Local, True> req to all unit/city vision reqs,
  * as compat for missing CAP_VUT_VISIONLAYER
  */
 static bool rscompat_vision_effect_cb(struct effect *peffect, void *data)
@@ -1087,7 +1087,8 @@ static bool rscompat_vision_effect_cb(struct effect *peffect, void *data)
   struct rscompat_info [[maybe_unused]] *info =
       static_cast<struct rscompat_info *>(data);
 
-  if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ) {
+  if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ ||
+      peffect->type == EFT_CITY_VISION_RADIUS_SQ) {
     effect_req_append(peffect,
                       req_from_str("VisionLayer", "Local", false, true,
                                    false, "Main"));
@@ -1168,8 +1169,14 @@ static void rscompat_optional_capabilities(rscompat_info *info)
     unit_type_iterate_end;
   }
 
-  if (!has_capability(CAP_VUT_VISIONLAYER, info->cap_effects.data()))
+  if (!has_capability(CAP_VUT_VISIONLAYER, info->cap_effects.data())) {
+    // Add vlayer=Main to existing vision effects
     iterate_effect_cache(rscompat_vision_effect_cb, info);
+    // Add effect to give cities radius 2 vision on other layers
+    auto effect = effect_new(EFT_CITY_VISION_RADIUS_SQ, 2, nullptr);
+    effect_req_append(effect, req_from_str("VisionLayer", "Local", false,
+                                           false, false, "Main"));
+  }
 }
 
 /**

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1087,11 +1087,10 @@ static bool rscompat_vision_effect_cb(struct effect *peffect, void *data)
   struct rscompat_info [[maybe_unused]] *info =
       static_cast<struct rscompat_info *>(data);
 
-  if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ ||
-      peffect->type == EFT_CITY_VISION_RADIUS_SQ) {
-    effect_req_append(peffect,
-                      req_from_str("VisionLayer", "Local", false, true,
-                                   false, "Main"));
+  if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ
+      || peffect->type == EFT_CITY_VISION_RADIUS_SQ) {
+    effect_req_append(peffect, req_from_str("VisionLayer", "Local", false,
+                                            true, false, "Main"));
   }
 
   return true;

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1079,6 +1079,24 @@ void rscompat_postprocess(struct rscompat_info *info)
 }
 
 /**
+ * Adds <VisionLayer, Main, Local, True> req to all unit vision reqs,
+ * as compat for missing CAP_VUT_VISIONLAYER
+ */
+static bool rscompat_vision_effect_cb(struct effect *peffect, void *data)
+{
+  struct rscompat_info [[maybe_unused]] *info =
+      static_cast<struct rscompat_info *>(data);
+
+  if (peffect->type == EFT_UNIT_VISION_RADIUS_SQ) {
+    effect_req_append(peffect,
+                      req_from_str("VisionLayer", "Local", false, true,
+                                   false, "Main"));
+  }
+
+  return true;
+}
+
+/**
  * Handles compatibility with older versions when the new behavior is
  * tied to the presence of an optional ruleset capability.
  */
@@ -1149,6 +1167,9 @@ static void rscompat_optional_capabilities(rscompat_info *info)
     }
     unit_type_iterate_end;
   }
+
+  if (!has_capability(CAP_VUT_VISIONLAYER, info->cap_effects.data()))
+    iterate_effect_cache(rscompat_vision_effect_cb, info);
 }
 
 /**

--- a/server/rssanity.cpp
+++ b/server/rssanity.cpp
@@ -308,6 +308,7 @@ static bool sanity_check_req_set(int reqs_of_type[],
     case VUT_STYLE:
     case VUT_IMPR_GENUS:
     case VUT_CITYSTATUS:
+    case VUT_VISIONLAYER:
       /* There can be only one requirement of these types (with current
        * range limitations)
        * Requirements might be identical, but we consider multiple

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -16,9 +16,10 @@
 
 #define CAP_EFT_HP_REGEN_MIN "HP_Regen_Min"
 #define CAP_EFT_BOMBARD_LIMIT_PCT "Bombard_Limit_Pct"
+#define CAP_VUT_VISIONLAYER "Vision_Layer"
 #define RULESET_CAPABILITIES                                                \
   "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN                \
-  " " CAP_EFT_BOMBARD_LIMIT_PCT
+  " " CAP_EFT_BOMBARD_LIMIT_PCT " " CAP_VUT_VISIONLAYER
 /*
  * Ruleset capabilities acceptable to this program:
  *

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -4571,16 +4571,16 @@ bool execute_orders(struct unit *punit, const bool fresh)
 int get_unit_vision_at(struct unit *punit, const struct tile *ptile,
                        enum vision_layer vlayer)
 {
-  const int base =
-      (unit_type_get(punit)->vision_radius_sq
-       + get_unittype_bonus(unit_owner(punit), ptile, unit_type_get(punit),
-                            EFT_UNIT_VISION_RADIUS_SQ));
+  const int base = unit_type_get(punit)->vision_radius_sq;
+  const int bonus = get_unittype_bonus(unit_owner(punit), ptile,
+                                       unit_type_get(punit),
+                                       EFT_UNIT_VISION_RADIUS_SQ, vlayer);
   switch (vlayer) {
   case V_MAIN:
-    return MAX(0, base);
+    return MAX(0, base) + MAX(0, bonus);
   case V_INVIS:
   case V_SUBSURFACE:
-    return CLIP(0, base, 2);
+    return CLIP(0, base, 2) + MAX(0, bonus);
   case V_COUNT:
     break;
   }

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -1511,6 +1511,16 @@ void transform_unit(struct unit *punit, const struct unit_type *to_unit,
   const struct unit_type *old_type = punit->utype;
   int old_mr = unit_move_rate(punit);
   int old_hp = unit_type_get(punit)->hp;
+  bv_player can_see_unit;
+
+  BV_CLR_ALL(can_see_unit);
+  players_iterate(oplayer)
+  {
+    if (can_player_see_unit(oplayer, punit)) {
+      BV_SET(can_see_unit, player_index(oplayer));
+    }
+  }
+  players_iterate_end;
 
   if (!is_free) {
     pplayer->economic.gold -=
@@ -1559,6 +1569,16 @@ void transform_unit(struct unit *punit, const struct unit_type *to_unit,
   conn_list_do_buffer(pplayer->connections);
 
   unit_refresh_vision(punit);
+
+  // unit may disappear for some players if vlayer changed
+  players_iterate(oplayer)
+  {
+    if (BV_ISSET(can_see_unit, player_index(oplayer))
+        && !can_player_see_unit(oplayer, punit)) {
+      unit_goes_out_of_sight(oplayer, punit);
+    }
+  }
+  players_iterate_end;
 
   CALL_PLR_AI_FUNC(unit_transformed, pplayer, punit, old_type);
   CALL_FUNC_EACH_AI(unit_info, punit);

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -4592,9 +4592,9 @@ int get_unit_vision_at(struct unit *punit, const struct tile *ptile,
                        enum vision_layer vlayer)
 {
   const int base = unit_type_get(punit)->vision_radius_sq;
-  const int bonus = get_unittype_bonus(unit_owner(punit), ptile,
-                                       unit_type_get(punit),
-                                       EFT_UNIT_VISION_RADIUS_SQ, vlayer);
+  const int bonus =
+      get_unittype_bonus(unit_owner(punit), ptile, unit_type_get(punit),
+                         EFT_UNIT_VISION_RADIUS_SQ, vlayer);
   switch (vlayer) {
   case V_MAIN:
     return MAX(0, base) + MAX(0, bonus);

--- a/tools/ruledit/univ_value.cpp
+++ b/tools/ruledit/univ_value.cpp
@@ -216,6 +216,9 @@ bool universal_value_initial(struct universal *src)
   case VUT_EXTRAFLAG:
     src->value.extraflag = EF_NATIVE_TILE;
     return true;
+  case VUT_VISIONLAYER:
+    src->value.vlayer = V_MAIN;
+    return true;
   case VUT_COUNT:
     fc_assert(src->kind != VUT_COUNT);
     return false;
@@ -466,6 +469,12 @@ void universal_kind_values(struct universal *univ, univ_kind_values_cb cb,
       cb(action_rule_name(pact), univ->value.action == pact, data);
     }
     action_iterate_end;
+    break;
+  case VUT_VISIONLAYER:
+    for (i = 0; i < V_COUNT; i++) {
+      cb(vision_layer_name(vision_layer(i)),
+         univ->value.vlayer == i, data);
+    }
     break;
   case VUT_MINSIZE:
   case VUT_MINYEAR:

--- a/tools/ruledit/univ_value.cpp
+++ b/tools/ruledit/univ_value.cpp
@@ -472,8 +472,7 @@ void universal_kind_values(struct universal *univ, univ_kind_values_cb cb,
     break;
   case VUT_VISIONLAYER:
     for (i = 0; i < V_COUNT; i++) {
-      cb(vision_layer_name(vision_layer(i)),
-         univ->value.vlayer == i, data);
+      cb(vision_layer_name(vision_layer(i)), univ->value.vlayer == i, data);
     }
     break;
   case VUT_MINSIZE:


### PR DESCRIPTION
Add a requirement type `Vision_Layer` that allows `Unit_Vision_Radius_Sq` or `City_Vision_Radius_Sq` effects to apply to `Subsurface` or `Stealth` layers instead of `Main`; make those bonuses apply _after_ subs/invis vision range is capped to 2; and fix a couple of bugs in vision handling.
Add a ruleset effects capability `+Vision_Layer`; and compatibility for old rulesets to retain existing behaviour.  Update the shipped rulesets to retain their old behaviour (except in the case of `stub` where we omit the req on city vision for simplicity).

Closes #893.