### PR TITLE
Add move constructor and move assignment for PFPath

### DIFF
--- a/ai/default/aiferry.cpp
+++ b/ai/default/aiferry.cpp
@@ -675,7 +675,7 @@ bool dai_amphibious_goto_constrained(struct ai_type *ait, struct unit *ferry,
        * has run out of movement points */
       struct tile *next_tile;
 
-      if (!path.pf_path_advance(unit_tile(passenger))) {
+      if (!path.advance(unit_tile(passenger))) {
         /* Somehow we got thrown away from our route.
          * This can happen if our movement caused alliance breakup. */
         return unit_is_alive(pass_id);

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3229,15 +3229,8 @@ static void pf_position_fill_start_tile(struct pf_position *pos,
 /**
  * MEMBER FUNCTIONS FOR THE CLASS Pf_Class
  */
-// Constructors
-PFPath::PFPath() {}
 // Constructor to just initialize with size
 PFPath::PFPath(int size) : positions(std::vector<pf_position>(size)) {}
-// Copy Constructor
-PFPath::PFPath(const PFPath &obj)
-    : positions(std::vector<pf_position>(obj.positions))
-{
-}
 /**
    Create a path with start tile of a parameter.
  */

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -3255,7 +3255,7 @@ void PFPath::add_pos(pf_position pos) { positions.push_back(pos); }
    If tile is not on the path at all, returns FALSE and path is not changed
    at all.
  */
-bool PFPath::pf_path_advance(struct tile *ptile)
+bool PFPath::advance(struct tile *ptile)
 {
   int i;
   int length = positions.size();
@@ -3281,7 +3281,7 @@ bool PFPath::pf_path_advance(struct tile *ptile)
    If tile is not on the path at all, returns FALSE and path is not changed
    at all.
  */
-bool PFPath::pf_path_backtrack(struct tile *ptile)
+bool PFPath::backtrack(struct tile *ptile)
 {
   int i;
   fc_assert_ret_val(positions.size() > 0, false);
@@ -3299,11 +3299,6 @@ bool PFPath::pf_path_backtrack(struct tile *ptile)
     new_positions[i] = positions[i];
   }
   positions.clear();
-  /*
-  memcpy(new_positions, path->positions,
-         path->length * sizeof(*path->positions));
-  delete[] path->positions;
-  */
   positions = new_positions;
 
   return true;
@@ -3352,21 +3347,11 @@ PFPath pf_path_concat(PFPath dest_path, const PFPath &src_path)
   if (src_path.length() == 1) {
     return dest_path;
   }
-
+  /* Be careful to include the first position of src_path, it contains
+   * the direction (it is undefined in the last position of dest_path) */
   for (int i = 0; i < src_path.length(); i++) {
     dest_path.add_pos(src_path[i]);
   }
-  /* Be careful to include the first position of src_path, it contains
-   * the direction (it is undefined in the last position of dest_path) */
-  /*
-   dest_path->length = dest_end + src_path->length;
-   dest_path->positions = static_cast<pf_position *>(
-       fc_realloc(dest_path->positions,
-                  sizeof(*dest_path->positions) * dest_path->length));
-   memcpy(dest_path->positions + dest_end, src_path->positions,
-          sizeof(*dest_path->positions) * src_path->length);
-                  */
-
   return dest_path;
 }
 

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -329,14 +329,13 @@ public:
   void add_pos(pf_position pos);
   virtual ~PFPath();
   bool empty() const;
-  bool pf_path_advance(struct tile *ptile);
-  bool pf_path_backtrack(struct tile *ptile);
+  bool advance(struct tile *ptile);
+  bool backtrack(struct tile *ptile);
   pf_position &operator[](int i);
   const pf_position &operator[](int i) const;
   PFPath &operator=(PFPath &&other) = default; // Default move assignment
 };
 // Paths functions.
-void pf_path_destroy(PFPath *path);
 PFPath pf_path_concat(PFPath *dest_path, const PFPath &src_path);
 QDebug &operator<<(QDebug &logger, const PFPath &path);
 

--- a/common/aicore/path_finding.h
+++ b/common/aicore/path_finding.h
@@ -320,9 +320,10 @@ class PFPath {
   std::vector<pf_position> positions;
 
 public:
-  PFPath();
-  PFPath(int size);
-  PFPath(const PFPath &obj);
+  PFPath() = default;                  // Constructor
+  PFPath(int size);                    // Construct with size
+  PFPath(const PFPath &obj) = default; // Default copy constructor
+  PFPath(PFPath &&obj) = default;      // Default move constructor
   PFPath(const struct pf_parameter *param);
   int length() const;
   void add_pos(pf_position pos);
@@ -332,6 +333,7 @@ public:
   bool pf_path_backtrack(struct tile *ptile);
   pf_position &operator[](int i);
   const pf_position &operator[](int i) const;
+  PFPath &operator=(PFPath &&other) = default; // Default move assignment
 };
 // Paths functions.
 void pf_path_destroy(PFPath *path);


### PR DESCRIPTION
It improves performance in places a default copy constructor is used instead (Fixes #989)

Additionally, Remove the implementation of some constructors and use the default keyword instead