### PR TITLE
Don't include headers in CMakeLists.txt after all

### DIFF
--- a/ai/CMakeLists.txt
+++ b/ai/CMakeLists.txt
@@ -2,12 +2,9 @@ add_library(
   ai
   STATIC
   aitraits.cpp
-  aitraits.h
   classic
   difficulty.cpp
-  difficulty.h
   handicaps.cpp
-  handicaps.h
 )
 
 target_include_directories(ai PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/ai/classic/CMakeLists.txt
+++ b/ai/classic/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(
   ai_classic
   STATIC
   classicai.cpp
-  classicai.h
 )
 
 target_include_directories(ai_classic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/ai/default/CMakeLists.txt
+++ b/ai/default/CMakeLists.txt
@@ -2,45 +2,25 @@ add_library(
   ai_default
   STATIC
   aiair.cpp
-  aiair.h
   aidata.cpp
-  aidata.h
   aidiplomat.cpp
-  aidiplomat.h
   aiferry.cpp
-  aiferry.h
   aiguard.cpp
-  aiguard.h
   aihand.cpp
-  aihand.h
   aihunt.cpp
-  aihunt.h
   ailog.cpp
-  ailog.h
   aiparatrooper.cpp
-  aiparatrooper.h
   aiplayer.cpp
-  aiplayer.h
   aisettler.cpp
-  aisettler.h
   aitech.cpp
-  aitech.h
   aitools.cpp
-  aitools.h
   aiunit.cpp
-  aiunit.h
   daiactions.cpp
-  daiactions.h
   daicity.cpp
-  daicity.h
   daidiplomacy.cpp
-  daidiplomacy.h
   daidomestic.cpp
-  daidomestic.h
   daieffects.cpp
-  daieffects.h
   daimilitary.cpp
-  daimilitary.h
 )
 
 target_include_directories(ai_default PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -31,94 +31,55 @@ target_include_directories(client_gen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(client_gen PUBLIC common)
 
 if (AUDIO_SDL)
-  set(FREECIV_AUDIO audio_sdl.cpp audio_sdl.h)
+  set(FREECIV_AUDIO audio_sdl.cpp)
 endif()
 
 add_library(
   client
   STATIC
   attribute.cpp
-  attribute.h
   audio_none.cpp
-  audio_none.h
   audio.cpp
-  audio.h
   chatline_common.cpp
-  chatline_common.h
   citybar.cpp
-  citybar.h
   citydlg_common.cpp
-  citydlg_common.h
   cityrepdata.cpp
-  cityrepdata.h
   client_main.cpp
-  client_main.h
   climap.cpp
-  climap.h
   climisc.cpp
-  climisc.h
   clinet.cpp
-  clinet.h
   colors_common.cpp
-  colors_common.h
   connectdlg_common.cpp
-  connectdlg_common.h
   control.cpp
-  control.h
   editor.cpp
-  editor.h
   global_worklist.cpp
-  global_worklist.h
   goto.cpp
-  goto.h
   governor.cpp
-  governor.h
   layer_background.cpp
-  layer_background.h
   layer_base_flags.cpp
-  layer_base_flags.h
   layer_darkness.cpp
-  layer_darkness.h
   layer_special.cpp
-  layer_special.h
   layer_terrain.cpp
-  layer_terrain.h
   layer.cpp
-  layer.h
   luaconsole_common.cpp
-  luaconsole_common.h
   mapctrl_common.cpp
-  mapctrl_common.h
   mapview_common.cpp
-  mapview_common.h
   messagewin_common.cpp
-  messagewin_common.h
   music.cpp
-  music.h
   options.cpp
-  options.h
   overview_common.cpp
-  overview_common.h
   plrdlg_common.cpp
-  plrdlg_common.h
   repodlgs_common.cpp
-  repodlgs_common.h
   reqtree.cpp
-  reqtree.h
   text.cpp
-  text.h
   themes_common.cpp
-  themes_common.h
   tilespec.cpp
-  tilespec.h
   update_queue.cpp
-  update_queue.h
   voteinfo.cpp
-  voteinfo.h
   ${FREECIV_AUDIO}
 )
 if(NOT EMSCRIPTEN)
-  target_sources(client PRIVATE servers.cpp servers.h)
+  target_sources(client PRIVATE servers.cpp)
 endif()
 
 target_include_directories(client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -142,7 +103,7 @@ add_compile_definitions(NOMINMAX)
 
 if(FREECIV_ENABLE_CLIENT)
   add_subdirectory(gui-qt)
-  add_executable(freeciv21-client ${GUI_TYPE} packhand.cpp packhand.h) # packhand.c depends on gui-qt
+  add_executable(freeciv21-client ${GUI_TYPE} packhand.cpp) # packhand.c depends on gui-qt
   if(EMSCRIPTEN)
     target_link_options(freeciv21-client PRIVATE
                         -sASSERTIONS=1

--- a/client/gui-qt/CMakeLists.txt
+++ b/client/gui-qt/CMakeLists.txt
@@ -5,106 +5,55 @@ add_library(
   gui-qt
   STATIC
   canvas.cpp
-  canvas.h
   chatline.cpp
-  chatline.h
   citydlg.cpp
-  citydlg.h
   cityrep.cpp
-  cityrep.h
   civstatus.cpp
-  civstatus.h
   colors.cpp
-  colors.h
   connectdlg.cpp
-  connectdlg.h
   dialogs.cpp
-  dialogs.h
   diplodlg.cpp
-  diplodlg.h
   economyreport.cpp
-  economyreport.h
   endgamereport.cpp
-  endgamereport.h
   fc_client.cpp
-  fc_client.h
   fonts.cpp
-  fonts.h
   gotodlg.cpp
-  gotodlg.h
   gui_main.cpp
-  gui_main.h
   helpdlg.cpp
-  helpdlg.h
   hudwidget.cpp
-  hudwidget.h
   icons.cpp
-  icons.h
   idlecallback.cpp
-  idlecallback.h
-  listener.h
   luaconsole.cpp
-  luaconsole.h
   mapctrl.cpp
-  mapctrl.h
   mapview.cpp
-  mapview.h
   menu.cpp
-  menu.h
   messageoptions.cpp
-  messageoptions.h
   messagewin.cpp
-  messagewin.h
   minimap.cpp
-  minimap.h
   notifyreport.cpp
-  notifyreport.h
   optiondlg.cpp
-  optiondlg.h
   page_game.cpp
-  page_game.h
   page_load.cpp
-  page_load.h
   page_main.cpp
-  page_main.h
   page_network.cpp
-  page_network.h
   page_pregame.cpp
-  page_pregame.h
   page_scenario.cpp
-  page_scenario.h
   plrdlg.cpp
-  plrdlg.h
   pregameoptions.cpp
-  pregameoptions.h
-  qtg_cxxside.h
   ratesdlg.cpp
-  ratesdlg.h
   sciencedlg.cpp
-  sciencedlg.h
   shortcuts.cpp
-  shortcuts.h
   spaceshipdlg.cpp
-  spaceshipdlg.h
   sprite.cpp
-  sprite.h
   themes.cpp
   tileset_debugger.cpp
-  tileset_debugger.h
   tooltips.cpp
-  tooltips.h
   top_bar.cpp
-  top_bar.h
   tradecalculation.cpp
-  tradecalculation.h
   unitreport.cpp
-  unitreport.h
   unitselect.cpp
-  unitselect.h
   voteinfo_bar.cpp
-  voteinfo_bar.h
   widgetdecorations.cpp
-  widgetdecorations.h
 )
 
 target_include_directories(gui-qt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/client/luascript/CMakeLists.txt
+++ b/client/luascript/CMakeLists.txt
@@ -9,9 +9,7 @@ add_library(
   luascript
   STATIC
   api_client_base.cpp
-  api_client_base.h
   script_client.cpp
-  script_client.h
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_client_gen.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_client_gen.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(
   STATIC
   # The generated code calls these directly
   capstr.cpp
-  capstr.h
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/packets_gen.cpp
 )
@@ -42,122 +41,60 @@ add_library(
   common
   STATIC
   achievements.cpp
-  achievements.h
   actions.cpp
-  actions.h
   ai.cpp
-  ai.h
   base.cpp
-  base.h
   borders.cpp
-  borders.h
   calendar.cpp
-  calendar.h
-  chat.h
   citizens.cpp
-  citizens.h
   city.cpp
-  city.h
   clientutils.cpp
-  clientutils.h
   combat.cpp
-  combat.h
   culture.cpp
-  culture.h
   diptreaty.cpp
-  diptreaty.h
   disaster.cpp
-  disaster.h
   effects.cpp
-  effects.h
   events.cpp
-  events.h
-  explanation.h
   extras.cpp
-  extras.h
   fc_interface.cpp
-  fc_interface.h
-  fc_types.h
   featured_text.cpp
-  featured_text.h
   game.cpp
-  game.h
   government.cpp
-  government.h
   helpdata.cpp
-  helpdata.h
   idex.cpp
-  idex.h
   improvement.cpp
-  improvement.h
   map.cpp
-  map.h
   mapimg.cpp
-  mapimg.h
-  map_types.h
   metaknowledge.cpp
-  metaknowledge.h
   movement.cpp
-  movement.h
   multipliers.cpp
-  multipliers.h
-  name_translation.h
   nation.cpp
-  nation.h
   path.cpp
-  path.h
   path_finder.cpp
-  path_finder.h
   player.cpp
-  player.h
   reqtext.cpp
-  reqtext.h
   requirements.cpp
-  requirements.h
   research.cpp
-  research.h
   rgbcolor.cpp
-  rgbcolor.h
   road.cpp
-  road.h
   server_settings.cpp
-  server_settings.h
   spaceship.cpp
-  spaceship.h
   specialist.cpp
-  specialist.h
   style.cpp
-  style.h
   team.cpp
-  team.h
   tech.cpp
-  tech.h
   terrain.cpp
-  terrain.h
   tile.cpp
-  tile.h
   traderoutes.cpp
-  traderoutes.h
-  traits.h
   unit.cpp
-  unit.h
   unit_utils.cpp
-  unit_utils.h
   unitlist.cpp
-  unitlist.h
   unittype.cpp
-  unittype.h
   version.cpp
-  version.h
   victory.cpp
-  victory.h
   vision.cpp
-  vision.h
   workertask.cpp
-  workertask.h
   worklist.cpp
-  worklist.h
-  world_object.h
 )
 target_include_directories(common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/common/aicore/CMakeLists.txt
+++ b/common/aicore/CMakeLists.txt
@@ -2,19 +2,12 @@ add_library(
   aicore
   STATIC
   aiactions.cpp
-  aiactions.h
   aisupport.cpp
-  aisupport.h
   caravan.cpp
-  caravan.h
   citymap.cpp
-  citymap.h
   cm.cpp
-  cm.h
   path_finding.cpp
-  path_finding.h
   pf_tools.cpp
-  pf_tools.h
 )
 
 target_include_directories(aicore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/common/networking/CMakeLists.txt
+++ b/common/networking/CMakeLists.txt
@@ -2,11 +2,8 @@ add_library(
   networking
   STATIC
   connection.cpp
-  connection.h
   dataio_raw.cpp
-  dataio_raw.h
   packets.cpp
-  packets.h
 )
 
 target_include_directories(networking PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/common/scriptcore/CMakeLists.txt
+++ b/common/scriptcore/CMakeLists.txt
@@ -21,26 +21,15 @@ add_library(
   scriptcore
   STATIC
   api_common_intl.cpp
-  api_common_intl.h
   api_common_utilities.cpp
-  api_common_utilities.h
   api_game_effects.cpp
-  api_game_effects.h
   api_game_find.cpp
-  api_game_find.h
   api_game_methods.cpp
-  api_game_methods.h
   api_game_specenum.cpp
-  api_game_specenum.h
   api_signal_base.cpp
-  api_signal_base.h
   luascript.cpp
-  luascript.h
   luascript_func.cpp
-  luascript_func.h
   luascript_signal.cpp
-  luascript_signal.h
-  luascript_types.h
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_common_a_gen.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_common_a_gen.h

--- a/tools/fcmp/CMakeLists.txt
+++ b/tools/fcmp/CMakeLists.txt
@@ -4,13 +4,9 @@ add_library(
   freeciv_modpack
   STATIC
   download.cpp
-  download.h
   modinst.cpp
-  modinst.h
   mpcmdline.cpp
-  mpcmdline.h
   mpdb.cpp
-  mpdb.h
 )
 
 target_link_libraries(freeciv_modpack PUBLIC common)
@@ -29,9 +25,7 @@ if (FREECIV_ENABLE_FCMP_QT)
   add_executable(
     freeciv21-modpack-qt ${GUI_TYPE}
     mpgui_qt_worker.cpp
-    mpgui_qt_worker.h
     mpgui_qt.cpp
-    mpgui_qt.h
   )
   target_link_libraries(freeciv21-modpack-qt PRIVATE freeciv_modpack)
   target_link_libraries(freeciv21-modpack-qt PRIVATE Qt5::Widgets)

--- a/tools/ruledit/CMakeLists.txt
+++ b/tools/ruledit/CMakeLists.txt
@@ -3,47 +3,26 @@ set(CMAKE_AUTOMOC ON)
 add_executable(
   freeciv21-ruledit ${GUI_TYPE}
   conversion_log.cpp
-  conversion_log.h
   edit_utype.cpp
-  edit_utype.h
   effect_edit.cpp
-  effect_edit.h
   req_edit.cpp
-  req_edit.h
   req_vec_fix.cpp
-  req_vec_fix.h
   requirers_dlg.cpp
-  requirers_dlg.h
   ruledit_qt.cpp
-  ruledit_qt.h
   ruledit.cpp
-  ruledit.h
   tab_building.cpp
-  tab_building.h
   tab_enablers.cpp
-  tab_enablers.h
   tab_extras.cpp
-  tab_extras.h
   tab_good.cpp
-  tab_good.h
   tab_gov.cpp
-  tab_gov.h
   tab_misc.cpp
-  tab_misc.h
   tab_multiplier.cpp
-  tab_multiplier.h
   tab_nation.cpp
-  tab_nation.h
   tab_tech.cpp
-  tab_tech.h
   tab_terrains.cpp
-  tab_terrains.h
   tab_unit.cpp
-  tab_unit.h
   univ_value.cpp
-  univ_value.h
   validity.cpp
-  validity.h
 )
 
 target_link_libraries(freeciv21-ruledit server)

--- a/tools/ruleutil/CMakeLists.txt
+++ b/tools/ruleutil/CMakeLists.txt
@@ -2,9 +2,7 @@ add_library(
   tools_ruleutil
   STATIC
   comments.cpp
-  comments.h
   rulesave.cpp
-  rulesave.h
 )
 
 target_include_directories(tools_ruleutil PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/shared/CMakeLists.txt
+++ b/tools/shared/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(
   tools_shared
   STATIC
   tools_fc_interface.cpp
-  tools_fc_interface.h
 )
 
 target_include_directories(tools_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -22,54 +22,28 @@ add_library(
   utility
   STATIC
   astring.cpp
-  astring.h
   bitvector.cpp
-  bitvector.h
   bugs.cpp
-  bugs.h
   capability.cpp
-  capability.h
   deprecations.cpp
-  deprecations.h
   distribute.cpp
-  distribute.h
   fcbacktrace.cpp
-  fcbacktrace.h
   fciconv.cpp
-  fciconv.h
   fcintl.cpp
-  fcintl.h
   fcthread.cpp
-  fcthread.h
   genhash.cpp
-  genhash.h
   genlist.cpp
-  genlist.h
   inputfile.cpp
-  inputfile.h
   iterator.cpp
-  iterator.h
   log.cpp
-  log.h
   netfile.cpp
-  netfile.h
-  net_types.h
   rand.cpp
-  rand.h
   registry.cpp
-  registry.h
   registry_ini.cpp
-  registry_ini.h
   section_file.cpp
-  section_file.h
   shared.cpp
-  shared.h
-  speclist.h
-  specvec.h
   support.cpp
-  support.h
   timing.cpp
-  timing.h
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/specenum_gen.h
 )


### PR DESCRIPTION
The headers were added because Microsoft Visual Studio's "Solution" view
doesn't show the headers.  However, VS' built-in CMake handling doesn't use the
solution view and is based on folders (much like CMake itself).  There is no
recommendation from the CMake side on how to handle this problem with CMake's
built-in generators for Visual Studio.

Following the VS documentation and the instructions added in #999, one can get
(at least) decent VS support with IntelliSense working.  This doesn't require
keeping the headers in the CMakeLists, so remove them for more idiomatic CMake
code.

This reverts part of commit 6e38a15ac21b75dc616c0c30cec760d026f2598a.
See #1005.