### PR TITLE
Add clang-format automation

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -1,0 +1,58 @@
+name: Automation
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply-clang-format:
+    name: "Apply clang-format"
+    runs-on: ubuntu-latest
+    # Conditions for the action to run:
+    # - It must be a comment on a PR
+    # - The comment must contain "Auto clang-format"
+    # - The author of the comment must be the PR author or a repo member. For
+    #   the values of author_association, see:
+    #    https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: >-
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, 'Auto clang-format')
+      && (github.event.comment.user.id == github.event.issue.user.id
+          || github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `:baby_bottle: **clang-format**
+            This branch will be reformatted automatically with \`clang-format\`. Please avoid doing this for complex PRs and use squash merge when it makes sense — the bot :space_invader:`
+            })
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install clang-format-11
+        run: |
+          sudo apt-get install clang-format-11
+      - name: Format the code
+        run: |
+          find -name dependencies -prune -o \
+            \( -name '*.h' -o -name '*.cpp' \) \
+            -print \
+            -exec clang-format-11 -i '{}' +
+      - name: Commit and push
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'actions@github.com>'
+          # Only try to commit if clang-format changed something
+          if ! git diff --quiet ; then
+            git commit -a \
+              -m "Automated clang-format" \
+              -m "See PR #${{ github.event.issue.number }}"
+          fi
+          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}" \
+            "HEAD:${GITHUB_REF_NAME}"

--- a/docs/Contributing/eval-pull-request.rst
+++ b/docs/Contributing/eval-pull-request.rst
@@ -6,6 +6,13 @@ It is the policy of the Longturn community that all (100%) Pull Requests have at
 an evaluation of a change and either approve or make suggestions for improvements before a merge into the
 master branch.
 
+For each Pull Request, a set of tests are run automatically. When the tests do not pass, the author is
+expected to fix the problems by himself before someone tries to test the code. There is an exception to this
+for simple changes with code formatting issues (as flagged by the automated `clang-format` test): in this
+case, the author of the Pull Request or a maintainer can request automatic reformatting of the code by adding
+a comment that contains the case-sensitive phrase "Auto clang-format". This triggers a script that, if
+successful, fixes the code formatting by adding a new commit to the branch of the Pull Request.
+
 This page assumes the user knows how to use :file:`git`, compile Freeciv21 and use GitHub.
 
 :strong:`Create A Testing Branch`


### PR DESCRIPTION
By commenting on a PR with a message that contains "Auto clang-format",
maintainers and PR authors can trigger an automated run of clang-format.  This
can be used to fix PRs when their author isn't willing to do so or is simply
not responding.

The action posts a message reminding to avoid this for complex PRs: this action
is mainly intended at PRs with a single commit where the reformatting can be
squashed easily.  Anything more complex should be handled by a human.

Developed and tested in https://github.com/lmoureaux/freeciv21/pull/1.
See https://github.com/longturn/freeciv21/pull/923, https://github.com/longturn/freeciv21/pull/947 for PRs that would [have] benefited from this action.
See https://github.com/longturn/freeciv21/pull/924 for an example where I think use of this action not indicated.

----

The action needs to live on the main branch of the repository and thus cannot be tested here. I did my testing in https://github.com/lmoureaux/freeciv21/pull/1 and any PR against my fork will have the action enabled because it is currently present in the default branch. This can be used for testing.

The action posts the following message as soon as it starts running:

> :baby_bottle: **clang-format**
> This branch will be reformatted automatically with `clang-format`. Please avoid doing this for complex PRs and use squash merge when it makes sense — the bot :space_invader: