### PR TITLE
Refactor/path finding class

### DIFF
--- a/ai/classic/classicai.cpp
+++ b/ai/classic/classicai.cpp
@@ -39,6 +39,7 @@
 
 #include "classicai.h"
 
+class Pf_path;
 /* This function is only needed as symbol in module. Nevertheless
    gcc requires that there is prior prototype. */
 const char *fc_ai_classic_capstr();
@@ -349,7 +350,7 @@ static void cai_unit_turn_end(struct unit *punit)
    Call default ai with classic ai type as parameter.
  */
 static void cai_unit_move_or_attack(struct unit *punit, struct tile *ptile,
-                                    struct pf_path *path, int step)
+                                    Pf_path *path, int step)
 {
   struct ai_type *deftype = classic_ai_get_self();
 

--- a/ai/classic/classicai.cpp
+++ b/ai/classic/classicai.cpp
@@ -350,7 +350,7 @@ static void cai_unit_turn_end(struct unit *punit)
    Call default ai with classic ai type as parameter.
  */
 static void cai_unit_move_or_attack(struct unit *punit, struct tile *ptile,
-                                    PFPath path, int step)
+                                    const PFPath &path, int step)
 {
   struct ai_type *deftype = classic_ai_get_self();
 

--- a/ai/classic/classicai.cpp
+++ b/ai/classic/classicai.cpp
@@ -350,7 +350,7 @@ static void cai_unit_turn_end(struct unit *punit)
    Call default ai with classic ai type as parameter.
  */
 static void cai_unit_move_or_attack(struct unit *punit, struct tile *ptile,
-                                    Pf_path *path, int step)
+                                    Pf_path path, int step)
 {
   struct ai_type *deftype = classic_ai_get_self();
 

--- a/ai/classic/classicai.cpp
+++ b/ai/classic/classicai.cpp
@@ -39,7 +39,7 @@
 
 #include "classicai.h"
 
-class Pf_path;
+class PFPath;
 /* This function is only needed as symbol in module. Nevertheless
    gcc requires that there is prior prototype. */
 const char *fc_ai_classic_capstr();
@@ -350,7 +350,7 @@ static void cai_unit_turn_end(struct unit *punit)
    Call default ai with classic ai type as parameter.
  */
 static void cai_unit_move_or_attack(struct unit *punit, struct tile *ptile,
-                                    Pf_path path, int step)
+                                    PFPath path, int step)
 {
   struct ai_type *deftype = classic_ai_get_self();
 

--- a/ai/default/aiair.cpp
+++ b/ai/default/aiair.cpp
@@ -48,7 +48,7 @@
 
 #include "aiair.h"
 
-class Pf_path;
+class PFPath;
 /**
    Looks for nearest airbase for punit reachable imediatly.
    Returns nullptr if not found.  The path is stored in the path
@@ -57,7 +57,7 @@ class Pf_path;
          IMO should be less restrictive than general H_MAP, H_FOG
  */
 static struct tile *find_nearest_airbase(const struct unit *punit,
-                                         Pf_path *path)
+                                         PFPath *path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -75,7 +75,7 @@ static struct tile *find_nearest_airbase(const struct unit *punit,
     }
 
     if (is_airunit_refuel_point(ptile, pplayer, punit)) {
-        *path = pf_map_path(pfm, ptile);
+      *path = pf_map_path(pfm, ptile);
       pf_map_destroy(pfm);
       return ptile;
     }
@@ -201,7 +201,7 @@ static int dai_evaluate_tile_for_air_attack(struct unit *punit,
          IMO should be more restrictive than general H_MAP, H_FOG
  */
 static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
-                                  Pf_path *path, struct tile **pptile)
+                                  PFPath *path, struct tile **pptile)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -252,7 +252,7 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
     *pptile = best_tile;
   }
   if (path) {
-    *path = best_tile ? pf_map_path(pfm, best_tile) : Pf_path();
+    *path = best_tile ? pf_map_path(pfm, best_tile) : PFPath();
   }
   pf_map_destroy(pfm);
   return best;
@@ -265,7 +265,7 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
  */
 static struct tile *dai_find_strategic_airbase(struct ai_type *ait,
                                                const struct unit *punit,
-                                               Pf_path *path)
+                                               PFPath *path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -317,7 +317,7 @@ static struct tile *dai_find_strategic_airbase(struct ai_type *ait,
 
   if (path) {
     // Stores the path.
-    *path = best_tile ? pf_map_path(pfm, best_tile) : Pf_path();
+    *path = best_tile ? pf_map_path(pfm, best_tile) : PFPath();
   }
   pf_map_destroy(pfm);
 
@@ -346,7 +346,7 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
   int id = punit->id;
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  Pf_path path;
+  PFPath path;
   CHECK_UNIT(punit);
   pft_fill_unit_parameter(&parameter, punit);
 

--- a/ai/default/aiair.cpp
+++ b/ai/default/aiair.cpp
@@ -57,7 +57,7 @@ class Pf_path;
          IMO should be less restrictive than general H_MAP, H_FOG
  */
 static struct tile *find_nearest_airbase(const struct unit *punit,
-                                         Pf_path **path)
+                                         Pf_path *path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -75,9 +75,7 @@ static struct tile *find_nearest_airbase(const struct unit *punit,
     }
 
     if (is_airunit_refuel_point(ptile, pplayer, punit)) {
-      if (path) {
         *path = pf_map_path(pfm, ptile);
-      }
       pf_map_destroy(pfm);
       return ptile;
     }
@@ -203,7 +201,7 @@ static int dai_evaluate_tile_for_air_attack(struct unit *punit,
          IMO should be more restrictive than general H_MAP, H_FOG
  */
 static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
-                                  Pf_path **path, struct tile **pptile)
+                                  Pf_path *path, struct tile **pptile)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -254,9 +252,8 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
     *pptile = best_tile;
   }
   if (path) {
-    *path = best_tile ? pf_map_path(pfm, best_tile) : nullptr;
+    *path = best_tile ? pf_map_path(pfm, best_tile) : Pf_path();
   }
-
   pf_map_destroy(pfm);
   return best;
 }
@@ -268,7 +265,7 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
  */
 static struct tile *dai_find_strategic_airbase(struct ai_type *ait,
                                                const struct unit *punit,
-                                               Pf_path **path)
+                                               Pf_path *path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -320,7 +317,7 @@ static struct tile *dai_find_strategic_airbase(struct ai_type *ait,
 
   if (path) {
     // Stores the path.
-    *path = best_tile ? pf_map_path(pfm, best_tile) : nullptr;
+    *path = best_tile ? pf_map_path(pfm, best_tile) : Pf_path();
   }
   pf_map_destroy(pfm);
 
@@ -349,8 +346,7 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
   int id = punit->id;
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  Pf_path *path;
-
+  Pf_path path;
   CHECK_UNIT(punit);
   pft_fill_unit_parameter(&parameter, punit);
 
@@ -363,10 +359,8 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
         && is_airunit_refuel_point(punit->goto_tile, pplayer, punit)) {
       pfm = pf_map_new(&parameter);
       path = pf_map_path(pfm, punit->goto_tile);
-      if (path) {
+      if (!path.empty()) {
         bool alive = adv_follow_path(punit, path, punit->goto_tile);
-
-        pf_path_destroy(path);
         pf_map_destroy(pfm);
         if (alive && punit->moves_left > 0) {
           // Maybe do something else.
@@ -378,10 +372,8 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
     } else if ((dst_tile = find_nearest_airbase(punit, &path))) {
       // Go refuelling
       if (!adv_follow_path(punit, path, dst_tile)) {
-        pf_path_destroy(path);
         return; // The unit died.
       }
-      pf_path_destroy(path);
     } else {
       if (punit->fuel == 1) {
         UNIT_LOG(LOG_DEBUG, punit, "Oops, fallin outta the sky");
@@ -397,12 +389,10 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
       /* Found target, coordinates are in punit's goto_dest.
        * TODO: separate attacking into a function, check for the best
        * tile to attack from */
-      fc_assert_ret(path != nullptr && dst_tile != nullptr);
+      fc_assert_ret(!path.empty() && dst_tile != nullptr);
       if (!adv_follow_path(punit, path, dst_tile)) {
-        pf_path_destroy(path);
         return; // The unit died.
       }
-      pf_path_destroy(path);
 
       /* goto would be aborted: "Aborting GOTO for AI attack procedures"
        * now actually need to attack */
@@ -418,10 +408,8 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
                                     : "");
       def_ai_unit_data(punit, ait)->done = true; // Wait for next turn
       if (!adv_follow_path(punit, path, dst_tile)) {
-        pf_path_destroy(path);
         return; // The unit died.
       }
-      pf_path_destroy(path);
     } else {
       log_debug("%s cannot find anything to kill and is staying put",
                 unit_rule_name(punit));

--- a/ai/default/aiair.cpp
+++ b/ai/default/aiair.cpp
@@ -48,6 +48,7 @@
 
 #include "aiair.h"
 
+class Pf_path;
 /**
    Looks for nearest airbase for punit reachable imediatly.
    Returns nullptr if not found.  The path is stored in the path
@@ -56,7 +57,7 @@
          IMO should be less restrictive than general H_MAP, H_FOG
  */
 static struct tile *find_nearest_airbase(const struct unit *punit,
-                                         struct pf_path **path)
+                                         Pf_path **path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -202,8 +203,7 @@ static int dai_evaluate_tile_for_air_attack(struct unit *punit,
          IMO should be more restrictive than general H_MAP, H_FOG
  */
 static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
-                                  struct pf_path **path,
-                                  struct tile **pptile)
+                                  Pf_path **path, struct tile **pptile)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -268,7 +268,7 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
  */
 static struct tile *dai_find_strategic_airbase(struct ai_type *ait,
                                                const struct unit *punit,
-                                               struct pf_path **path)
+                                               Pf_path **path)
 {
   struct player *pplayer = unit_owner(punit);
   struct pf_parameter parameter;
@@ -349,7 +349,7 @@ void dai_manage_airunit(struct ai_type *ait, struct player *pplayer,
   int id = punit->id;
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
 
   CHECK_UNIT(punit);
   pft_fill_unit_parameter(&parameter, punit);

--- a/ai/default/aidiplomat.cpp
+++ b/ai/default/aidiplomat.cpp
@@ -77,7 +77,7 @@
  * previously used one. This is important for diplomacy. - Per */
 #define DIPLO_DEFENSE_WANT 3000
 
-class Pf_path;
+class PFPath;
 
 static bool is_city_surrounded_by_our_spies(struct player *pplayer,
                                             struct city *pcity);
@@ -651,7 +651,7 @@ static bool dai_diplomat_bribe_nearby(struct ai_type *ait,
     // Found someone!
     {
       struct tile *bribee_tile;
-      Pf_path path;
+      PFPath path;
 
       bribee_tile =
           mapstep(&(wld.map), pos.tile,

--- a/ai/default/aidiplomat.cpp
+++ b/ai/default/aidiplomat.cpp
@@ -651,18 +651,16 @@ static bool dai_diplomat_bribe_nearby(struct ai_type *ait,
     // Found someone!
     {
       struct tile *bribee_tile;
-      Pf_path *path;
+      Pf_path path;
 
       bribee_tile =
           mapstep(&(wld.map), pos.tile,
                   static_cast<direction8>(DIR_REVERSE(pos.dir_to_here)));
       path = pf_map_path(pfm, bribee_tile);
-      if (!path || !adv_unit_execute_path(punit, path)
+      if (!path.empty() || !adv_unit_execute_path(punit, path)
           || punit->moves_left <= 0) {
-        pf_path_destroy(path);
         return false;
       }
-      pf_path_destroy(path);
     }
 
     if (action_prob_possible(
@@ -838,10 +836,8 @@ void dai_manage_diplomat(struct ai_type *ait, struct player *pplayer,
 
   // GOTO unless we want to stay
   if (!same_pos(unit_tile(punit), ctarget->tile)) {
-    Pf_path *path;
-
-    path = pf_map_path(pfm, punit->goto_tile);
-    if (path && adv_unit_execute_path(punit, path)
+    auto path = pf_map_path(pfm, punit->goto_tile);
+    if (!path.empty() && adv_unit_execute_path(punit, path)
         && punit->moves_left > 0) {
       // Check if we can do something with our destination now.
       if (unit_data->task == AIUNIT_ATTACK) {
@@ -856,7 +852,6 @@ void dai_manage_diplomat(struct ai_type *ait, struct player *pplayer,
         }
       }
     }
-    pf_path_destroy(path);
   } else {
     def_ai_unit_data(punit, ait)->done = true;
   }

--- a/ai/default/aidiplomat.cpp
+++ b/ai/default/aidiplomat.cpp
@@ -657,7 +657,7 @@ static bool dai_diplomat_bribe_nearby(struct ai_type *ait,
           mapstep(&(wld.map), pos.tile,
                   static_cast<direction8>(DIR_REVERSE(pos.dir_to_here)));
       path = pf_map_path(pfm, bribee_tile);
-      if (!path.empty() || !adv_unit_execute_path(punit, path)
+      if (path.empty() || !adv_unit_execute_path(punit, path)
           || punit->moves_left <= 0) {
         return false;
       }

--- a/ai/default/aidiplomat.cpp
+++ b/ai/default/aidiplomat.cpp
@@ -77,6 +77,8 @@
  * previously used one. This is important for diplomacy. - Per */
 #define DIPLO_DEFENSE_WANT 3000
 
+class Pf_path;
+
 static bool is_city_surrounded_by_our_spies(struct player *pplayer,
                                             struct city *pcity);
 
@@ -649,7 +651,7 @@ static bool dai_diplomat_bribe_nearby(struct ai_type *ait,
     // Found someone!
     {
       struct tile *bribee_tile;
-      struct pf_path *path;
+      Pf_path *path;
 
       bribee_tile =
           mapstep(&(wld.map), pos.tile,
@@ -836,7 +838,7 @@ void dai_manage_diplomat(struct ai_type *ait, struct player *pplayer,
 
   // GOTO unless we want to stay
   if (!same_pos(unit_tile(punit), ctarget->tile)) {
-    struct pf_path *path;
+    Pf_path *path;
 
     path = pf_map_path(pfm, punit->goto_tile);
     if (path && adv_unit_execute_path(punit, path)

--- a/ai/default/aiferry.cpp
+++ b/ai/default/aiferry.cpp
@@ -495,7 +495,7 @@ bool is_boss_of_boat(struct ai_type *ait, struct unit *punit)
    combined_land_sea_move), the path won't lead onto the boat itself.
  */
 int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
-                      Pf_path *path)
+                      PFPath *path)
 {
   int best_turns = FC_INFINITY;
   int best_id = 0;
@@ -565,7 +565,7 @@ int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
                      "Found a potential boat %s[%d](%d,%d)(moves left: %d)",
                      unit_rule_name(aunit), aunit->id,
                      TILE_XY(unit_tile(aunit)), aunit->moves_left);
-              *path = pf_map_iter_path(search_map);
+            *path = pf_map_iter_path(search_map);
             best_turns = turns;
             best_id = aunit->id;
           }
@@ -777,7 +777,7 @@ bool aiferry_gobyboat(struct ai_type *ait, struct player *pplayer,
              TILE_XY(dest_tile));
 
     if (!is_terrain_class_near_tile(unit_tile(punit), TC_OCEAN)) {
-      Pf_path path_to_ferry;
+      PFPath path_to_ferry;
 
       boatid = aiferry_find_boat(ait, punit, cap, &path_to_ferry);
       if (boatid <= 0) {

--- a/ai/default/aiferry.cpp
+++ b/ai/default/aiferry.cpp
@@ -495,7 +495,7 @@ bool is_boss_of_boat(struct ai_type *ait, struct unit *punit)
    combined_land_sea_move), the path won't lead onto the boat itself.
  */
 int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
-                      struct pf_path **path)
+                      Pf_path **path)
 {
   int best_turns = FC_INFINITY;
   int best_id = 0;
@@ -650,7 +650,7 @@ bool dai_amphibious_goto_constrained(struct ai_type *ait, struct unit *ferry,
   bool alive = true;
   struct player *pplayer = unit_owner(passenger);
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
   int pass_id = passenger->id;
 
   fc_assert_ret_val(is_ai(pplayer), true);
@@ -784,7 +784,7 @@ bool aiferry_gobyboat(struct ai_type *ait, struct player *pplayer,
              TILE_XY(dest_tile));
 
     if (!is_terrain_class_near_tile(unit_tile(punit), TC_OCEAN)) {
-      struct pf_path *path_to_ferry = nullptr;
+      Pf_path *path_to_ferry = nullptr;
 
       boatid = aiferry_find_boat(ait, punit, cap, &path_to_ferry);
       if (boatid <= 0) {

--- a/ai/default/aiferry.cpp
+++ b/ai/default/aiferry.cpp
@@ -512,7 +512,7 @@ int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
    * Don't try to be clever and pass 'fallback' path that will be returned
    * if no path is found. Instead check for nullptr return value and then
    * use fallback path in calling function. */
-  fc_assert_ret_val(!path->empty(), 0);
+  fc_assert_ret_val(path->empty(), 0);
 
   fc_assert_ret_val(0 < ferryboat || FERRY_NONE == ferryboat
                         || FERRY_WANTED == ferryboat,

--- a/ai/default/aiferry.h
+++ b/ai/default/aiferry.h
@@ -13,7 +13,7 @@
 
 #include "fc_types.h"
 
-class Pf_path;
+class PFPath;
 struct pft_amphibious;
 
 bool dai_is_ferry_type(const struct unit_type *pferry, struct ai_type *ait);
@@ -28,7 +28,7 @@ void aiferry_init_stats(struct ai_type *ait, struct player *pplayer);
  * Find the nearest boat.  Can be called from inside the continents too
  */
 int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
-                      Pf_path *path);
+                      PFPath *path);
 
 /*
  * How many boats are available

--- a/ai/default/aiferry.h
+++ b/ai/default/aiferry.h
@@ -13,7 +13,7 @@
 
 #include "fc_types.h"
 
-struct pf_path;
+class Pf_path;
 struct pft_amphibious;
 
 bool dai_is_ferry_type(const struct unit_type *pferry, struct ai_type *ait);
@@ -28,7 +28,7 @@ void aiferry_init_stats(struct ai_type *ait, struct player *pplayer);
  * Find the nearest boat.  Can be called from inside the continents too
  */
 int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
-                      struct pf_path **path);
+                      Pf_path **path);
 
 /*
  * How many boats are available

--- a/ai/default/aiferry.h
+++ b/ai/default/aiferry.h
@@ -28,7 +28,7 @@ void aiferry_init_stats(struct ai_type *ait, struct player *pplayer);
  * Find the nearest boat.  Can be called from inside the continents too
  */
 int aiferry_find_boat(struct ai_type *ait, struct unit *punit, int cap,
-                      Pf_path **path);
+                      Pf_path *path);
 
 /*
  * How many boats are available

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -55,7 +55,7 @@
 
 #include "aihunt.h"
 
-class Pf_path;
+class PFPath;
 
 /**
    We don't need a hunter in this city if we already have one. Return

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -55,6 +55,8 @@
 
 #include "aihunt.h"
 
+class Pf_path;
+
 /**
    We don't need a hunter in this city if we already have one. Return
    existing hunter if any.
@@ -487,7 +489,7 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
       struct player *aplayer = unit_owner(target);
       int dist1, dist2, stackthreat = 0, stackcost = 0;
       int sanity_target = target->id;
-      struct pf_path *path;
+      Pf_path *path;
       struct unit_ai *target_data;
 
       // Note that we need not (yet) be at war with aplayer

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -489,7 +489,6 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
       struct player *aplayer = unit_owner(target);
       int dist1, dist2, stackthreat = 0, stackcost = 0;
       int sanity_target = target->id;
-      Pf_path *path;
       struct unit_ai *target_data;
 
       // Note that we need not (yet) be at war with aplayer
@@ -591,13 +590,11 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
       }
 
       // Go towards it.
-      path = pf_map_path(pfm, unit_tile(target));
+      auto path = pf_map_path(pfm, unit_tile(target));
       if (!adv_unit_execute_path(punit, path)) {
-        pf_path_destroy(path);
         pf_map_destroy(pfm);
         return 0;
       }
-      pf_path_destroy(path);
 
       if (target != game_unit_by_number(sanity_target)) {
         UNIT_LOG(LOGLEVEL_HUNT, punit, "mission accomplished");

--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -1089,7 +1089,7 @@ BUILD_CITY:
     if (pcity == nullptr) {
       best_impr = settler_evaluate_improvements(
           punit, &best_act, &best_target, &best_tile, &path, state);
-      if (path.empty()) {
+      if (!path.empty()) {
         completion_time = path[-1].turn;
       }
     }

--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -114,7 +114,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  * This is % of defense % to increase want by. */
 #define DEFENSE_EMPHASIS 20
 
-class Pf_path;
+class PFPath;
 
 struct tile_data_cache {
   char food;   // food output of the tile
@@ -901,7 +901,7 @@ static struct cityresult *find_best_city_placement(struct ai_type *ait,
   // Phase 2: Consider travelling to another continent
 
   if (look_for_boat) {
-    auto path = Pf_path();
+    auto path = PFPath();
     int ferry_id = aiferry_find_boat(ait, punit, 1, &path);
 
     ferry = game_unit_by_number(ferry_id);
@@ -1013,7 +1013,7 @@ void dai_auto_settler_run(struct ai_type *ait, struct player *pplayer,
   enum unit_activity best_act;
   struct extra_type *best_target;
   struct tile *best_tile = nullptr;
-  Pf_path path;
+  PFPath path;
   struct city *pcity = nullptr;
 
   // time it will take worker to complete its given task
@@ -1130,7 +1130,7 @@ BUILD_CITY:
       cityresult_destroy(result);
 
       /*** Go back to and found a city ***/
-      path = Pf_path();
+      path = PFPath();
       goto BUILD_CITY;
     } else if (best_impr > 0) {
       UNIT_LOG(LOG_DEBUG, punit, "improves terrain instead of founding");

--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -114,6 +114,8 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  * This is % of defense % to increase want by. */
 #define DEFENSE_EMPHASIS 20
 
+class Pf_path;
+
 struct tile_data_cache {
   char food;   // food output of the tile
   char trade;  // trade output of the tile
@@ -1010,7 +1012,7 @@ void dai_auto_settler_run(struct ai_type *ait, struct player *pplayer,
   enum unit_activity best_act;
   struct extra_type *best_target;
   struct tile *best_tile = nullptr;
-  struct pf_path *path = nullptr;
+  Pf_path *path = nullptr;
   struct city *pcity = nullptr;
 
   // time it will take worker to complete its given task

--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -901,7 +901,8 @@ static struct cityresult *find_best_city_placement(struct ai_type *ait,
   // Phase 2: Consider travelling to another continent
 
   if (look_for_boat) {
-    int ferry_id = aiferry_find_boat(ait, punit, 1, nullptr);
+    auto path = Pf_path();
+    int ferry_id = aiferry_find_boat(ait, punit, 1, &path);
 
     ferry = game_unit_by_number(ferry_id);
   }

--- a/ai/default/aitools.cpp
+++ b/ai/default/aitools.cpp
@@ -326,27 +326,23 @@ struct tile *immediate_destination(struct unit *punit,
       && utype_fuel(unit_type_get(punit))) {
     struct pf_parameter parameter;
     struct pf_map *pfm;
-    Pf_path *path;
     size_t i;
     struct player *pplayer = unit_owner(punit);
 
     pft_fill_unit_parameter(&parameter, punit);
     parameter.omniscience = !has_handicap(pplayer, H_MAP);
     pfm = pf_map_new(&parameter);
-    path = pf_map_path(pfm, punit->goto_tile);
+    auto path = pf_map_path(pfm, punit->goto_tile);
 
-    if (path) {
-      for (i = 1; i < path->length; i++) {
-        if (path->positions[i].tile == path->positions[i - 1].tile) {
+    if (!path.empty()) {
+      for (i = 1; i < path.length(); i++) {
+        if (path[i].tile == path[i - 1].tile) {
           // The path-finding code advices us to wait there to refuel.
-          struct tile *ptile = path->positions[i].tile;
-
-          pf_path_destroy(path);
+          struct tile *ptile = path[i].tile;
           pf_map_destroy(pfm);
           return ptile;
         }
       }
-      pf_path_destroy(path);
       pf_map_destroy(pfm);
       // Seems it's the immediate destination
       return punit->goto_tile;
@@ -368,16 +364,16 @@ struct tile *immediate_destination(struct unit *punit,
 /**
    Log the cost of travelling a path.
  */
-void dai_log_path(struct unit *punit, Pf_path *path,
+void dai_log_path(struct unit *punit, Pf_path path,
                   struct pf_parameter *parameter)
 {
-  const struct pf_position *last = pf_path_last_position(path);
-  const int cc = PF_TURN_FACTOR * last->total_MC
-                 + parameter->move_rate * last->total_EC;
+  const struct pf_position last = path[-1];
+  const int cc =
+      PF_TURN_FACTOR * last.total_MC + parameter->move_rate * last.total_EC;
   const int tc = cc / (PF_TURN_FACTOR * parameter->move_rate);
 
   UNIT_LOG(LOG_DEBUG, punit, "path L=%d T=%d(%d) MC=%d EC=%d CC=%d",
-           path->length - 1, last->turn, tc, last->total_MC, last->total_EC,
+           path.length() - 1, last.turn, tc, last.total_MC, last.total_EC,
            cc);
 }
 
@@ -396,7 +392,6 @@ bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
 {
   bool alive = true;
   struct pf_map *pfm;
-  Pf_path *path;
 
   UNIT_LOG(LOG_DEBUG, punit, "constrained goto to %d,%d", TILE_XY(ptile));
 
@@ -426,9 +421,9 @@ bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
   }
 
   pfm = pf_map_new(parameter);
-  path = pf_map_path(pfm, ptile);
+  auto path = pf_map_path(pfm, ptile);
 
-  if (path) {
+  if (!path.empty()) {
     dai_log_path(punit, path, parameter);
     UNIT_LOG(LOG_DEBUG, punit, "constrained goto: following path.");
     alive = adv_follow_path(punit, path, ptile);
@@ -436,7 +431,6 @@ bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
     UNIT_LOG(LOG_DEBUG, punit, "no path to destination");
   }
 
-  pf_path_destroy(path);
   pf_map_destroy(pfm);
 
   return alive;
@@ -941,9 +935,9 @@ bool dai_unit_attack(struct ai_type *ait, struct unit *punit,
    Ai unit moving function called from AI interface.
  */
 void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, Pf_path *path, int step)
+                             struct tile *ptile, Pf_path path, int step)
 {
-  if (step == path->length - 1) {
+  if (step == path.length() - 1) {
     (void) dai_unit_attack(ait, punit, ptile);
   } else {
     (void) dai_unit_move(ait, punit, ptile);

--- a/ai/default/aitools.cpp
+++ b/ai/default/aitools.cpp
@@ -364,7 +364,7 @@ struct tile *immediate_destination(struct unit *punit,
 /**
    Log the cost of travelling a path.
  */
-void dai_log_path(struct unit *punit, PFPath path,
+void dai_log_path(struct unit *punit, const PFPath &path,
                   struct pf_parameter *parameter)
 {
   const struct pf_position last = path[-1];
@@ -935,7 +935,8 @@ bool dai_unit_attack(struct ai_type *ait, struct unit *punit,
    Ai unit moving function called from AI interface.
  */
 void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, PFPath path, int step)
+                             struct tile *ptile, const PFPath &path,
+                             int step)
 {
   if (step == path.length() - 1) {
     (void) dai_unit_attack(ait, punit, ptile);

--- a/ai/default/aitools.cpp
+++ b/ai/default/aitools.cpp
@@ -70,6 +70,7 @@
 
 #include "aitools.h"
 
+class Pf_path;
 /**
    Return the (untranslated) rule name of the ai_unit_task.
    You don't have to free the return pointer.
@@ -325,7 +326,7 @@ struct tile *immediate_destination(struct unit *punit,
       && utype_fuel(unit_type_get(punit))) {
     struct pf_parameter parameter;
     struct pf_map *pfm;
-    struct pf_path *path;
+    Pf_path *path;
     size_t i;
     struct player *pplayer = unit_owner(punit);
 
@@ -367,7 +368,7 @@ struct tile *immediate_destination(struct unit *punit,
 /**
    Log the cost of travelling a path.
  */
-void dai_log_path(struct unit *punit, struct pf_path *path,
+void dai_log_path(struct unit *punit, Pf_path *path,
                   struct pf_parameter *parameter)
 {
   const struct pf_position *last = pf_path_last_position(path);
@@ -395,7 +396,7 @@ bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
 {
   bool alive = true;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
 
   UNIT_LOG(LOG_DEBUG, punit, "constrained goto to %d,%d", TILE_XY(ptile));
 
@@ -940,8 +941,7 @@ bool dai_unit_attack(struct ai_type *ait, struct unit *punit,
    Ai unit moving function called from AI interface.
  */
 void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, struct pf_path *path,
-                             int step)
+                             struct tile *ptile, Pf_path *path, int step)
 {
   if (step == path->length - 1) {
     (void) dai_unit_attack(ait, punit, ptile);

--- a/ai/default/aitools.cpp
+++ b/ai/default/aitools.cpp
@@ -70,7 +70,7 @@
 
 #include "aitools.h"
 
-class Pf_path;
+class PFPath;
 /**
    Return the (untranslated) rule name of the ai_unit_task.
    You don't have to free the return pointer.
@@ -364,7 +364,7 @@ struct tile *immediate_destination(struct unit *punit,
 /**
    Log the cost of travelling a path.
  */
-void dai_log_path(struct unit *punit, Pf_path path,
+void dai_log_path(struct unit *punit, PFPath path,
                   struct pf_parameter *parameter)
 {
   const struct pf_position last = path[-1];
@@ -935,7 +935,7 @@ bool dai_unit_attack(struct ai_type *ait, struct unit *punit,
    Ai unit moving function called from AI interface.
  */
 void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, Pf_path path, int step)
+                             struct tile *ptile, PFPath path, int step)
 {
   if (step == path.length() - 1) {
     (void) dai_unit_attack(ait, punit, ptile);

--- a/ai/default/aitools.h
+++ b/ai/default/aitools.h
@@ -35,8 +35,8 @@ int military_amortize(struct player *pplayer, struct city *pcity, int value,
                       int delay, int build_cost);
 int stack_cost(struct unit *pattacker, struct unit *pdefender);
 
-void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, Pf_path *path, int step);
+void dai_unit_move_or_attack(ai_type *ait, unit *punit, tile *ptile,
+                             Pf_path path, int step);
 
 void dai_fill_unit_param(struct ai_type *ait, struct pf_parameter *parameter,
                          struct adv_risk_cost *risk_cost, struct unit *punit,
@@ -45,7 +45,7 @@ bool dai_gothere(struct ai_type *ait, struct player *pplayer,
                  struct unit *punit, struct tile *dst_tile);
 struct tile *immediate_destination(struct unit *punit,
                                    struct tile *dest_tile);
-void dai_log_path(struct unit *punit, Pf_path *path,
+void dai_log_path(struct unit *punit, Pf_path path,
                   struct pf_parameter *parameter);
 bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
                                struct tile *ptile,

--- a/ai/default/aitools.h
+++ b/ai/default/aitools.h
@@ -36,7 +36,7 @@ int military_amortize(struct player *pplayer, struct city *pcity, int value,
 int stack_cost(struct unit *pattacker, struct unit *pdefender);
 
 void dai_unit_move_or_attack(ai_type *ait, unit *punit, tile *ptile,
-                             PFPath path, int step);
+                             const PFPath &path, int step);
 
 void dai_fill_unit_param(struct ai_type *ait, struct pf_parameter *parameter,
                          struct adv_risk_cost *risk_cost, struct unit *punit,
@@ -45,7 +45,7 @@ bool dai_gothere(struct ai_type *ait, struct player *pplayer,
                  struct unit *punit, struct tile *dst_tile);
 struct tile *immediate_destination(struct unit *punit,
                                    struct tile *dest_tile);
-void dai_log_path(struct unit *punit, PFPath path,
+void dai_log_path(struct unit *punit, const PFPath &path,
                   struct pf_parameter *parameter);
 bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
                                struct tile *ptile,

--- a/ai/default/aitools.h
+++ b/ai/default/aitools.h
@@ -24,7 +24,7 @@
 #include "aiunit.h"
 #include "daicity.h"
 
-struct pf_path;
+class Pf_path;
 struct pf_parameter;
 struct pft_amphibious;
 
@@ -36,8 +36,7 @@ int military_amortize(struct player *pplayer, struct city *pcity, int value,
 int stack_cost(struct unit *pattacker, struct unit *pdefender);
 
 void dai_unit_move_or_attack(struct ai_type *ait, struct unit *punit,
-                             struct tile *ptile, struct pf_path *path,
-                             int step);
+                             struct tile *ptile, Pf_path *path, int step);
 
 void dai_fill_unit_param(struct ai_type *ait, struct pf_parameter *parameter,
                          struct adv_risk_cost *risk_cost, struct unit *punit,
@@ -46,7 +45,7 @@ bool dai_gothere(struct ai_type *ait, struct player *pplayer,
                  struct unit *punit, struct tile *dst_tile);
 struct tile *immediate_destination(struct unit *punit,
                                    struct tile *dest_tile);
-void dai_log_path(struct unit *punit, struct pf_path *path,
+void dai_log_path(struct unit *punit, Pf_path *path,
                   struct pf_parameter *parameter);
 bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
                                struct tile *ptile,

--- a/ai/default/aitools.h
+++ b/ai/default/aitools.h
@@ -24,7 +24,7 @@
 #include "aiunit.h"
 #include "daicity.h"
 
-class Pf_path;
+class PFPath;
 struct pf_parameter;
 struct pft_amphibious;
 
@@ -36,7 +36,7 @@ int military_amortize(struct player *pplayer, struct city *pcity, int value,
 int stack_cost(struct unit *pattacker, struct unit *pdefender);
 
 void dai_unit_move_or_attack(ai_type *ait, unit *punit, tile *ptile,
-                             Pf_path path, int step);
+                             PFPath path, int step);
 
 void dai_fill_unit_param(struct ai_type *ait, struct pf_parameter *parameter,
                          struct adv_risk_cost *risk_cost, struct unit *punit,
@@ -45,7 +45,7 @@ bool dai_gothere(struct ai_type *ait, struct player *pplayer,
                  struct unit *punit, struct tile *dst_tile);
 struct tile *immediate_destination(struct unit *punit,
                                    struct tile *dest_tile);
-void dai_log_path(struct unit *punit, Pf_path path,
+void dai_log_path(struct unit *punit, PFPath path,
                   struct pf_parameter *parameter);
 bool dai_unit_goto_constrained(struct ai_type *ait, struct unit *punit,
                                struct tile *ptile,

--- a/ai/default/aiunit.cpp
+++ b/ai/default/aiunit.cpp
@@ -1295,8 +1295,9 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
 
     if (nullptr == ferryboat) {
       // Try to find new boat
+      auto path = Pf_path();
       ferryboat = player_unit_by_number(
-          pplayer, aiferry_find_boat(ait, punit, 1, nullptr));
+          pplayer, aiferry_find_boat(ait, punit, 1, &path));
     }
 
     if (0 == punit->id && is_terrain_class_near_tile(punit_tile, TC_OCEAN)) {

--- a/ai/default/aiunit.cpp
+++ b/ai/default/aiunit.cpp
@@ -87,6 +87,8 @@
 #define LOG_CARAVAN2 LOG_DEBUG
 #define LOG_CARAVAN3 LOG_DEBUG
 
+class Pf_path;
+
 static bool dai_find_boat_for_unit(struct ai_type *ait, struct unit *punit);
 static bool dai_caravan_can_trade_cities_diff_cont(struct player *pplayer,
                                                    struct unit *punit);
@@ -521,11 +523,11 @@ static int dai_rampage_want(struct unit *punit, struct tile *ptile)
 /**
    Look for worthy targets within a one-turn horizon.
  */
-static struct pf_path *find_rampage_target(struct unit *punit,
-                                           int thresh_adj, int thresh_move)
+static Pf_path *find_rampage_target(struct unit *punit, int thresh_adj,
+                                    int thresh_move)
 {
   struct pf_map *tgt_map;
-  struct pf_path *path = nullptr;
+  Pf_path *path = nullptr;
   struct pf_parameter parameter;
   // Coordinates of the best target (initialize to silence compiler)
   struct tile *ptile = unit_tile(punit);
@@ -605,7 +607,7 @@ bool dai_military_rampage(struct unit *punit, int thresh_adj,
                           int thresh_move)
 {
   int count = punit->moves_left + 1; // break any infinite loops
-  struct pf_path *path = nullptr;
+  Pf_path *path = nullptr;
 
   TIMING_LOG(AIT_RAMPAGE, TIMER_START);
   CHECK_UNIT(punit);
@@ -1131,7 +1133,7 @@ bool find_beachhead(const struct player *pplayer, struct pf_map *ferry_map,
  */
 int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
                            struct unit *punit, struct tile **pdest_tile,
-                           struct pf_path **ppath, struct pf_map **pferrymap,
+                           Pf_path **ppath, struct pf_map **pferrymap,
                            struct unit **pferryboat,
                            const struct unit_type **pboattype,
                            int *pmove_time)
@@ -1783,7 +1785,7 @@ static void dai_military_attack(struct ai_type *ait, struct player *pplayer,
   // Main attack loop
   do {
     struct tile *start_tile = unit_tile(punit);
-    struct pf_path *path;
+    Pf_path *path;
     struct unit *ferryboat;
 
     // Then find enemies the hard way
@@ -1905,7 +1907,7 @@ static bool dai_find_boat_for_unit(struct ai_type *ait, struct unit *punit)
 {
   bool alive = true;
   int ferryboat = 0;
-  struct pf_path *path_to_ferry = nullptr;
+  Pf_path *path_to_ferry = nullptr;
 
   UNIT_LOG(LOG_CARAVAN, punit, "requesting a boat!");
   ferryboat = aiferry_find_boat(ait, punit, 1, &path_to_ferry);
@@ -2949,7 +2951,7 @@ static void dai_manage_barbarian_leader(struct ai_type *ait,
         if (unit_owner(punit) == pplayer
             && !unit_has_type_role(punit, L_BARBARIAN_LEADER)
             && goto_is_sane(punit, leader_tile)) {
-          struct pf_path *path = pf_map_path(pfm, ptile);
+          Pf_path *path = pf_map_path(pfm, ptile);
 
           adv_follow_path(leader, path, ptile);
           pf_path_destroy(path);

--- a/ai/default/aiunit.cpp
+++ b/ai/default/aiunit.cpp
@@ -87,7 +87,7 @@
 #define LOG_CARAVAN2 LOG_DEBUG
 #define LOG_CARAVAN3 LOG_DEBUG
 
-class Pf_path;
+class PFPath;
 
 static bool dai_find_boat_for_unit(struct ai_type *ait, struct unit *punit);
 static bool dai_caravan_can_trade_cities_diff_cont(struct player *pplayer,
@@ -523,11 +523,11 @@ static int dai_rampage_want(struct unit *punit, struct tile *ptile)
 /**
    Look for worthy targets within a one-turn horizon.
  */
-static Pf_path find_rampage_target(struct unit *punit, int thresh_adj,
-                                   int thresh_move)
+static PFPath find_rampage_target(struct unit *punit, int thresh_adj,
+                                  int thresh_move)
 {
   struct pf_map *tgt_map;
-  Pf_path path;
+  PFPath path;
   struct pf_parameter parameter;
   // Coordinates of the best target (initialize to silence compiler)
   struct tile *ptile = unit_tile(punit);
@@ -607,7 +607,7 @@ bool dai_military_rampage(struct unit *punit, int thresh_adj,
                           int thresh_move)
 {
   int count = punit->moves_left + 1; // break any infinite loops
-  Pf_path path;
+  PFPath path;
 
   TIMING_LOG(AIT_RAMPAGE, TIMER_START);
   CHECK_UNIT(punit);
@@ -1129,7 +1129,7 @@ bool find_beachhead(const struct player *pplayer, struct pf_map *ferry_map,
  */
 int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
                            struct unit *punit, struct tile **pdest_tile,
-                           Pf_path *ppath, struct pf_map **pferrymap,
+                           PFPath *ppath, struct pf_map **pferrymap,
                            struct unit **pferryboat,
                            const struct unit_type **pboattype,
                            int *pmove_time)
@@ -1184,7 +1184,7 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
     *pmove_time = 0;
   }
   if (!ppath->empty()) {
-    *ppath = Pf_path();
+    *ppath = PFPath();
   }
 
   if (0 == attack_value) {
@@ -1295,7 +1295,7 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
 
     if (nullptr == ferryboat) {
       // Try to find new boat
-      auto path = Pf_path();
+      auto path = PFPath();
       ferryboat = player_unit_by_number(
           pplayer, aiferry_find_boat(ait, punit, 1, &path));
     }
@@ -1607,7 +1607,7 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
   if (!ppath->empty()) {
     *ppath = (nullptr != goto_dest_tile && goto_dest_tile != punit_tile
                   ? pf_map_path(punit_map, goto_dest_tile)
-                  : Pf_path());
+                  : PFPath());
   }
 
   pf_map_destroy(punit_map);
@@ -1782,7 +1782,7 @@ static void dai_military_attack(struct ai_type *ait, struct player *pplayer,
   // Main attack loop
   do {
     struct tile *start_tile = unit_tile(punit);
-    Pf_path path;
+    PFPath path;
     struct unit *ferryboat;
 
     // Then find enemies the hard way
@@ -1897,7 +1897,7 @@ static bool dai_find_boat_for_unit(struct ai_type *ait, struct unit *punit)
 {
   bool alive = true;
   int ferryboat = 0;
-  Pf_path path_to_ferry;
+  PFPath path_to_ferry;
 
   UNIT_LOG(LOG_CARAVAN, punit, "requesting a boat!");
   ferryboat = aiferry_find_boat(ait, punit, 1, &path_to_ferry);

--- a/ai/default/aiunit.h
+++ b/ai/default/aiunit.h
@@ -18,7 +18,7 @@
 #include "unittype.h"
 
 struct pf_map;
-struct pf_path;
+class Pf_path;
 
 struct section_file;
 
@@ -112,7 +112,7 @@ bool find_beachhead(const struct player *pplayer, struct pf_map *ferry_map,
                     struct tile **ferry_dest, struct tile **beachhead_tile);
 int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
                            struct unit *punit, struct tile **pdest_tile,
-                           struct pf_path **ppath, struct pf_map **pferrymap,
+                           Pf_path **ppath, struct pf_map **pferrymap,
                            struct unit **pferryboat,
                            const struct unit_type **pboattype,
                            int *pmove_time);

--- a/ai/default/aiunit.h
+++ b/ai/default/aiunit.h
@@ -110,12 +110,10 @@ bool find_beachhead(const struct player *pplayer, struct pf_map *ferry_map,
                     struct tile *dest_tile,
                     const struct unit_type *cargo_type,
                     struct tile **ferry_dest, struct tile **beachhead_tile);
-int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
-                           struct unit *punit, struct tile **pdest_tile,
-                           Pf_path **ppath, struct pf_map **pferrymap,
-                           struct unit **pferryboat,
-                           const struct unit_type **pboattype,
-                           int *pmove_time);
+int find_something_to_kill(ai_type *ait, player *pplayer, unit *punit,
+                           tile **pdest_tile, Pf_path *ppath,
+                           pf_map **pferrymap, unit **pferryboat,
+                           const unit_type **pboattype, int *pmove_time);
 
 int build_cost_balanced(const struct unit_type *punittype);
 int unittype_def_rating_squared(const struct unit_type *att_type,

--- a/ai/default/aiunit.h
+++ b/ai/default/aiunit.h
@@ -18,7 +18,7 @@
 #include "unittype.h"
 
 struct pf_map;
-class Pf_path;
+class PFPath;
 
 struct section_file;
 
@@ -111,7 +111,7 @@ bool find_beachhead(const struct player *pplayer, struct pf_map *ferry_map,
                     const struct unit_type *cargo_type,
                     struct tile **ferry_dest, struct tile **beachhead_tile);
 int find_something_to_kill(ai_type *ait, player *pplayer, unit *punit,
-                           tile **pdest_tile, Pf_path *ppath,
+                           tile **pdest_tile, PFPath *ppath,
                            pf_map **pferrymap, unit **pferryboat,
                            const unit_type **pboattype, int *pmove_time);
 

--- a/ai/default/daimilitary.cpp
+++ b/ai/default/daimilitary.cpp
@@ -1233,7 +1233,7 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
   struct adv_choice *best_choice;
   struct ai_city *city_data = def_ai_city_data(pcity, ait);
   struct ai_city *acity_data;
-  auto path = Pf_path();
+  auto path = PFPath();
 
   fc_assert_ret_val(is_military_unit(myunit)
                         && !utype_fuel(unit_type_get(myunit)),

--- a/ai/default/daimilitary.cpp
+++ b/ai/default/daimilitary.cpp
@@ -1233,6 +1233,7 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
   struct adv_choice *best_choice;
   struct ai_city *city_data = def_ai_city_data(pcity, ait);
   struct ai_city *acity_data;
+  auto path = Pf_path();
 
   fc_assert_ret_val(is_military_unit(myunit)
                         && !utype_fuel(unit_type_get(myunit)),
@@ -1249,8 +1250,8 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
   }
 
   best_choice->want =
-      find_something_to_kill(ait, pplayer, myunit, &ptile, nullptr,
-                             &ferry_map, &ferryboat, &boattype, &move_time);
+      find_something_to_kill(ait, pplayer, myunit, &ptile, &path, &ferry_map,
+                             &ferryboat, &boattype, &move_time);
   if (nullptr == ptile || ptile == unit_tile(myunit)
       || !can_unit_attack_tile(myunit, ptile)) {
     goto cleanup;

--- a/ai/default/daimilitary.h
+++ b/ai/default/daimilitary.h
@@ -23,7 +23,7 @@
    to finish him off. */
 #define FINISH_HIM_CITY_COUNT 5
 
-typedef struct unit_list *(player_unit_list_getter)(struct player *pplayer);
+typedef struct unit_list *(player_unit_list_getter) (struct player *pplayer);
 
 struct unit_type *dai_choose_defender_versus(struct city *pcity,
                                              struct unit *attacker);

--- a/ai/default/daimilitary.h
+++ b/ai/default/daimilitary.h
@@ -23,7 +23,7 @@
    to finish him off. */
 #define FINISH_HIM_CITY_COUNT 5
 
-typedef struct unit_list *(player_unit_list_getter) (struct player *pplayer);
+typedef struct unit_list *(player_unit_list_getter)(struct player *pplayer);
 
 struct unit_type *dai_choose_defender_versus(struct city *pcity,
                                              struct unit *attacker);

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -44,6 +44,8 @@
 // Logging category for goto
 Q_LOGGING_CATEGORY(goto_category, "freeciv.goto")
 
+class Pf_path;
+
 static bool goto_warned = false;
 
 // Indexed by unit id
@@ -495,7 +497,7 @@ void request_orders_cleared(struct unit *punit)
 /**
    Creates orders for a path as a goto or patrol route.
  */
-static void make_path_orders(struct unit *punit, struct pf_path *path,
+static void make_path_orders(struct unit *punit, Pf_path *path,
                              enum unit_orders orders,
                              struct unit_order *final_order,
                              struct unit_order *order_list, int *length,
@@ -587,9 +589,8 @@ static void make_path_orders(struct unit *punit, struct pf_path *path,
 /**
    Send a path as a goto or patrol route to the server.
  */
-static void send_path_orders(struct unit *punit, struct pf_path *path,
-                             bool repeat, bool vigilant,
-                             enum unit_orders orders,
+static void send_path_orders(struct unit *punit, Pf_path *path, bool repeat,
+                             bool vigilant, enum unit_orders orders,
                              struct unit_order *final_order)
 {
   struct packet_unit_orders p;
@@ -619,7 +620,7 @@ static void send_path_orders(struct unit *punit, struct pf_path *path,
    Send a path as a goto or patrol rally orders to the server.
  */
 static void send_rally_path_orders(struct city *pcity, struct unit *punit,
-                                   struct pf_path *path, bool vigilant,
+                                   Pf_path *path, bool vigilant,
                                    enum unit_orders orders,
                                    struct unit_order *final_order)
 {
@@ -641,7 +642,7 @@ static void send_rally_path_orders(struct city *pcity, struct unit *punit,
 /**
    Send an arbitrary goto path for the unit to the server.
  */
-void send_goto_path(struct unit *punit, struct pf_path *path,
+void send_goto_path(struct unit *punit, Pf_path *path,
                     struct unit_order *final_order)
 {
   send_path_orders(punit, path, false, false, ORDER_MOVE, final_order);
@@ -650,8 +651,8 @@ void send_goto_path(struct unit *punit, struct pf_path *path,
 /**
    Send an arbitrary rally path for the city to the server.
  */
-void send_rally_path(struct city *pcity, struct unit *punit,
-                     struct pf_path *path, struct unit_order *final_order)
+void send_rally_path(struct city *pcity, struct unit *punit, Pf_path *path,
+                     struct unit_order *final_order)
 {
   send_rally_path_orders(pcity, punit, path, false, ORDER_MOVE, final_order);
 }
@@ -664,7 +665,7 @@ bool send_goto_tile(struct unit *punit, struct tile *ptile)
 {
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
 
   goto_fill_parameter_base(&parameter, punit);
   pfm = pf_map_new(&parameter);
@@ -691,7 +692,7 @@ bool send_rally_tile(struct city *pcity, struct tile *ptile)
 
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
 
   fc_assert_ret_val(pcity != nullptr, false);
   fc_assert_ret_val(ptile != nullptr, false);
@@ -732,7 +733,7 @@ bool send_attack_tile(struct unit *punit, struct tile *ptile)
 {
   struct pf_parameter parameter;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
 
   goto_fill_parameter_base(&parameter, punit);
   parameter.move_rate = 0;
@@ -819,7 +820,7 @@ struct tile *tile_before_end_path(struct unit *punit, struct tile *ptile)
   struct pf_parameter parameter;
   struct pf_map *pfm;
   struct tile *dtile;
-  struct pf_path *path;
+  Pf_path *path;
 
   goto_fill_parameter_base(&parameter, punit);
   parameter.move_rate = 0;

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -497,7 +497,7 @@ void request_orders_cleared(struct unit *punit)
 /**
    Creates orders for a path as a goto or patrol route.
  */
-static void make_path_orders(struct unit *punit, PFPath path,
+static void make_path_orders(struct unit *punit, const PFPath &path,
                              enum unit_orders orders,
                              struct unit_order *final_order,
                              struct unit_order *order_list, int *length,
@@ -589,8 +589,9 @@ static void make_path_orders(struct unit *punit, PFPath path,
 /**
    Send a path as a goto or patrol route to the server.
  */
-static void send_path_orders(struct unit *punit, PFPath path, bool repeat,
-                             bool vigilant, enum unit_orders orders,
+static void send_path_orders(struct unit *punit, const PFPath &path,
+                             bool repeat, bool vigilant,
+                             enum unit_orders orders,
                              struct unit_order *final_order)
 {
   struct packet_unit_orders p;
@@ -620,7 +621,7 @@ static void send_path_orders(struct unit *punit, PFPath path, bool repeat,
    Send a path as a goto or patrol rally orders to the server.
  */
 static void send_rally_path_orders(struct city *pcity, struct unit *punit,
-                                   PFPath path, bool vigilant,
+                                   const PFPath &path, bool vigilant,
                                    enum unit_orders orders,
                                    struct unit_order *final_order)
 {
@@ -642,7 +643,7 @@ static void send_rally_path_orders(struct city *pcity, struct unit *punit,
 /**
    Send an arbitrary goto path for the unit to the server.
  */
-void send_goto_path(struct unit *punit, PFPath path,
+void send_goto_path(struct unit *punit, const PFPath &path,
                     struct unit_order *final_order)
 {
   send_path_orders(punit, path, false, false, ORDER_MOVE, final_order);
@@ -651,8 +652,8 @@ void send_goto_path(struct unit *punit, PFPath path,
 /**
    Send an arbitrary rally path for the city to the server.
  */
-void send_rally_path(struct city *pcity, struct unit *punit, PFPath path,
-                     struct unit_order *final_order)
+void send_rally_path(struct city *pcity, struct unit *punit,
+                     const PFPath &path, struct unit_order *final_order)
 {
   send_rally_path_orders(pcity, punit, path, false, ORDER_MOVE, final_order);
 }

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -44,7 +44,7 @@
 // Logging category for goto
 Q_LOGGING_CATEGORY(goto_category, "freeciv.goto")
 
-class Pf_path;
+class PFPath;
 
 static bool goto_warned = false;
 
@@ -497,7 +497,7 @@ void request_orders_cleared(struct unit *punit)
 /**
    Creates orders for a path as a goto or patrol route.
  */
-static void make_path_orders(struct unit *punit, Pf_path path,
+static void make_path_orders(struct unit *punit, PFPath path,
                              enum unit_orders orders,
                              struct unit_order *final_order,
                              struct unit_order *order_list, int *length,
@@ -589,7 +589,7 @@ static void make_path_orders(struct unit *punit, Pf_path path,
 /**
    Send a path as a goto or patrol route to the server.
  */
-static void send_path_orders(struct unit *punit, Pf_path path, bool repeat,
+static void send_path_orders(struct unit *punit, PFPath path, bool repeat,
                              bool vigilant, enum unit_orders orders,
                              struct unit_order *final_order)
 {
@@ -620,7 +620,7 @@ static void send_path_orders(struct unit *punit, Pf_path path, bool repeat,
    Send a path as a goto or patrol rally orders to the server.
  */
 static void send_rally_path_orders(struct city *pcity, struct unit *punit,
-                                   Pf_path path, bool vigilant,
+                                   PFPath path, bool vigilant,
                                    enum unit_orders orders,
                                    struct unit_order *final_order)
 {
@@ -642,7 +642,7 @@ static void send_rally_path_orders(struct city *pcity, struct unit *punit,
 /**
    Send an arbitrary goto path for the unit to the server.
  */
-void send_goto_path(struct unit *punit, Pf_path path,
+void send_goto_path(struct unit *punit, PFPath path,
                     struct unit_order *final_order)
 {
   send_path_orders(punit, path, false, false, ORDER_MOVE, final_order);
@@ -651,7 +651,7 @@ void send_goto_path(struct unit *punit, Pf_path path,
 /**
    Send an arbitrary rally path for the city to the server.
  */
-void send_rally_path(struct city *pcity, struct unit *punit, Pf_path path,
+void send_rally_path(struct city *pcity, struct unit *punit, PFPath path,
                      struct unit_order *final_order)
 {
   send_rally_path_orders(pcity, punit, path, false, ORDER_MOVE, final_order);

--- a/client/goto.h
+++ b/client/goto.h
@@ -12,7 +12,7 @@
 
 #include "fc_types.h"
 
-struct pf_path;
+class Pf_path;
 struct tile;
 struct unit;
 struct unit_list;
@@ -45,10 +45,10 @@ bool is_valid_goto_destination(const struct tile *ptile);
 bool is_valid_goto_draw_line(struct tile *dest_tile);
 
 void request_orders_cleared(struct unit *punit);
-void send_goto_path(struct unit *punit, struct pf_path *path,
+void send_goto_path(struct unit *punit, Pf_path *path,
                     struct unit_order *last_order);
-void send_rally_path(struct city *pcity, struct unit *punit,
-                     struct pf_path *path, struct unit_order *final_order);
+void send_rally_path(struct city *pcity, struct unit *punit, Pf_path *path,
+                     struct unit_order *final_order);
 bool send_goto_tile(struct unit *punit, struct tile *ptile);
 bool send_rally_tile(struct city *pcity, struct tile *ptile);
 bool send_attack_tile(struct unit *punit, struct tile *ptile);

--- a/client/goto.h
+++ b/client/goto.h
@@ -12,7 +12,7 @@
 
 #include "fc_types.h"
 
-class Pf_path;
+class PFPath;
 struct tile;
 struct unit;
 struct unit_list;
@@ -45,9 +45,9 @@ bool is_valid_goto_destination(const struct tile *ptile);
 bool is_valid_goto_draw_line(struct tile *dest_tile);
 
 void request_orders_cleared(struct unit *punit);
-void send_goto_path(struct unit *punit, Pf_path *path,
+void send_goto_path(struct unit *punit, PFPath *path,
                     struct unit_order *last_order);
-void send_rally_path(city *pcity, unit *punit, Pf_path path,
+void send_rally_path(city *pcity, unit *punit, PFPath path,
                      unit_order *final_order);
 bool send_goto_tile(struct unit *punit, struct tile *ptile);
 bool send_rally_tile(struct city *pcity, struct tile *ptile);

--- a/client/goto.h
+++ b/client/goto.h
@@ -47,8 +47,8 @@ bool is_valid_goto_draw_line(struct tile *dest_tile);
 void request_orders_cleared(struct unit *punit);
 void send_goto_path(struct unit *punit, Pf_path *path,
                     struct unit_order *last_order);
-void send_rally_path(struct city *pcity, struct unit *punit, Pf_path *path,
-                     struct unit_order *final_order);
+void send_rally_path(city *pcity, unit *punit, Pf_path path,
+                     unit_order *final_order);
 bool send_goto_tile(struct unit *punit, struct tile *ptile);
 bool send_rally_tile(struct city *pcity, struct tile *ptile);
 bool send_attack_tile(struct unit *punit, struct tile *ptile);

--- a/client/goto.h
+++ b/client/goto.h
@@ -47,7 +47,7 @@ bool is_valid_goto_draw_line(struct tile *dest_tile);
 void request_orders_cleared(struct unit *punit);
 void send_goto_path(struct unit *punit, PFPath *path,
                     struct unit_order *last_order);
-void send_rally_path(city *pcity, unit *punit, PFPath path,
+void send_rally_path(city *pcity, unit *punit, const PFPath &path,
                      unit_order *final_order);
 bool send_goto_tile(struct unit *punit, struct tile *ptile);
 bool send_rally_tile(struct city *pcity, struct tile *ptile);

--- a/common/ai.h
+++ b/common/ai.h
@@ -208,7 +208,7 @@ struct ai_type {
     void (*unit_turn_end)(struct unit *punit);
 
     // Called for unit owner AI type when advisors goto moves unit.
-    void (*unit_move)(struct unit *punit, struct tile *ptile, Pf_path *path,
+    void (*unit_move)(struct unit *punit, struct tile *ptile, Pf_path path,
                       int step);
 
     // Called for all AI types when ever unit has moved.

--- a/common/ai.h
+++ b/common/ai.h
@@ -33,7 +33,7 @@ struct city;
 struct unit;
 struct tile;
 struct settlermap;
-struct pf_path;
+class Pf_path;
 struct section_file;
 struct adv_data;
 
@@ -208,8 +208,8 @@ struct ai_type {
     void (*unit_turn_end)(struct unit *punit);
 
     // Called for unit owner AI type when advisors goto moves unit.
-    void (*unit_move)(struct unit *punit, struct tile *ptile,
-                      struct pf_path *path, int step);
+    void (*unit_move)(struct unit *punit, struct tile *ptile, Pf_path *path,
+                      int step);
 
     // Called for all AI types when ever unit has moved.
     void (*unit_move_seen)(struct unit *punit);

--- a/common/ai.h
+++ b/common/ai.h
@@ -33,7 +33,7 @@ struct city;
 struct unit;
 struct tile;
 struct settlermap;
-class Pf_path;
+class PFPath;
 struct section_file;
 struct adv_data;
 
@@ -208,7 +208,7 @@ struct ai_type {
     void (*unit_turn_end)(struct unit *punit);
 
     // Called for unit owner AI type when advisors goto moves unit.
-    void (*unit_move)(struct unit *punit, struct tile *ptile, Pf_path path,
+    void (*unit_move)(struct unit *punit, struct tile *ptile, PFPath path,
                       int step);
 
     // Called for all AI types when ever unit has moved.

--- a/common/ai.h
+++ b/common/ai.h
@@ -208,8 +208,8 @@ struct ai_type {
     void (*unit_turn_end)(struct unit *punit);
 
     // Called for unit owner AI type when advisors goto moves unit.
-    void (*unit_move)(struct unit *punit, struct tile *ptile, PFPath path,
-                      int step);
+    void (*unit_move)(struct unit *punit, struct tile *ptile,
+                      const PFPath &path, int step);
 
     // Called for all AI types when ever unit has moved.
     void (*unit_move_seen)(struct unit *punit);

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3343,7 +3343,7 @@ const pf_position &PFPath::operator[](int i) const
 
    If 'dest_path' == nullptr, we just copy the src_path and nothing else.
  */
-PFPath pf_path_concat(PFPath dest_path, const PFPath src_path)
+PFPath pf_path_concat(PFPath dest_path, const PFPath &src_path)
 {
   fc_assert_ret_val(src_path.empty(), PFPath());
   if (dest_path.empty()) {

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3232,18 +3232,18 @@ static void pf_position_fill_start_tile(struct pf_position *pos,
 // Constructors
 PFPath::PFPath() {}
 // Constructor to just initialize with size
-PFPath::PFPath(int size) { positions = std::vector<pf_position>(size); }
+PFPath::PFPath(int size) : positions(std::vector<pf_position>(size)) {}
 // Copy Constructor
 PFPath::PFPath(const PFPath &obj)
+    : positions(std::vector<pf_position>(obj.positions))
 {
-  positions = std::vector<pf_position>(obj.positions);
 }
 /**
    Create a path with start tile of a parameter.
  */
 PFPath::PFPath(const struct pf_parameter *param)
+    : positions(std::vector<pf_position>(1))
 {
-  positions = std::vector<pf_position>(1);
   pf_position_fill_start_tile(&positions[0], param);
 }
 

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3317,25 +3317,23 @@ bool Pf_path::pf_path_backtrack(struct tile *ptile)
 }
 pf_position &Pf_path::operator[](int i)
 {
-  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
-  if (i > positions.size()) {
-  }
   if (i < 0) {
-    fc_assert_msg((-i < positions.size()), "id %d/%zu", i, positions.size());
+    fc_assert_msg((-i <= positions.size()), "id %d/%zu", i,
+                  positions.size());
     return positions[positions.size() + i];
   }
+  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
   return positions[i];
 }
 
 const pf_position &Pf_path::operator[](int i) const
 {
-  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
-  if (i > positions.size()) {
-  }
   if (i < 0) {
-    fc_assert_msg((-i < positions.size()), "id %d/%zu", i, positions.size());
+    fc_assert_msg((-i <= positions.size()), "id %d/%zu", i,
+                  positions.size());
     return positions[positions.size() + i];
   }
+  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
   return positions[i];
 }
 /**

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3317,19 +3317,23 @@ bool Pf_path::pf_path_backtrack(struct tile *ptile)
 }
 pf_position &Pf_path::operator[](int i)
 {
+  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
   if (i > positions.size()) {
   }
   if (i < 0) {
+    fc_assert_msg((-i < positions.size()), "id %d/%zu", i, positions.size());
     return positions[positions.size() + i];
   }
   return positions[i];
 }
 
-pf_position Pf_path::operator[](int i) const
+const pf_position &Pf_path::operator[](int i) const
 {
+  fc_assert_msg((i < positions.size()), "id %d/%zu", i, positions.size());
   if (i > positions.size()) {
   }
   if (i < 0) {
+    fc_assert_msg((-i < positions.size()), "id %d/%zu", i, positions.size());
     return positions[positions.size() + i];
   }
   return positions[i];

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -85,7 +85,7 @@ struct pf_map {
   // "Virtual" function table.
   void (*destroy)(struct pf_map *pfm); // Destructor.
   int (*get_move_cost)(struct pf_map *pfm, struct tile *ptile);
-  struct pf_path *(*get_path)(struct pf_map *pfm, struct tile *ptile);
+  Pf_path *(*get_path)(struct pf_map *pfm, struct tile *ptile);
   bool (*get_position)(struct pf_map *pfm, struct tile *ptile,
                        struct pf_position *pos);
   bool (*iterate)(struct pf_map *pfm);
@@ -193,8 +193,7 @@ static inline void pf_finalize_position(const struct pf_parameter *param,
   }
 }
 
-static struct pf_path *
-pf_path_new_to_start_tile(const struct pf_parameter *param);
+static Pf_path *pf_path_new_to_start_tile(const struct pf_parameter *param);
 static void pf_position_fill_start_tile(struct pf_position *pos,
                                         const struct pf_parameter *param);
 
@@ -399,14 +398,14 @@ static void pf_normal_map_fill_position(const struct pf_normal_map *pfnm,
    Read off the path to the node dest_tile, which must already be discovered.
    A helper for pf_normal_map_path functions.
  */
-static struct pf_path *
+static Pf_path *
 pf_normal_map_construct_path(const struct pf_normal_map *pfnm,
                              struct tile *dest_tile)
 {
   struct pf_normal_node *node = pfnm->lattice + tile_index(dest_tile);
   const struct pf_parameter *params = pf_map_parameter(PF_MAP(pfnm));
   enum direction8 dir_next = direction8_invalid();
-  struct pf_path *path;
+  Pf_path *path;
   struct tile *ptile;
   int i;
 
@@ -417,7 +416,7 @@ pf_normal_map_construct_path(const struct pf_normal_map *pfnm,
 #endif // PF_DEBUG
 
   ptile = dest_tile;
-  path = new pf_path;
+  path = new Pf_path;
 
   /* 1: Count the number of steps to get here.
    * To do it, backtrack until we hit the starting point */
@@ -774,8 +773,7 @@ static int pf_normal_map_move_cost(struct pf_map *pfm, struct tile *ptile)
    Return the path to ptile. If ptile has not been reached yet, iterate the
    map until we reach it or run out of map.
  */
-static struct pf_path *pf_normal_map_path(struct pf_map *pfm,
-                                          struct tile *ptile)
+static Pf_path *pf_normal_map_path(struct pf_map *pfm, struct tile *ptile)
 {
   struct pf_normal_map *pfnm = PF_NORMAL_MAP(pfm);
 
@@ -1141,11 +1139,11 @@ pf_danger_map_fill_cost_for_full_moves(const struct pf_parameter *param,
    Read off the path to the node 'ptile', but with dangers.
    NB: will only find paths to safe tiles!
  */
-static struct pf_path *
+static Pf_path *
 pf_danger_map_construct_path(const struct pf_danger_map *pfdm,
                              struct tile *ptile)
 {
-  auto *path = new pf_path;
+  auto *path = new Pf_path;
   enum direction8 dir_next = direction8_invalid();
   struct pf_danger_node::pf_danger_pos *danger_seg = nullptr;
   bool waited = false;
@@ -1731,8 +1729,7 @@ static int pf_danger_map_move_cost(struct pf_map *pfm, struct tile *ptile)
    Return the path to ptile. If ptile has not been reached yet, iterate the
    map until we reach it or run out of map.
  */
-static struct pf_path *pf_danger_map_path(struct pf_map *pfm,
-                                          struct tile *ptile)
+static Pf_path *pf_danger_map_path(struct pf_map *pfm, struct tile *ptile)
 {
   struct pf_danger_map *pfdm = PF_DANGER_MAP(pfm);
 
@@ -2244,11 +2241,10 @@ pf_fuel_map_fill_cost_for_full_moves(const struct pf_parameter *param,
 /**
    Read off the path to the node 'ptile', but with fuel danger.
  */
-static struct pf_path *
-pf_fuel_map_construct_path(const struct pf_fuel_map *pffm,
-                           struct tile *ptile)
+static Pf_path *pf_fuel_map_construct_path(const struct pf_fuel_map *pffm,
+                                           struct tile *ptile)
 {
-  auto *path = new pf_path;
+  auto *path = new Pf_path;
   enum direction8 dir_next = direction8_invalid();
   struct pf_fuel_node *node = pffm->lattice + tile_index(ptile);
   struct pf_fuel_pos *segment = node->segment;
@@ -2902,8 +2898,7 @@ static int pf_fuel_map_move_cost(struct pf_map *pfm, struct tile *ptile)
    Return the path to ptile. If 'ptile' has not been reached yet, iterate
    the map until we reach it or run out of map.
  */
-static struct pf_path *pf_fuel_map_path(struct pf_map *pfm,
-                                        struct tile *ptile)
+static Pf_path *pf_fuel_map_path(struct pf_map *pfm, struct tile *ptile)
 {
   struct pf_fuel_map *pffm = PF_FUEL_MAP(pfm);
 
@@ -3090,10 +3085,10 @@ int pf_map_move_cost(struct pf_map *pfm, struct tile *ptile)
    pf_map_position(). If ptile has not been reached yet, iterate the map
    until we reach it or run out of map.
  */
-struct pf_path *pf_map_path(struct pf_map *pfm, struct tile *ptile)
+Pf_path *pf_map_path(struct pf_map *pfm, struct tile *ptile)
 {
 #ifdef PF_DEBUG
-  struct pf_path *path;
+  Pf_path *path;
 
   fc_assert_ret_val(nullptr != pfm, nullptr);
   fc_assert_ret_val(nullptr != ptile, nullptr);
@@ -3190,7 +3185,7 @@ int pf_map_iter_move_cost(struct pf_map *pfm)
    Return the path to our current position.This is equivalent to
    pf_map_path(pfm, pf_map_iter(pfm)).
  */
-struct pf_path *pf_map_iter_path(struct pf_map *pfm)
+Pf_path *pf_map_iter_path(struct pf_map *pfm)
 {
 #ifdef PF_DEBUG
   fc_assert_ret_val(nullptr != pfm, nullptr);
@@ -3226,7 +3221,7 @@ const struct pf_parameter *pf_map_parameter(const struct pf_map *pfm)
   return &pfm->params;
 }
 
-// ====================== pf_path public functions =======================
+// ====================== Pf_path public functions =======================
 
 /**
    Fill the position for the start tile of a parameter.
@@ -3247,10 +3242,9 @@ static void pf_position_fill_start_tile(struct pf_position *pos,
 /**
    Create a path to the start tile of a parameter.
  */
-static struct pf_path *
-pf_path_new_to_start_tile(const struct pf_parameter *param)
+static Pf_path *pf_path_new_to_start_tile(const struct pf_parameter *param)
 {
-  auto *path = new pf_path;
+  auto *path = new Pf_path;
   auto *pos = new pf_position[1];
 
   path->length = 1;
@@ -3263,7 +3257,7 @@ pf_path_new_to_start_tile(const struct pf_parameter *param)
    After use, a path must be destroyed. Note this function accept nullptr as
    argument.
  */
-void pf_path_destroy(struct pf_path *path)
+void pf_path_destroy(Pf_path *path)
 {
   if (nullptr != path) {
     delete[] path->positions;
@@ -3278,8 +3272,7 @@ void pf_path_destroy(struct pf_path *path)
 
    If 'dest_path' == nullptr, we just copy the src_path and nothing else.
  */
-struct pf_path *pf_path_concat(struct pf_path *dest_path,
-                               const struct pf_path *src_path)
+Pf_path *pf_path_concat(Pf_path *dest_path, const Pf_path *src_path)
 {
   int dest_end;
 
@@ -3287,7 +3280,7 @@ struct pf_path *pf_path_concat(struct pf_path *dest_path,
 
   if (dest_path == nullptr) {
     // Just copy path.
-    dest_path = new pf_path;
+    dest_path = new Pf_path;
     dest_path->length = src_path->length;
     dest_path->positions = new pf_position[dest_path->length];
     memcpy(dest_path->positions, src_path->positions,
@@ -3326,7 +3319,7 @@ struct pf_path *pf_path_concat(struct pf_path *dest_path,
    If tile is not on the path at all, returns FALSE and path is not changed
    at all.
  */
-bool pf_path_advance(struct pf_path *path, struct tile *ptile)
+bool pf_path_advance(Pf_path *path, struct tile *ptile)
 {
   int i;
   struct pf_position *new_positions;
@@ -3354,7 +3347,7 @@ bool pf_path_advance(struct pf_path *path, struct tile *ptile)
    If tile is not on the path at all, returns FALSE and path is not changed
    at all.
  */
-bool pf_path_backtrack(struct pf_path *path, struct tile *ptile)
+bool pf_path_backtrack(Pf_path *path, struct tile *ptile)
 {
   int i;
   struct pf_position *new_positions;
@@ -3382,7 +3375,7 @@ bool pf_path_backtrack(struct pf_path *path, struct tile *ptile)
 /**
    Get the last position of the path.
  */
-const struct pf_position *pf_path_last_position(const struct pf_path *path)
+const struct pf_position *pf_path_last_position(const Pf_path *path)
 {
   return path->positions + (path->length - 1);
 }
@@ -3390,7 +3383,7 @@ const struct pf_position *pf_path_last_position(const struct pf_path *path)
 /**
    Debug a path.
  */
-QDebug &operator<<(QDebug &logger, const pf_path *path)
+QDebug &operator<<(QDebug &logger, const Pf_path *path)
 {
   struct pf_position *pos;
   int i;

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -317,10 +317,28 @@ struct pf_position {
 
 // Full specification of a path.
 class Pf_path {
+  std::vector<pf_position> positions;
+
 public:
-  int length; // Number of steps in the path
-  struct pf_position *positions;
+  Pf_path();
+  Pf_path(int size);
+  Pf_path(const Pf_path &obj);
+  Pf_path(const struct pf_parameter *param);
+  int length() const;
+  void add_pos(pf_position pos);
+  virtual ~Pf_path();
+  bool empty() const;
+  bool pf_path_advance(struct tile *ptile);
+  bool pf_path_backtrack(struct tile *ptile);
+  pf_position &operator[](int i);
+  pf_position operator[](int i) const;
 };
+// Paths functions.
+void pf_path_destroy(Pf_path *path);
+Pf_path pf_path_concat(Pf_path *dest_path, const Pf_path *src_path);
+bool pf_path_backtrack(Pf_path *path, struct tile *ptile);
+
+QDebug &operator<<(QDebug &logger, const Pf_path &path);
 
 /* Initial data for the path-finding. Normally should use functions
  * from "pf_tools.[ch]" to fill the parameter.
@@ -461,8 +479,8 @@ void pf_map_destroy(struct pf_map *pfm);
 
 // Method A) functions.
 int pf_map_move_cost(struct pf_map *pfm, struct tile *ptile);
-Pf_path *pf_map_path(struct pf_map *pfm,
-                     struct tile *ptile) fc__warn_unused_result;
+Pf_path pf_map_path(struct pf_map *pfm,
+                    struct tile *ptile) fc__warn_unused_result;
 bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
                      struct pf_position *pos) fc__warn_unused_result;
 
@@ -470,20 +488,11 @@ bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
 bool pf_map_iterate(struct pf_map *pfm);
 struct tile *pf_map_iter(struct pf_map *pfm);
 int pf_map_iter_move_cost(struct pf_map *pfm);
-Pf_path *pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
+Pf_path pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
 void pf_map_iter_position(struct pf_map *pfm, struct pf_position *pos);
 
 // Other related functions.
 const struct pf_parameter *pf_map_parameter(const struct pf_map *pfm);
-
-// Paths functions.
-void pf_path_destroy(Pf_path *path);
-Pf_path *pf_path_concat(Pf_path *dest_path, const Pf_path *src_path);
-bool pf_path_advance(Pf_path *path, struct tile *ptile);
-bool pf_path_backtrack(Pf_path *path, struct tile *ptile);
-const struct pf_position *pf_path_last_position(const Pf_path *path);
-
-QDebug &operator<<(QDebug &logger, const Pf_path *path);
 
 // Reverse map functions (Costs to go to start tile).
 struct pf_reverse_map *

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -335,9 +335,7 @@ public:
 };
 // Paths functions.
 void pf_path_destroy(PFPath *path);
-PFPath pf_path_concat(PFPath *dest_path, const PFPath *src_path);
-bool pf_path_backtrack(PFPath *path, struct tile *ptile);
-
+PFPath pf_path_concat(PFPath *dest_path, const PFPath &src_path);
 QDebug &operator<<(QDebug &logger, const PFPath &path);
 
 /* Initial data for the path-finding. Normally should use functions

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -331,7 +331,7 @@ public:
   bool pf_path_advance(struct tile *ptile);
   bool pf_path_backtrack(struct tile *ptile);
   pf_position &operator[](int i);
-  pf_position operator[](int i) const;
+  const pf_position &operator[](int i) const;
 };
 // Paths functions.
 void pf_path_destroy(Pf_path *path);

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -157,7 +157,7 @@
  *
  *    struct pf_parameter parameter;
  *    struct pf_map *pfm;
- *    struct pf_path *path;
+ *    Pf_path *path;
  *
  *    // fill parameter (see below)
  *
@@ -311,12 +311,13 @@ struct pf_position {
   int total_MC; // Total MC to reach this point
   int total_EC; // Total EC to reach this point
 
-  enum direction8 dir_to_next_pos; // Used only in 'struct pf_path'.
+  enum direction8 dir_to_next_pos; // Used only in 'Pf_path'.
   enum direction8 dir_to_here;     // Where did we come from.
 };
 
 // Full specification of a path.
-struct pf_path {
+class Pf_path {
+public:
   int length; // Number of steps in the path
   struct pf_position *positions;
 };
@@ -460,8 +461,8 @@ void pf_map_destroy(struct pf_map *pfm);
 
 // Method A) functions.
 int pf_map_move_cost(struct pf_map *pfm, struct tile *ptile);
-struct pf_path *pf_map_path(struct pf_map *pfm,
-                            struct tile *ptile) fc__warn_unused_result;
+Pf_path *pf_map_path(struct pf_map *pfm,
+                     struct tile *ptile) fc__warn_unused_result;
 bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
                      struct pf_position *pos) fc__warn_unused_result;
 
@@ -469,21 +470,20 @@ bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
 bool pf_map_iterate(struct pf_map *pfm);
 struct tile *pf_map_iter(struct pf_map *pfm);
 int pf_map_iter_move_cost(struct pf_map *pfm);
-struct pf_path *pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
+Pf_path *pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
 void pf_map_iter_position(struct pf_map *pfm, struct pf_position *pos);
 
 // Other related functions.
 const struct pf_parameter *pf_map_parameter(const struct pf_map *pfm);
 
 // Paths functions.
-void pf_path_destroy(struct pf_path *path);
-struct pf_path *pf_path_concat(struct pf_path *dest_path,
-                               const struct pf_path *src_path);
-bool pf_path_advance(struct pf_path *path, struct tile *ptile);
-bool pf_path_backtrack(struct pf_path *path, struct tile *ptile);
-const struct pf_position *pf_path_last_position(const struct pf_path *path);
+void pf_path_destroy(Pf_path *path);
+Pf_path *pf_path_concat(Pf_path *dest_path, const Pf_path *src_path);
+bool pf_path_advance(Pf_path *path, struct tile *ptile);
+bool pf_path_backtrack(Pf_path *path, struct tile *ptile);
+const struct pf_position *pf_path_last_position(const Pf_path *path);
 
-QDebug &operator<<(QDebug &logger, const pf_path *path);
+QDebug &operator<<(QDebug &logger, const Pf_path *path);
 
 // Reverse map functions (Costs to go to start tile).
 struct pf_reverse_map *
@@ -581,7 +581,7 @@ bool pf_reverse_map_unit_position(struct pf_reverse_map *pfrm,
  * NB: you need to free the pathes with pf_path_destroy(path_iter).
  *
  * ARG_pfm - A pf_map structure pointer.
- * NAME_path - The name of the iterator to use (type struct pf_path *). This
+ * NAME_path - The name of the iterator to use (type Pf_path *). This
  *             is defined inside the macro.
  * COND_from_start - A boolean value (or equivalent, it can be a function)
  *                   which indicate if the start tile should be iterated or
@@ -589,7 +589,7 @@ bool pf_reverse_map_unit_position(struct pf_reverse_map *pfrm,
 #define pf_map_paths_iterate(ARG_pfm, NAME_path, COND_from_start)           \
   if (COND_from_start || pf_map_iterate((ARG_pfm))) {                       \
     struct pf_map *_MY_pf_map_ = (ARG_pfm);                                 \
-    struct pf_path *NAME_path;                                              \
+    Pf_path *NAME_path;                                                     \
     do {                                                                    \
       NAME_path = pf_map_iter_path(_MY_pf_map_);
 

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -157,7 +157,7 @@
  *
  *    struct pf_parameter parameter;
  *    struct pf_map *pfm;
- *    Pf_path *path;
+ *    PFPath *path;
  *
  *    // fill parameter (see below)
  *
@@ -311,22 +311,22 @@ struct pf_position {
   int total_MC; // Total MC to reach this point
   int total_EC; // Total EC to reach this point
 
-  enum direction8 dir_to_next_pos; // Used only in 'Pf_path'.
+  enum direction8 dir_to_next_pos; // Used only in 'PFPath'.
   enum direction8 dir_to_here;     // Where did we come from.
 };
 
 // Full specification of a path.
-class Pf_path {
+class PFPath {
   std::vector<pf_position> positions;
 
 public:
-  Pf_path();
-  Pf_path(int size);
-  Pf_path(const Pf_path &obj);
-  Pf_path(const struct pf_parameter *param);
+  PFPath();
+  PFPath(int size);
+  PFPath(const PFPath &obj);
+  PFPath(const struct pf_parameter *param);
   int length() const;
   void add_pos(pf_position pos);
-  virtual ~Pf_path();
+  virtual ~PFPath();
   bool empty() const;
   bool pf_path_advance(struct tile *ptile);
   bool pf_path_backtrack(struct tile *ptile);
@@ -334,11 +334,11 @@ public:
   const pf_position &operator[](int i) const;
 };
 // Paths functions.
-void pf_path_destroy(Pf_path *path);
-Pf_path pf_path_concat(Pf_path *dest_path, const Pf_path *src_path);
-bool pf_path_backtrack(Pf_path *path, struct tile *ptile);
+void pf_path_destroy(PFPath *path);
+PFPath pf_path_concat(PFPath *dest_path, const PFPath *src_path);
+bool pf_path_backtrack(PFPath *path, struct tile *ptile);
 
-QDebug &operator<<(QDebug &logger, const Pf_path &path);
+QDebug &operator<<(QDebug &logger, const PFPath &path);
 
 /* Initial data for the path-finding. Normally should use functions
  * from "pf_tools.[ch]" to fill the parameter.
@@ -479,8 +479,8 @@ void pf_map_destroy(struct pf_map *pfm);
 
 // Method A) functions.
 int pf_map_move_cost(struct pf_map *pfm, struct tile *ptile);
-Pf_path pf_map_path(struct pf_map *pfm,
-                    struct tile *ptile) fc__warn_unused_result;
+PFPath pf_map_path(struct pf_map *pfm,
+                   struct tile *ptile) fc__warn_unused_result;
 bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
                      struct pf_position *pos) fc__warn_unused_result;
 
@@ -488,7 +488,7 @@ bool pf_map_position(struct pf_map *pfm, struct tile *ptile,
 bool pf_map_iterate(struct pf_map *pfm);
 struct tile *pf_map_iter(struct pf_map *pfm);
 int pf_map_iter_move_cost(struct pf_map *pfm);
-Pf_path pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
+PFPath pf_map_iter_path(struct pf_map *pfm) fc__warn_unused_result;
 void pf_map_iter_position(struct pf_map *pfm, struct pf_position *pos);
 
 // Other related functions.
@@ -590,7 +590,7 @@ bool pf_reverse_map_unit_position(struct pf_reverse_map *pfrm,
  * NB: you need to free the pathes with pf_path_destroy(path_iter).
  *
  * ARG_pfm - A pf_map structure pointer.
- * NAME_path - The name of the iterator to use (type Pf_path *). This
+ * NAME_path - The name of the iterator to use (type PFPath *). This
  *             is defined inside the macro.
  * COND_from_start - A boolean value (or equivalent, it can be a function)
  *                   which indicate if the start tile should be iterated or
@@ -598,7 +598,7 @@ bool pf_reverse_map_unit_position(struct pf_reverse_map *pfrm,
 #define pf_map_paths_iterate(ARG_pfm, NAME_path, COND_from_start)           \
   if (COND_from_start || pf_map_iterate((ARG_pfm))) {                       \
     struct pf_map *_MY_pf_map_ = (ARG_pfm);                                 \
-    Pf_path *NAME_path;                                                     \
+    PFPath *NAME_path;                                                      \
     do {                                                                    \
       NAME_path = pf_map_iter_path(_MY_pf_map_);
 

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -44,8 +44,7 @@ static bool adv_unit_move(struct unit *punit, struct tile *ptile);
    or assigned destination
    Return FALSE iff we died.
  */
-bool adv_follow_path(struct unit *punit, struct pf_path *path,
-                     struct tile *ptile)
+bool adv_follow_path(struct unit *punit, Pf_path *path, struct tile *ptile)
 {
   struct tile *old_tile = punit->goto_tile;
   enum unit_activity activity = punit->activity;
@@ -79,7 +78,7 @@ bool adv_follow_path(struct unit *punit, struct pf_path *path,
    Brings our bodyguard along.
    Returns FALSE only if died.
  */
-bool adv_unit_execute_path(struct unit *punit, struct pf_path *path)
+bool adv_unit_execute_path(struct unit *punit, Pf_path *path)
 {
   const bool is_plr_ai = is_ai(unit_owner(punit));
   int i;

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -44,7 +44,7 @@ static bool adv_unit_move(struct unit *punit, struct tile *ptile);
    or assigned destination
    Return FALSE iff we died.
  */
-bool adv_follow_path(struct unit *punit, Pf_path *path, struct tile *ptile)
+bool adv_follow_path(struct unit *punit, Pf_path path, struct tile *ptile)
 {
   struct tile *old_tile = punit->goto_tile;
   enum unit_activity activity = punit->activity;
@@ -78,14 +78,14 @@ bool adv_follow_path(struct unit *punit, Pf_path *path, struct tile *ptile)
    Brings our bodyguard along.
    Returns FALSE only if died.
  */
-bool adv_unit_execute_path(struct unit *punit, Pf_path *path)
+bool adv_unit_execute_path(struct unit *punit, Pf_path path)
 {
   const bool is_plr_ai = is_ai(unit_owner(punit));
   int i;
 
   // We start with i = 1 for i = 0 is our present position
-  for (i = 1; i < path->length; i++) {
-    struct tile *ptile = path->positions[i].tile;
+  for (i = 1; i < path.length(); i++) {
+    struct tile *ptile = path[i].tile;
     int id = punit->id;
 
     if (same_pos(unit_tile(punit), ptile)) {

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -44,7 +44,8 @@ static bool adv_unit_move(struct unit *punit, struct tile *ptile);
    or assigned destination
    Return FALSE iff we died.
  */
-bool adv_follow_path(struct unit *punit, PFPath path, struct tile *ptile)
+bool adv_follow_path(struct unit *punit, const PFPath &path,
+                     struct tile *ptile)
 {
   struct tile *old_tile = punit->goto_tile;
   enum unit_activity activity = punit->activity;
@@ -78,7 +79,7 @@ bool adv_follow_path(struct unit *punit, PFPath path, struct tile *ptile)
    Brings our bodyguard along.
    Returns FALSE only if died.
  */
-bool adv_unit_execute_path(struct unit *punit, PFPath path)
+bool adv_unit_execute_path(struct unit *punit, const PFPath &path)
 {
   const bool is_plr_ai = is_ai(unit_owner(punit));
   int i;

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -44,7 +44,7 @@ static bool adv_unit_move(struct unit *punit, struct tile *ptile);
    or assigned destination
    Return FALSE iff we died.
  */
-bool adv_follow_path(struct unit *punit, Pf_path path, struct tile *ptile)
+bool adv_follow_path(struct unit *punit, PFPath path, struct tile *ptile)
 {
   struct tile *old_tile = punit->goto_tile;
   enum unit_activity activity = punit->activity;
@@ -78,7 +78,7 @@ bool adv_follow_path(struct unit *punit, Pf_path path, struct tile *ptile)
    Brings our bodyguard along.
    Returns FALSE only if died.
  */
-bool adv_unit_execute_path(struct unit *punit, Pf_path path)
+bool adv_unit_execute_path(struct unit *punit, PFPath path)
 {
   const bool is_plr_ai = is_ai(unit_owner(punit));
   int i;

--- a/server/advisors/advgoto.h
+++ b/server/advisors/advgoto.h
@@ -25,9 +25,9 @@ struct adv_risk_cost {
   double enemy_zoc_cost;
 };
 
-bool adv_follow_path(struct unit *punit, Pf_path path, struct tile *ptile);
+bool adv_follow_path(struct unit *punit, PFPath path, struct tile *ptile);
 
-bool adv_unit_execute_path(struct unit *punit, Pf_path path);
+bool adv_unit_execute_path(struct unit *punit, PFPath path);
 
 int adv_could_unit_move_to_tile(struct unit *punit, struct tile *dst_tile);
 

--- a/server/advisors/advgoto.h
+++ b/server/advisors/advgoto.h
@@ -25,9 +25,10 @@ struct adv_risk_cost {
   double enemy_zoc_cost;
 };
 
-bool adv_follow_path(struct unit *punit, PFPath path, struct tile *ptile);
+bool adv_follow_path(struct unit *punit, const PFPath &path,
+                     struct tile *ptile);
 
-bool adv_unit_execute_path(struct unit *punit, PFPath path);
+bool adv_unit_execute_path(struct unit *punit, const PFPath &path);
 
 int adv_could_unit_move_to_tile(struct unit *punit, struct tile *dst_tile);
 

--- a/server/advisors/advgoto.h
+++ b/server/advisors/advgoto.h
@@ -25,9 +25,9 @@ struct adv_risk_cost {
   double enemy_zoc_cost;
 };
 
-bool adv_follow_path(struct unit *punit, Pf_path *path, struct tile *ptile);
+bool adv_follow_path(struct unit *punit, Pf_path path, struct tile *ptile);
 
-bool adv_unit_execute_path(struct unit *punit, Pf_path *path);
+bool adv_unit_execute_path(struct unit *punit, Pf_path path);
 
 int adv_could_unit_move_to_tile(struct unit *punit, struct tile *dst_tile);
 

--- a/server/advisors/advgoto.h
+++ b/server/advisors/advgoto.h
@@ -25,10 +25,9 @@ struct adv_risk_cost {
   double enemy_zoc_cost;
 };
 
-bool adv_follow_path(struct unit *punit, struct pf_path *path,
-                     struct tile *ptile);
+bool adv_follow_path(struct unit *punit, Pf_path *path, struct tile *ptile);
 
-bool adv_unit_execute_path(struct unit *punit, struct pf_path *path);
+bool adv_unit_execute_path(struct unit *punit, Pf_path *path);
 
 int adv_could_unit_move_to_tile(struct unit *punit, struct tile *dst_tile);
 

--- a/server/advisors/autoexplorer.cpp
+++ b/server/advisors/autoexplorer.cpp
@@ -127,7 +127,7 @@ static bool explorer_goto(struct unit *punit, struct tile *ptile)
   struct adv_risk_cost risk_cost;
   bool alive = true;
   struct pf_map *pfm;
-  Pf_path path;
+  PFPath path;
   struct player *pplayer = unit_owner(punit);
 
   pft_fill_unit_parameter(&parameter, punit);

--- a/server/advisors/autoexplorer.cpp
+++ b/server/advisors/autoexplorer.cpp
@@ -127,7 +127,7 @@ static bool explorer_goto(struct unit *punit, struct tile *ptile)
   struct adv_risk_cost risk_cost;
   bool alive = true;
   struct pf_map *pfm;
-  struct pf_path *path;
+  Pf_path *path;
   struct player *pplayer = unit_owner(punit);
 
   pft_fill_unit_parameter(&parameter, punit);

--- a/server/advisors/autoexplorer.cpp
+++ b/server/advisors/autoexplorer.cpp
@@ -127,7 +127,7 @@ static bool explorer_goto(struct unit *punit, struct tile *ptile)
   struct adv_risk_cost risk_cost;
   bool alive = true;
   struct pf_map *pfm;
-  Pf_path *path;
+  Pf_path path;
   struct player *pplayer = unit_owner(punit);
 
   pft_fill_unit_parameter(&parameter, punit);
@@ -144,9 +144,8 @@ static bool explorer_goto(struct unit *punit, struct tile *ptile)
   pfm = pf_map_new(&parameter);
   path = pf_map_path(pfm, ptile);
 
-  if (path != nullptr) {
+  if (!path.empty()) {
     alive = adv_follow_path(punit, path, ptile);
-    pf_path_destroy(path);
   }
 
   pf_map_destroy(pfm);

--- a/server/advisors/autosettlers.cpp
+++ b/server/advisors/autosettlers.cpp
@@ -430,8 +430,7 @@ autosettler_tile_behavior(const struct tile *ptile, enum known_type known,
 adv_want settler_evaluate_improvements(struct unit *punit,
                                        enum unit_activity *best_act,
                                        struct extra_type **best_target,
-                                       struct tile **best_tile,
-                                       Pf_path *path,
+                                       struct tile **best_tile, PFPath *path,
                                        struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -788,7 +787,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
   }
 
   if (path) {
-    *path = *best_tile ? pf_map_path(pfm, *best_tile) : Pf_path();
+    *path = *best_tile ? pf_map_path(pfm, *best_tile) : PFPath();
   }
 
   pf_map_destroy(pfm);
@@ -801,7 +800,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
  */
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            Pf_path *path,
+                                            PFPath *path,
                                             struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -882,7 +881,7 @@ struct city *settler_evaluate_city_requests(struct unit *punit,
   *best_task = best;
 
   if (!path->empty()) {
-    *path = best ? pf_map_path(pfm, best->ptile) : Pf_path();
+    *path = best ? pf_map_path(pfm, best->ptile) : PFPath();
   }
 
   pf_map_destroy(pfm);
@@ -900,7 +899,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
   enum unit_activity best_act;
   struct tile *best_tile = nullptr;
   struct extra_type *best_target;
-  Pf_path path;
+  PFPath path;
   struct city *taskcity;
 
   // time it will take worker to complete its given task
@@ -967,7 +966,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
  */
 bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                              struct settlermap *state, int recursion,
-                             Pf_path *path, struct tile *best_tile,
+                             PFPath *path, struct tile *best_tile,
                              enum unit_activity best_act,
                              struct extra_type **best_target,
                              int completion_time)
@@ -1054,7 +1053,7 @@ bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
       bool alive;
 
       alive = adv_follow_path(punit, *path, best_tile);
-      *path = Pf_path(); // Done moving have an empty path
+      *path = PFPath(); // Done moving have an empty path
       if (alive && same_pos(unit_tile(punit), best_tile)
           && punit->moves_left > 0) {
         // Reached destination and can start working immediately

--- a/server/advisors/autosettlers.cpp
+++ b/server/advisors/autosettlers.cpp
@@ -431,7 +431,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
                                        enum unit_activity *best_act,
                                        struct extra_type **best_target,
                                        struct tile **best_tile,
-                                       struct pf_path **path,
+                                       Pf_path **path,
                                        struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -801,7 +801,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
  */
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            struct pf_path **path,
+                                            Pf_path **path,
                                             struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -900,7 +900,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
   enum unit_activity best_act;
   struct tile *best_tile = nullptr;
   struct extra_type *best_target;
-  struct pf_path *path = nullptr;
+  Pf_path *path = nullptr;
   struct city *taskcity;
 
   // time it will take worker to complete its given task
@@ -975,7 +975,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
  */
 bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                              struct settlermap *state, int recursion,
-                             struct pf_path *path, struct tile *best_tile,
+                             Pf_path *path, struct tile *best_tile,
                              enum unit_activity best_act,
                              struct extra_type **best_target,
                              int completion_time)

--- a/server/advisors/autosettlers.cpp
+++ b/server/advisors/autosettlers.cpp
@@ -431,7 +431,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
                                        enum unit_activity *best_act,
                                        struct extra_type **best_target,
                                        struct tile **best_tile,
-                                       Pf_path **path,
+                                       Pf_path *path,
                                        struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -788,7 +788,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
   }
 
   if (path) {
-    *path = *best_tile ? pf_map_path(pfm, *best_tile) : nullptr;
+    *path = *best_tile ? pf_map_path(pfm, *best_tile) : Pf_path();
   }
 
   pf_map_destroy(pfm);
@@ -801,7 +801,7 @@ adv_want settler_evaluate_improvements(struct unit *punit,
  */
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            Pf_path **path,
+                                            Pf_path *path,
                                             struct settlermap *state)
 {
   const struct player *pplayer = unit_owner(punit);
@@ -881,8 +881,8 @@ struct city *settler_evaluate_city_requests(struct unit *punit,
 
   *best_task = best;
 
-  if (path != nullptr) {
-    *path = best ? pf_map_path(pfm, best->ptile) : nullptr;
+  if (!path->empty()) {
+    *path = best ? pf_map_path(pfm, best->ptile) : Pf_path();
   }
 
   pf_map_destroy(pfm);
@@ -900,7 +900,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
   enum unit_activity best_act;
   struct tile *best_tile = nullptr;
   struct extra_type *best_target;
-  Pf_path *path = nullptr;
+  Pf_path path;
   struct city *taskcity;
 
   // time it will take worker to complete its given task
@@ -925,22 +925,18 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
   taskcity = settler_evaluate_city_requests(punit, &best_task, &path, state);
 
   if (taskcity != nullptr) {
-    if (path != nullptr) {
-      completion_time = pf_path_last_position(path)->turn;
+    if (!path.empty()) {
+      completion_time = path[-1].turn;
     }
 
     adv_unit_new_task(punit, AUT_AUTO_SETTLER, best_tile);
 
     best_target = best_task->tgt;
 
-    if (auto_settler_setup_work(pplayer, punit, state, recursion, path,
+    if (auto_settler_setup_work(pplayer, punit, state, recursion, &path,
                                 best_task->ptile, best_task->act,
                                 &best_target, completion_time)) {
       clear_worker_task(taskcity, best_task);
-    }
-
-    if (path != nullptr) {
-      pf_path_destroy(path);
     }
 
     return;
@@ -952,20 +948,16 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
     TIMING_LOG(AIT_WORKERS, TIMER_START);
     settler_evaluate_improvements(punit, &best_act, &best_target, &best_tile,
                                   &path, state);
-    if (path) {
-      completion_time = pf_path_last_position(path)->turn;
+    if (!path.empty()) {
+      completion_time = path[-1].turn;
     }
     TIMING_LOG(AIT_WORKERS, TIMER_STOP);
 
     adv_unit_new_task(punit, AUT_AUTO_SETTLER, best_tile);
 
-    auto_settler_setup_work(pplayer, punit, state, recursion, path,
+    auto_settler_setup_work(pplayer, punit, state, recursion, &path,
                             best_tile, best_act, &best_target,
                             completion_time);
-
-    if (nullptr != path) {
-      pf_path_destroy(path);
-    }
   }
 }
 
@@ -1050,19 +1042,19 @@ bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                                          : "-",
              TILE_XY(best_tile));
 
-    if (!path) {
+    if (!path->empty()) {
       pft_fill_unit_parameter(&parameter, punit);
       parameter.omniscience = !has_handicap(pplayer, H_MAP);
       parameter.get_TB = autosettler_tile_behavior;
       pfm = pf_map_new(&parameter);
-      path = pf_map_path(pfm, best_tile);
+      *path = pf_map_path(pfm, best_tile);
     }
 
-    if (path) {
+    if (!path->empty()) {
       bool alive;
 
-      alive = adv_follow_path(punit, path, best_tile);
-
+      alive = adv_follow_path(punit, *path, best_tile);
+      *path = Pf_path(); // Done moving have an empty path
       if (alive && same_pos(unit_tile(punit), best_tile)
           && punit->moves_left > 0) {
         // Reached destination and can start working immediately

--- a/server/advisors/autosettlers.h
+++ b/server/advisors/autosettlers.h
@@ -35,16 +35,14 @@ bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                              struct extra_type **best_target,
                              int completion_time);
 
-adv_want settler_evaluate_improvements(struct unit *punit,
-                                       enum unit_activity *best_act,
-                                       struct extra_type **best_target,
-                                       struct tile **best_tile,
-                                       Pf_path **path,
-                                       struct settlermap *state);
+adv_want settler_evaluate_improvements(unit *punit, unit_activity *best_act,
+                                       extra_type **best_target,
+                                       tile **best_tile, Pf_path *path,
+                                       settlermap *state);
 
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            Pf_path **path,
+                                            Pf_path *path,
                                             struct settlermap *state);
 
 void adv_unit_new_task(struct unit *punit, enum adv_unit_task task,

--- a/server/advisors/autosettlers.h
+++ b/server/advisors/autosettlers.h
@@ -19,7 +19,7 @@
 void auto_settlers_ruleset_init();
 
 struct settlermap;
-class Pf_path;
+class PFPath;
 
 void adv_settlers_free();
 
@@ -30,19 +30,19 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
 
 bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                              struct settlermap *state, int recursion,
-                             Pf_path *path, struct tile *best_tile,
+                             PFPath *path, struct tile *best_tile,
                              enum unit_activity best_act,
                              struct extra_type **best_target,
                              int completion_time);
 
 adv_want settler_evaluate_improvements(unit *punit, unit_activity *best_act,
                                        extra_type **best_target,
-                                       tile **best_tile, Pf_path *path,
+                                       tile **best_tile, PFPath *path,
                                        settlermap *state);
 
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            Pf_path *path,
+                                            PFPath *path,
                                             struct settlermap *state);
 
 void adv_unit_new_task(struct unit *punit, enum adv_unit_task task,

--- a/server/advisors/autosettlers.h
+++ b/server/advisors/autosettlers.h
@@ -19,7 +19,7 @@
 void auto_settlers_ruleset_init();
 
 struct settlermap;
-struct pf_path;
+class Pf_path;
 
 void adv_settlers_free();
 
@@ -30,7 +30,7 @@ void auto_settler_findwork(struct player *pplayer, struct unit *punit,
 
 bool auto_settler_setup_work(struct player *pplayer, struct unit *punit,
                              struct settlermap *state, int recursion,
-                             struct pf_path *path, struct tile *best_tile,
+                             Pf_path *path, struct tile *best_tile,
                              enum unit_activity best_act,
                              struct extra_type **best_target,
                              int completion_time);
@@ -39,12 +39,12 @@ adv_want settler_evaluate_improvements(struct unit *punit,
                                        enum unit_activity *best_act,
                                        struct extra_type **best_target,
                                        struct tile **best_tile,
-                                       struct pf_path **path,
+                                       Pf_path **path,
                                        struct settlermap *state);
 
 struct city *settler_evaluate_city_requests(struct unit *punit,
                                             struct worker_task **best_task,
-                                            struct pf_path **path,
+                                            Pf_path **path,
                                             struct settlermap *state);
 
 void adv_unit_new_task(struct unit *punit, enum adv_unit_task task,

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -539,7 +539,7 @@ void player_restore_units(struct player *pplayer)
             }
 
             if (is_airunit_refuel_point(ptile, pplayer, punit)) {
-              Pf_path path;
+              PFPath path;
               int id = punit->id;
 
               /* Client orders may be running for this unit - if so

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -539,7 +539,7 @@ void player_restore_units(struct player *pplayer)
             }
 
             if (is_airunit_refuel_point(ptile, pplayer, punit)) {
-              Pf_path *path;
+              Pf_path path;
               int id = punit->id;
 
               /* Client orders may be running for this unit - if so
@@ -579,7 +579,6 @@ void player_restore_units(struct player *pplayer)
                     pplayer, unit_tile(punit), E_UNIT_ORDERS, ftc_server,
                     _("Your %s has returned to refuel."), unit_link(punit));
               }
-              pf_path_destroy(path);
               break;
             }
           }

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -539,7 +539,7 @@ void player_restore_units(struct player *pplayer)
             }
 
             if (is_airunit_refuel_point(ptile, pplayer, punit)) {
-              struct pf_path *path;
+              Pf_path *path;
               int id = punit->id;
 
               /* Client orders may be running for this unit - if so


### PR DESCRIPTION
 Make Pf_path into a class

- Add many constructors for situations which the path is created to be immediately destroyed
- Overload the subscript operator [] to accept negative values. Negative values count backwards from end of array
- positions arent directly exposed and you reach positions using the overloaded [] operator
- move memory management to under the hood in as many places as possible
- algos which return nullptrs instead return an empty path. Checks now use, path.empty() to differentiate from other nullptrs.
- All functions which dont modify the path, now get the path by value. For functions which modify the path the pointer is passed. 
(this helps us differentiate both functions at the point of calling the functions)