### PR TITLE
Make the gold indicator widget more informative

### DIFF
--- a/client/gui-qt/page_game.cpp
+++ b/client/gui-qt/page_game.cpp
@@ -227,9 +227,11 @@ void pageGame::updateInfoLabelTimeout()
   if (client.conn.playing != nullptr) {
     sw_economy->set_gold(client.conn.playing->economic.gold);
     sw_economy->set_income(player_get_expected_income(client.conn.playing));
+    sw_economy->setEnabled(true);
   } else {
     sw_economy->set_gold(0);
     sw_economy->set_income(0);
+    sw_economy->setEnabled(false);
   }
 
   sw_indicators->update();

--- a/client/gui-qt/page_game.cpp
+++ b/client/gui-qt/page_game.cpp
@@ -97,8 +97,7 @@ pageGame::pageGame(QWidget *parent)
   sw_science->setIcon(
       fcIcons::instance()->getIcon(QStringLiteral("research")));
   sw_science->setCheckable(true);
-  sw_economy = new top_bar_widget(_("Economy"), QStringLiteral("ECO"),
-                                  economy_report_dialog_popup);
+  sw_economy = new gold_widget;
   sw_economy->setIcon(
       fcIcons::instance()->getIcon(QStringLiteral("economy")));
   sw_economy->setCheckable(true);
@@ -226,23 +225,13 @@ void pageGame::updateInfoLabelTimeout()
   sw_map->update();
 
   if (client.conn.playing != nullptr) {
-    if (player_get_expected_income(client.conn.playing) > 0) {
-      eco_info =
-          QString(_("%1 (+%2)"))
-              .arg(QString::number(client.conn.playing->economic.gold),
-                   QString::number(
-                       player_get_expected_income(client.conn.playing)));
-    } else {
-      eco_info =
-          QString(_("%1 (%2)"))
-              .arg(QString::number(client.conn.playing->economic.gold),
-                   QString::number(
-                       player_get_expected_income(client.conn.playing)));
-    }
-    sw_economy->setCustomLabels(eco_info);
+    sw_economy->set_gold(client.conn.playing->economic.gold);
+    sw_economy->set_income(player_get_expected_income(client.conn.playing));
   } else {
-    sw_economy->setCustomLabels(QLatin1String(""));
+    sw_economy->set_gold(0);
+    sw_economy->set_income(0);
   }
+
   sw_indicators->update();
   sw_tax->update();
   sw_economy->update();

--- a/client/gui-qt/page_game.h
+++ b/client/gui-qt/page_game.h
@@ -26,6 +26,7 @@ class indicators_widget;
 class chat_widget;
 class message_widget;
 class hud_battle_log;
+class gold_widget;
 class goto_dialog;
 class tax_rates_widget;
 class top_bar;
@@ -92,7 +93,7 @@ private:
   QTimer *update_info_timer;
   top_bar_widget *sw_cities;
   top_bar_widget *sw_cunit;
-  top_bar_widget *sw_economy;
+  gold_widget *sw_economy;
   top_bar_widget *sw_map;
   tax_rates_widget *sw_tax;
 };

--- a/client/gui-qt/top_bar.cpp
+++ b/client/gui-qt/top_bar.cpp
@@ -19,6 +19,7 @@
 #include <QScreen>
 #include <QStyle>
 #include <QStyleOptionToolButton>
+#include <QTextStream>
 #include <QTimer>
 
 // common
@@ -359,6 +360,67 @@ void top_bar_widget::someSlot()
     cn_bytes = s.toLocal8Bit();
     send_chat(cn_bytes.data());
   }
+}
+
+/**
+ * Constructor
+ */
+gold_widget::gold_widget()
+    : top_bar_widget("", QStringLiteral("ECO"), economy_report_dialog_popup)
+{
+  setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+}
+
+/**
+ * Destructor
+ */
+gold_widget::~gold_widget() {}
+
+/**
+ * Updates the displayed text after the gold or income changed.
+ */
+void gold_widget::update_contents()
+{
+  // Get a localized string representing the income, with the sign
+  QString income;
+  QTextStream s(&income);
+  s << forcesign << m_income;
+
+  // TRANS: Top bar: "gold (income)". The income always includes a sign (e.g.
+  //        +123, or -42).
+  setText(QString(_("%1 (%2)")).arg(m_gold).arg(income));
+
+  // This is only a hint for the style, we don't do any painting ourselves.
+  warning new_warning = warning::no_warning;
+  if (m_income < 0 && m_gold + m_income >= 0) {
+    new_warning = warning::losing_money;
+  } else if (m_income < 0) {
+    new_warning = warning::low_on_funds;
+  }
+
+  // Notify
+  if (new_warning != m_warning) {
+    m_warning = new_warning;
+
+    // Allow using the warning state in CSS selectors.
+    style()->unpolish(this);
+    style()->polish(this);
+  }
+}
+
+/**
+ * Renders the tax rates widget
+ */
+void gold_widget::paintEvent(QPaintEvent *event)
+{
+  if (client_is_global_observer()) {
+    // Nothing to show
+    return;
+  }
+
+  // Draw the button
+  QToolButton::paintEvent(event);
 }
 
 /**

--- a/client/gui-qt/top_bar.h
+++ b/client/gui-qt/top_bar.h
@@ -102,6 +102,62 @@ private:
   QTimer *timer;
 };
 
+/**
+ * Top bar widget that shows the amount of gold owned by the current player,
+ * and their income.
+ *
+ * The top bar widget displays a warning when the player has negative income
+ * or will go bankrupt.
+ */
+class gold_widget : public top_bar_widget {
+  Q_OBJECT
+  Q_PROPERTY(warning current_warning READ current_warning)
+
+public:
+  /// Types of warnings displayed by gold_widget
+  enum class warning {
+    no_warning = 0,   ///< Used when no warning is shown
+    losing_money = 1, ///< The current player has negative gold income
+    low_on_funds = 2, ///< The current player will soon go bankrupt
+  };
+  Q_ENUM(warning)
+
+  gold_widget();
+  ~gold_widget() override;
+
+  /// Returns the incom as currently shown.
+  int income() const { return m_gold; }
+
+  /// Changes the gold amount shown by the widget.
+  void set_income(int income)
+  {
+    m_income = income;
+    update_contents();
+  }
+
+  /// Returns the gold amount as currently shown.
+  int gold() const { return m_gold; }
+
+  /// Changes the gold amount shown by the widget.
+  void set_gold(int gold)
+  {
+    m_gold = gold;
+    update_contents();
+  }
+
+  /// Retrieves the current warning.
+  warning current_warning() const { return m_warning; }
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+
+private:
+  void update_contents();
+
+  int m_gold = 0, m_income = 0;
+  warning m_warning = warning::no_warning;
+};
+
 /***************************************************************************
   Freeciv21 top_bar
 ***************************************************************************/

