### PR TITLE
Give cities disbanded to units movement to escape the spot

### DIFF
--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -11,13 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <fc_config.h>
-#endif
-
 #include <cmath> // exp, sqrt
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
 
 // utility
@@ -45,7 +39,6 @@
 #include "map.h"
 #include "player.h"
 #include "research.h"
-#include "road.h"
 #include "server_settings.h"
 #include "specialist.h"
 #include "style.h"
@@ -67,15 +60,12 @@
 #include "sanitycheck.h"
 #include "spacerace.h"
 #include "srv_log.h"
-#include "srv_main.h"
 #include "techtools.h"
-#include "unithand.h"
 #include "unittools.h"
 
 /* server/advisors */
 #include "advbuilding.h"
 #include "advdata.h"
-#include "autosettlers.h"
 
 /* server/scripting */
 #include "script_server.h"
@@ -2478,7 +2468,7 @@ static struct unit *city_create_unit(struct city *pcity,
 
   punit = create_unit(pplayer, pcity->tile, utype,
                       city_production_unit_veteran_level(pcity, utype),
-                      pcity->id, 0);
+                      pcity->id, -1);
   pplayer->score.units_built++;
   saved_unit_id = punit->id;
 


### PR DESCRIPTION
Units built by cities, including when the city gets disbanded
in the process, were given zero movement initially. That meant
them to be unable to escape to neighboring tiles if the
disappearance of the city made the tile non-native for them.

Ported from: https://github.com/freeciv/freeciv/commit/7b284230005a9cc458d255edb3ecefe3c161ac76
Fixes #1014

I also removed some unused header files. 