### PR TITLE
Run clang-format before starting build checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ jobs:
   ubuntu:
     name: "Ubuntu"
     runs-on: ubuntu-latest
+    needs: clang-format
     strategy:
       matrix:
         compiler: [gcc, clang]
@@ -75,6 +76,7 @@ jobs:
   windows:
     name: "Windows"
     runs-on: windows-latest
+    needs: clang-format
     defaults:
       run:
         shell: msys2 {0}
@@ -122,6 +124,7 @@ jobs:
   os_x:
     name: "Mac OS X"
     runs-on: macos-latest
+    needs: clang-format
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
       VCPKG_BUILD_TYPE: release
@@ -188,6 +191,7 @@ jobs:
   wasm:
     name: "WebAssembly"
     runs-on: ubuntu-latest
+    needs: clang-format
     env:
       QT_VERSION: 5.15.2
     steps:


### PR DESCRIPTION
Closes #959.

~This also sends a bot message to the PR with some instructions when `clang-format` fails.~ edit: not possible without heavy workarounds.