### PR TITLE
Reset tileset data when the ruleset changes

### DIFF
--- a/client/layer.h
+++ b/client/layer.h
@@ -173,6 +173,11 @@ public:
     Q_UNUSED(terrain);
   }
 
+  /**
+   * Resets cached data that depends on the ruleset.
+   */
+  virtual void reset_ruleset() {}
+
   mapview_layer type() const { return m_layer; }
 
 protected:

--- a/client/layer_special.cpp
+++ b/client/layer_special.cpp
@@ -80,4 +80,13 @@ std::vector<drawn_sprite> layer_special::fill_sprite_array(
   return sprites;
 }
 
+void layer_special::reset_ruleset()
+{
+  // The array is indexed by the extra id, which depends on the ruleset.
+  // Clear it.
+  for (auto &sprite : m_sprites) {
+    sprite = nullptr;
+  }
+}
+
 } // namespace freeciv

--- a/client/layer_special.h
+++ b/client/layer_special.h
@@ -36,6 +36,8 @@ public:
                     const city *pcity,
                     const unit_type *putype) const override;
 
+  void reset_ruleset() override;
+
 private:
   std::array<std::unique_ptr<drawn_sprite>, MAX_EXTRA_TYPES> m_sprites;
 };

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -5799,13 +5799,15 @@ static void tileset_player_free(struct tileset *t, int plrid)
  */
 void tileset_ruleset_reset(struct tileset *t)
 {
-  int i;
-
-  for (i = 0; i < ESTYLE_COUNT; i++) {
+  for (int i = 0; i < ESTYLE_COUNT; i++) {
     if (t->style_lists[i] != nullptr) {
       extra_type_list_destroy(t->style_lists[i]);
       t->style_lists[i] = extra_type_list_new();
     }
+  }
+
+  for (auto &layer : t->layers) {
+    layer->reset_ruleset();
   }
 }
 


### PR DESCRIPTION
Some cached data needs to be updated when the ruleset changes and the tileset
remains the same.  Add a new virtual method in the layer class to trigger this
reset.

Fixes #974.