### PR TITLE
Fix starting the server from the client

### DIFF
--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -246,7 +246,7 @@ bool client_start_server(const QString &user_name)
   scensdir = QStringLiteral("%1/scenarios").arg(storage);
 
   arguments << QStringLiteral("-p") << port_buf << QStringLiteral("--bind")
-            << QStringLiteral("localhost") << QStringLiteral("-q")
+            << QStringLiteral("127.0.0.1") << QStringLiteral("-q")
             << QStringLiteral("1") << QStringLiteral("-e")
             << QStringLiteral("--saves") << savesdir
             << QStringLiteral("--scenarios") << scensdir


### PR DESCRIPTION
The --bind server option no longer takes hostnames (how to know which IP to
listen to?), but the client was passing "--bind localhost" when starting a
local server. Switch to "--bind 127.0.0.1", which is totally equivalent for
virtually every system out there.

Closes #935.