--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -866,6 +866,20 @@ top_bar_widget {
   selection-color: rgba(85, 25, 25, 185);
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: #aa0000;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: #aa0000;
+  border-color: #aa0000;
+}
+
 unit_hud_selector {
   color: white;
   background-image:url(LittleFingerpattern.png);

--- a/data/themes/gui-qt/Necrophos/resource.qss
+++ b/data/themes/gui-qt/Necrophos/resource.qss
@@ -783,6 +783,20 @@ top_bar_widget {
   selection-color: rgba(85, 25, 25, 185);
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: #aa0000;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: #aa0000;
+  border-color: #aa0000;
+}
+
 hud_message_box QDialogButtonBox QPushButton {
   border-radius: 0px;
   padding: 0px;

--- a/data/themes/gui-qt/NightStalker/resource.qss
+++ b/data/themes/gui-qt/NightStalker/resource.qss
@@ -949,6 +949,20 @@ top_bar_widget {
   selection-color: rgba(85, 25, 25, 185);
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: red;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: red;
+  border-color: red;
+}
+
 hud_action {
   selection-background-color: rgba(25,75,125, 150);
   color: rgb(5,5,185);

--- a/data/themes/gui-qt/System/resource.qss
+++ b/data/themes/gui-qt/System/resource.qss
@@ -94,6 +94,20 @@ top_bar_widget {
   selection-color: rgba(85, 25, 25, 185);
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: red;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: red;
+  border-color: red;
+}
+
 hud_unit_combat {
   selection-background-color: rgba(0, 0, 75,165);
   alternate-background-color: #0000AA;

--- a/data/themes/gui-qt/TheLastLaserMaster/resource.qss
+++ b/data/themes/gui-qt/TheLastLaserMaster/resource.qss
@@ -899,6 +899,20 @@ top_bar_widget {
   selection-color: rgba(85, 25, 25, 185);
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: red;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: red;
+  border-color: red;
+}
+
 hud_action {
   selection-background-color: rgba(125, 125, 0, 200);
   color: rgb(100,100,0);

--- a/data/themes/gui-qt/Web/resource.qss
+++ b/data/themes/gui-qt/Web/resource.qss
@@ -636,6 +636,13 @@ chat_widget QCheckBox::indicator:checked:hover {
 top_bar QToolButton {
   background: qlineargradient(x1: 0.0, y1: 0.0, x2: 0.0, y2: 1.0, stop: 0.0 rgba(246, 242, 232, 100%), stop: 1.0 rgba(243, 236, 221, 100%)); }
 
+
+gold_widget[current_warning="1"] {
+  color: hsl(341, 93%, 43%); }
+
+gold_widget[current_warning="2"] {
+  color: hsl(341, 93%, 43%); border-color: hsl(341, 93%, 43%); }
+
 hud_message_box, hud_input_box {
   /*background-color: transparent;*/
   color: #280f0b;

--- a/data/themes/gui-qt/Web/resource.scss
+++ b/data/themes/gui-qt/Web/resource.scss
@@ -830,6 +830,20 @@ top_bar QToolButton {
   background: $gradient;
 }
 
+/* Negative income */
+/* TODO Qt6:
+ * https://doc.qt.io/qt-6/widgets-changes-qt6.html#style-sheet-changes
+ */
+gold_widget[current_warning="1"] {
+  color: $redish;
+}
+
+/* Out of gold */
+gold_widget[current_warning="2"] {
+  color: $redish;
+  border-color: $redish;
+}
+
 hud_message_box, hud_input_box {
   /*background-color: transparent;*/
   color: $red-10;


### PR DESCRIPTION
The top bar widget that shows the current treasury and gold income gains two features:

* It turns red when the income is negative.
* Its outline turns red when low on funds.

This should help newbies figure out when something is wrong.

Closes #983.
Changes with respect to the proposed solution in the issue:

* The whole text turns red when income is negative (for a technical reason), and
* The global observer state is not implemented because the economy screen doesn't exist in that mode.

Only Nightstalker is implemented pending UI comments.

Screenshots of the new states:

![image](https://user-images.githubusercontent.com/22327575/166581842-2abf1bf6-f832-47e5-956b-0fc3459b9c90.png)
![image](https://user-images.githubusercontent.com/22327575/166581096-b60caaa7-c07d-48a1-8469-0f4e4c2deaa2.png)

