### PR TITLE
Check that the trade partner is known

### DIFF
--- a/common/traderoutes.h
+++ b/common/traderoutes.h
@@ -154,7 +154,11 @@ int city_trade_removable(const struct city *pcity,
   do {                                                                      \
     trade_routes_iterate(c, _proute_)                                       \
     {                                                                       \
-      struct city *p = game_city_by_number(_proute_->partner);
+      struct city *p = game_city_by_number(_proute_->partner);              \
+      /* Maybe we haven't yet recieved info about this city */              \
+      if (!p) {                                                             \
+        continue;                                                           \
+      }
 
 #define trade_partners_iterate_end                                          \
   }                                                                         \


### PR DESCRIPTION
It can happen that not all trade partners of a city are known when we draw
trade routes. In such cases we should ignore the unknown trade partner instead
of trying (and failing) to draw the trade route line.

Closes #1059.