### PR TITLE
Fix running the wasm CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -327,7 +327,7 @@ jobs:
         name: Checkout extra-cmake-modules
         with:
           repository: KDE/extra-cmake-modules
-          ref: v5.89.0
+          ref: v5.96.0
           path: ecm
       - name: Install ecm
         run: |
@@ -338,7 +338,7 @@ jobs:
         name: Checkout karchive
         with:
           repository: KDE/karchive
-          ref: v5.89.0
+          ref: v5.96.0
           path: karchive
       - name: Install karchive
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -245,7 +245,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/qt
-          key: qt-wasm-${{ env.QT_VERSION }}-svg-socket
+          key: qt-wasm-${{ env.QT_VERSION }}-svg-socket-v2
       - name: Install build tools
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -345,8 +345,10 @@ jobs:
           source emsdk/emsdk_env.sh
           cd karchive
           git apply ../patches/karchive.diff
-          emcmake cmake -DECM_DIR=/usr/local/share/ECM/cmake -DBUILD_TESTING=0 \
+          emcmake cmake . \
+            -DECM_DIR=/usr/local/share/ECM/cmake -DBUILD_TESTING=0 \
             -DQt5Core_DIR=$HOME/qt/lib/cmake/Qt5Core \
+            -DKF_IGNORE_PLATFORM_CHECK=1 \
             -DCMAKE_INSTALL_PREFIX=../emsdk/upstream/emscripten/cache/sysroot
           emmake make install
       - name: Build Freeciv

--- a/patches/karchive.diff
+++ b/patches/karchive.diff
@@ -1,13 +1,21 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 675ddf4..ff55e03 100644
+index 037b7d1..df1bcce 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -72,8 +72,6 @@ target_include_directories(KF5Archive
+@@ -24,7 +24,6 @@ endif()
+
+ if (LibZstd_FOUND)
+     target_sources(KF5Archive PRIVATE kzstdfilter.cpp)
+-    target_link_libraries(KF5Archive PRIVATE PkgConfig::LibZstd)
+ endif()
+
+
+@@ -72,8 +71,6 @@ target_include_directories(KF5Archive
  target_link_libraries(KF5Archive
      PUBLIC
-         Qt5::Core
+         Qt${QT_MAJOR_VERSION}::Core
 -    PRIVATE
 -        ZLIB::ZLIB
  )
- 
+
  set_target_properties(KF5Archive PROPERTIES


### PR DESCRIPTION
The CI started to fail because of an outdated cache after the latest release of
emsdk. Update the cache key to pull a fresh cache.