### PR TITLE
Don't auto-return units to refuel if they're converting

### DIFF
--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -515,7 +515,8 @@ void player_restore_units(struct player *pplayer)
       /* I think this is strongly against the spirit of client goto.
        * The problem is (again) that here we know too much. -- Zamar */
 
-      if (punit->fuel <= 1 && !is_unit_being_refueled(punit)) {
+      if (punit->fuel <= 1 && !is_unit_being_refueled(punit)
+          && !converting_fuel_rescue(punit)) {
         struct unit *carrier;
 
         carrier = transporter_for_unit(punit);


### PR DESCRIPTION
A converting unit may (e.g. Submersibles in Aviation ruleset) save
 itself from fuel exhaustion by conversion.  In that case, there is
 no need to override the unit's existing orders at turn-end and
 auto-move it to a nearby refueling point (city, carrier, etc.).
So, condition that auto-move code on !converting_fuel_rescue().