### PR TITLE
Restore --bind <address> functionality

### DIFF
--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -15,7 +15,9 @@
 #include <fc_config.h>
 #endif
 
+#include <QHostAddress>
 #include <QString>
+
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -301,7 +303,12 @@ int main(int argc, char *argv[])
     }
   }
   if (parser.isSet(QStringLiteral("bind"))) {
-    srvarg.bind_addr = parser.value(QStringLiteral("bind"));
+    auto addr = parser.value(QStringLiteral("bind"));
+    // Check consistency
+    if (!srvarg.bind_addr.setAddress(addr)) {
+      qCritical(_("Not a valid IP address: %s"), qUtf8Printable(addr));
+      exit(EXIT_FAILURE);
+    }
   }
   if (parser.isSet(QStringLiteral("Bind-meta"))) {
     srvarg.bind_meta_addr = parser.value(QStringLiteral("Bind-meta"));

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -378,11 +378,9 @@ QTcpServer *server_open_socket()
 
   int max = srvarg.port + 100;
   for (; srvarg.port < max; ++srvarg.port) {
-    qDebug("Server attempting to listen on %s:%d",
-           srvarg.bind_addr.isNull() ? qUtf8Printable(srvarg.bind_addr)
-                                     : "(any)",
-           srvarg.port);
-    if (server->listen(QHostAddress::Any, srvarg.port)) {
+    qInfo("Server attempting to listen on %s:%d",
+          qUtf8Printable(srvarg.bind_addr.toString()), srvarg.port);
+    if (server->listen(srvarg.bind_addr, srvarg.port)) {
       break;
     }
 

--- a/server/srv_main.h
+++ b/server/srv_main.h
@@ -20,6 +20,9 @@
 #include "fc_types.h"
 #include "game.h"
 
+// Qt
+#include <QHostAddress>
+
 struct conn_list;
 
 struct server_arguments {
@@ -30,7 +33,7 @@ struct server_arguments {
   QString identity_name;
   unsigned short int metaserver_port;
   // address this server is to listen on (NULL => INADDR_ANY)
-  QString bind_addr;
+  QHostAddress bind_addr;
   // this server's listen port
   int port;
   bool user_specified_port;


### PR DESCRIPTION
This allows to bind the server to a specific address, which is often safer.
Support for this option was broken when porting to Qt sockets.

**Test plan**

* Get a list of IP addresses for your machine (`inet` and `inet6` lines in the output of `ip addr`)
* Start a server with `--bind longturn.net`: fails with error
* Start a server, passing any address of the loopback interface (`lo`) to `--bind`: succeeds and client can connect
* Start a server, passing the address of your machine on any other interface (`eth`, `enps`, `wlan`, …): succeeds and client fails to connect for me, but YMMV I'm no networking expert. Client from another machine might be able to connect with this address if it's in the same network.
* Start a server, passing a random address (for instance `123.45.67.89`) fails very loudly.

Was part of #888 