### PR TITLE
Add Ubuntu 22.04 (Jammy) to CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,15 +11,20 @@ on:
 jobs:
   ubuntu:
     name: "Ubuntu"
-    runs-on: ubuntu-latest
     needs: clang-format
     strategy:
       matrix:
+        os: [ubuntu-latest]
         compiler: [gcc, clang]
         build_type: ["", Release, Debug, RelWithDebInfo]
+        include:
+          - os: ubuntu-22.04
+            compiler: gcc
+            build_type: Debug
         exclude:
           - compiler: clang
             build_type: RelWithDebInfo
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
             ninja-build \
             python3 \
             gettext \
-            qt5-default \
+            qtbase5-dev \
             libqt5svg5-dev \
             libkf5archive-dev \
             liblua5.3-dev \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other Linux users will need to compile the code. Ubuntu 20.04 or higher is suppo
 
 You may need to adjust this command for your package manager. You need CMake 3.16 or higher, Qt (base and SVG) 5.10 or higher, and Lua 5.3 or 5.4. You need to do this only once.
 ```sh
-sudo apt install git cmake ninja-build g++ python3 gettext qt5-default \
+sudo apt install git cmake ninja-build g++ python3 gettext qtbase5-dev \
   libqt5svg5-dev libkf5archive-dev liblua5.3-dev libsqlite3-dev libsdl2-mixer-dev
 ```
 

--- a/docs/General/install.rst
+++ b/docs/General/install.rst
@@ -230,7 +230,7 @@ following commands.
      ninja-build \
      python3 \
      python3-pip \
-     qt5-default \
+     qtbase5-dev \
      libqt5svg5-dev \
      libkf5archive-dev \
      liblua5.3-dev \


### PR DESCRIPTION
The main development target is still 20.04, but testing on 22.04 as well is a
first step towards a complete switch.  I don't expect any breakage since some
of us have been using Arch for development (-> newer versions of everything).

Include a single configuration for now, building with GCC in debug mode to
avoid using too many free Github CPU cycles.