### PR TITLE
Untested: Have Autorevision create a PR instead of trying to push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,14 @@ jobs:
   update-archive:
     name: "Update Source Archive"
     runs-on: ubuntu-latest
-    needs: update-autorevision
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: master
+      - run: git rev-parse --short=5 HEAD > cmake/AutoRevision.txt
+      - run: git describe --tags `git rev-list --tags --max-count=1` >> cmake/AutoRevision.txt
+      - run: cat cmake/AutoRevision.txt
       - name: Make build directory
         run: mkdir -p -v $PWD/build
       - name: Create tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,14 @@ jobs:
       - run: git rev-parse --short=5 HEAD > cmake/AutoRevision.txt
       - run: git describe --tags `git rev-list --tags --max-count=1` >> cmake/AutoRevision.txt
       - run: cat cmake/AutoRevision.txt
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.0.4
         with:
-          commit_message: "Release update of AutoRevision.txt"
+          commit-message: "Release update of AutoRevision.txt"
+          branch: "release/autorevision"
+          title: "Release update of AutoRevision.txt"
+          body: "Automatic changes triggered by a new release"
+          delete-branch: true
   update-archive:
     name: "Update Source Archive"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Direct pushes to master are forbidden by branch protection rules. Have the
automation create a PR instead, so we can approve it and enable automerge. It's
a bit less convenient than a push but good enough for now. It also lets us
check that the action is working is intended. If this works well, we could
consider enabling automerge from within the action (or pushing directly as it
looks like it's supported via an access token [1]).

Closes #955.

[1] https://github.com/stefanzweifel/git-auto-commit-action/issues/87