### PR TITLE
Add missing QtSvg dependency to Coverity build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,6 @@ jobs:
             gettext \
             qt5-default \
             libqt5svg5-dev \
-            libqt5svg5-dev \
             libkf5archive-dev \
             liblua5.3-dev \
             libsqlite3-dev \

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -23,6 +23,7 @@ jobs:
             python3 \
             gettext \
             qt5-default \
+            libqt5svg5-dev \
             libkf5archive-dev \
             liblua5.3-dev \
             libsqlite3-dev \


### PR DESCRIPTION
Also remove a duplicated dep from the normal CI builds.

Closes #927.