### PR TITLE
Fix assertion in api_methods_enemy_tile()

### DIFF
--- a/common/scriptcore/api_game_methods.cpp
+++ b/common/scriptcore/api_game_methods.cpp
@@ -884,7 +884,7 @@ bool api_methods_enemy_tile(lua_State *L, Tile *ptile, Player *against)
   }
 
   pcity = tile_city(ptile);
-  return ptile != NULL && !pplayers_allied(against, city_owner(pcity));
+  return pcity != NULL && !pplayers_allied(against, city_owner(pcity));
 }
 
 /**


### PR DESCRIPTION
If lua Tile:is_enemy() is called on a tile with neither enemy units nor
 a city, the call to city_owner() will be passed a NULL pcity.
Clearly the ptile != NULL guard was supposed to check pcity instead, so
 do that.