### PR TITLE
Remove function  player_slot_count()

### DIFF
--- a/ai/default/aidata.cpp
+++ b/ai/default/aidata.cpp
@@ -57,7 +57,7 @@ void dai_data_init(struct ai_type *ait, struct player *pplayer)
   ai->last_num_oceans = -1;
 
   ai->diplomacy.player_intel_slots =
-      new const ai_dip_intel *[player_slot_count()]();
+      new const ai_dip_intel *[MAX_NUM_PLAYER_SLOTS]();
   player_slots_iterate(pslot)
   {
     const struct ai_dip_intel **player_intel_slot =

--- a/ai/default/daidiplomacy.cpp
+++ b/ai/default/daidiplomacy.cpp
@@ -1015,7 +1015,7 @@ void dai_diplomacy_begin_new_phase(struct ai_type *ait,
 {
   struct ai_plr *ai = dai_plr_data_get(ait, pplayer, nullptr);
   struct adv_data *adv = adv_data_get(pplayer, nullptr);
-  int war_desire[player_slot_count()];
+  int war_desire[MAX_NUM_PLAYER_SLOTS];
   int best_desire = 0;
   struct player *best_target = nullptr;
 

--- a/common/player.cpp
+++ b/common/player.cpp
@@ -326,10 +326,10 @@ void player_slots_init()
   int i;
 
   // Init player slots.
-  player_slots.pslots = new player_slot[player_slot_count()]();
+  player_slots.pslots = new player_slot[MAX_NUM_PLAYER_SLOTS]();
   /* Can't use the defined functions as the needed data will be
    * defined here. */
-  for (i = 0; i < player_slot_count(); i++) {
+  for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
     player_slots.pslots[i].player = nullptr;
   }
   player_slots.used_slots = 0;
@@ -363,16 +363,9 @@ struct player_slot *player_slot_first() { return player_slots.pslots; }
 struct player_slot *player_slot_next(struct player_slot *pslot)
 {
   pslot++;
-  return (pslot < player_slots.pslots + player_slot_count() ? pslot
-                                                            : nullptr);
+  return (pslot < player_slots.pslots + MAX_NUM_PLAYER_SLOTS ? pslot
+                                                             : nullptr);
 }
-
-/**
-   Returns the total number of player slots, i.e. the maximum
-   number of players (including barbarians, etc.) that could ever
-   exist at once.
- */
-int player_slot_count() { return (MAX_NUM_PLAYER_SLOTS); }
 
 /**
    Returns the index of the player slot.
@@ -417,7 +410,7 @@ bool player_slot_is_used(const struct player_slot *pslot)
 struct player_slot *player_slot_by_number(int player_id)
 {
   if (!player_slots_initialised()
-      || !(0 <= player_id && player_id < player_slot_count())) {
+      || !(0 <= player_id && player_id < MAX_NUM_PLAYER_SLOTS)) {
     return nullptr;
   }
 
@@ -472,7 +465,7 @@ struct player *player_new(struct player_slot *pslot)
   pplayer = new player();
   pplayer->slot = pslot;
   pslot->player = pplayer;
-  pplayer->diplstates = new const player_diplstate *[player_slot_count()]();
+  pplayer->diplstates = new const player_diplstate *[MAX_NUM_PLAYER_SLOTS]();
 
   player_slots_iterate(dslot)
   {
@@ -858,7 +851,7 @@ struct player *player_by_name_prefix(const char *name,
 {
   int ind;
 
-  *result = match_prefix(player_name_by_number, player_slot_count(),
+  *result = match_prefix(player_name_by_number, MAX_NUM_PLAYER_SLOTS,
                          MAX_LEN_NAME - 1, fc_strncasequotecmp,
                          effectivestrlenquote, name, &ind);
 

--- a/common/player.h
+++ b/common/player.h
@@ -359,8 +359,6 @@ void player_slots_free();
 struct player_slot *player_slot_first();
 struct player_slot *player_slot_next(struct player_slot *pslot);
 
-// A player slot contains a possibly uninitialized player.
-int player_slot_count();
 int player_slot_index(const struct player_slot *pslot);
 struct player *player_slot_get_player(const struct player_slot *pslot);
 bool player_slot_is_used(const struct player_slot *pslot);

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -59,7 +59,7 @@ void researches_init()
 
   // Ensure we have enough space for players or teams.
   fc_assert(ARRAY_SIZE(research_array) >= team_slot_count());
-  fc_assert(ARRAY_SIZE(research_array) >= player_slot_count());
+  fc_assert(ARRAY_SIZE(research_array) >= MAX_NUM_PLAYER_SLOTS);
 
   memset(research_array, 0, sizeof(research_array));
   for (i = 0; i < ARRAY_SIZE(research_array); i++) {

--- a/server/advisors/advdata.cpp
+++ b/server/advisors/advdata.cpp
@@ -704,7 +704,7 @@ void adv_data_init(struct player *pplayer)
 
   adv->government_want = nullptr;
 
-  adv->dipl.adv_dipl_slots = new adv_dipl *[player_slot_count()]();
+  adv->dipl.adv_dipl_slots = new adv_dipl *[MAX_NUM_PLAYER_SLOTS]();
   player_slots_iterate(pslot)
   {
     struct adv_dipl **dip_slot =

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -506,7 +506,7 @@ static void package_conn_info(struct connection *pconn,
   packet->established = pconn->established;
   packet->player_num = (nullptr != pconn->playing)
                            ? player_number(pconn->playing)
-                           : player_slot_count();
+                           : MAX_NUM_PLAYER_SLOTS;
   packet->observer = pconn->observer;
   packet->access_level = pconn->access_level;
 

--- a/server/edithand.cpp
+++ b/server/edithand.cpp
@@ -76,7 +76,7 @@ void edithand_init()
   need_continents_reassigned = false;
 
   delete[] unfogged_players;
-  unfogged_players = new bool[player_slot_count()]();
+  unfogged_players = new bool[MAX_NUM_PLAYER_SLOTS]();
 }
 
 /**
@@ -163,7 +163,7 @@ static void check_leaving_edit_mode()
   players_iterate_end;
 
   // Clear the whole array.
-  memset(unfogged_players, 0, player_slot_count() * sizeof(bool));
+  memset(unfogged_players, 0, MAX_NUM_PLAYER_SLOTS * sizeof(bool));
 
   check_edited_tile_terrains();
   conn_list_do_unbuffer(game.est_connections);
@@ -882,11 +882,11 @@ void handle_edit_player_create(struct connection *pc, int tag)
   struct nation_type *pnation;
   struct research *presearch;
 
-  if (player_count() >= player_slot_count()) {
+  if (player_count() >= MAX_NUM_PLAYER_SLOTS) {
     notify_conn(pc->self, nullptr, E_BAD_COMMAND, ftc_editor,
                 _("No more players can be added because the maximum "
                   "number of players (%d) has been reached."),
-                player_slot_count());
+                MAX_NUM_PLAYER_SLOTS);
     return;
   }
 

--- a/server/gamehand.cpp
+++ b/server/gamehand.cpp
@@ -11,6 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
+#include <QtWidgets/QtWidgets>
 #include <cstdio> // for remove()
 
 // utility
@@ -415,8 +416,8 @@ static void do_team_placement(const struct team_placement_config *pconfig,
 void init_new_game()
 {
   struct startpos_list *impossible_list, *targeted_list, *flexible_list;
-  struct tile *player_startpos[player_slot_count()];
-  int placed_units[player_slot_count()];
+  struct tile *player_startpos[MAX_NUM_PLAYER_SLOTS];
+  int placed_units[MAX_NUM_PLAYER_SLOTS];
   int players_to_place = player_count();
   int sulen;
 

--- a/server/maphand.cpp
+++ b/server/maphand.cpp
@@ -1612,7 +1612,7 @@ static void create_vision_dependencies()
  */
 void give_shared_vision(struct player *pfrom, struct player *pto)
 {
-  bv_player save_vision[player_slot_count()];
+  bv_player save_vision[MAX_NUM_PLAYER_SLOTS];
   if (pfrom == pto) {
     return;
   }
@@ -1678,7 +1678,7 @@ void give_shared_vision(struct player *pfrom, struct player *pto)
  */
 void remove_shared_vision(struct player *pfrom, struct player *pto)
 {
-  bv_player save_vision[player_slot_count()];
+  bv_player save_vision[MAX_NUM_PLAYER_SLOTS];
 
   fc_assert_ret(pfrom != pto);
   if (!gives_shared_vision(pfrom, pto)) {

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -1126,7 +1126,7 @@ static void package_player_common(struct player *plr,
   packet->is_connected = plr->is_connected;
   packet->flags = plr->flags;
   packet->ai_skill_level = is_ai(plr) ? plr->ai_common.skill_level : 0;
-  for (i = 0; i < player_slot_count(); i++) {
+  for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
     packet->love[i] = plr->ai_common.love[i];
   }
   packet->barbarian_type = plr->ai_common.barbarian_type;
@@ -2020,7 +2020,7 @@ bool server_player_set_name_full(const struct connection *caller,
     // Try to append a number to 'real_name'.
     char test[MAX_LEN_NAME];
 
-    for (i = 2; i <= player_slot_count(); i++) {
+    for (i = 2; i <= MAX_NUM_PLAYER_SLOTS; i++) {
       fc_snprintf(test, sizeof(test), "%s%d", real_name, i);
       if (server_player_name_is_allowed(caller, pplayer, pnation, test,
                                         error_buf, error_buf_len)) {
@@ -2050,7 +2050,7 @@ bool server_player_set_name_full(const struct connection *caller,
   }
 
   // Try a very default name...
-  for (i = 0; i < player_slot_count(); i++) {
+  for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
     fc_snprintf(real_name, sizeof(real_name), _("Player no. %d"), i);
     if (server_player_name_is_allowed(caller, pplayer, pnation, real_name,
                                       error_buf, error_buf_len)) {
@@ -2188,7 +2188,7 @@ void maybe_make_contact(struct tile *ptile, struct player *pplayer)
 void shuffle_players()
 {
   // shuffled_order is defined global
-  int n = player_slot_count();
+  int n = MAX_NUM_PLAYER_SLOTS;
   int i;
 
   log_debug("shuffle_players: creating shuffled order");
@@ -2217,7 +2217,7 @@ void set_shuffled_players(int *shuffled_players)
   log_debug("set_shuffled_players: loading shuffled array %p",
             shuffled_players);
 
-  for (i = 0; i < player_slot_count(); i++) {
+  for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
     shuffled_order[i] = shuffled_players[i];
     log_debug("shuffled_order[%d] = %d", i, shuffled_order[i]);
   }

--- a/server/plrhand.h
+++ b/server/plrhand.h
@@ -100,7 +100,7 @@ void reset_all_start_commands(bool plrchange);
     struct player *NAME_pplayer;                                            \
     log_debug("shuffled_players_iterate @ %s line %d", __FILE__,            \
               __FC_LINE__);                                                 \
-    for (MY_i = 0; MY_i < player_slot_count(); MY_i++) {                    \
+    for (MY_i = 0; MY_i < MAX_NUM_PLAYER_SLOTS; MY_i++) {                   \
       NAME_pplayer = shuffled_player(MY_i);                                 \
       if (NAME_pplayer != nullptr) {
 

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1219,7 +1219,7 @@ static bool scan_score_log(char *id)
       log_debug("add player '%s' (from line %d: '%s')", plr_name, line_nr,
                 line);
 
-      if (0 > plr_no || plr_no >= player_slot_count()) {
+      if (0 > plr_no || plr_no >= MAX_NUM_PLAYER_SLOTS) {
         qCritical("[%s:%d] Invalid player number: %d!",
                   game.server.scorefile, line_nr, plr_no);
         return false;
@@ -1243,7 +1243,7 @@ static bool scan_score_log(char *id)
         return false;
       }
 
-      if (!(plr_no >= 0 && plr_no < player_slot_count())) {
+      if (!(plr_no >= 0 && plr_no < MAX_NUM_PLAYER_SLOTS)) {
         qCritical("[%s:%d] Invalid player number: %d!",
                   game.server.scorefile, line_nr, plr_no);
         return false;
@@ -1291,7 +1291,7 @@ void log_civ_score_init()
   score_log = new logging_civ_score[1]();
   score_log->fp = nullptr;
   score_log->last_turn = -1;
-  score_log->plrdata = new plrdata_slot[player_slot_count()]();
+  score_log->plrdata = new plrdata_slot[MAX_NUM_PLAYER_SLOTS]();
   player_slots_iterate(pslot)
   {
     struct plrdata_slot *plrdata =

--- a/server/sanitycheck.cpp
+++ b/server/sanitycheck.cpp
@@ -170,7 +170,7 @@ static void check_misc(const char *file, const char *function, int line)
   SANITY_CHECK(nplayers == player_count());
   SANITY_CHECK(nbarbs == server.nbarbarians);
 
-  SANITY_CHECK(player_count() <= player_slot_count());
+  SANITY_CHECK(player_count() <= MAX_NUM_PLAYER_SLOTS);
   SANITY_CHECK(team_count() <= MAX_NUM_TEAM_SLOTS);
   SANITY_CHECK(normal_player_count() <= game.server.max_players);
 }

--- a/server/savegame/savecompat.cpp
+++ b/server/savegame/savecompat.cpp
@@ -1124,7 +1124,7 @@ static void compat_load_020600(struct loaddata *loading,
                    {"now_name", ENTRY_STR},   {"got_tech", ENTRY_BOOL},
                    {"done", ENTRY_STR}};
 
-    int researches[MAX(player_slot_count(), team_slot_count())];
+    int researches[MAX(MAX_NUM_PLAYER_SLOTS, team_slot_count())];
     int count = 0;
     int i;
 

--- a/server/savegame/savegame2.cpp
+++ b/server/savegame/savegame2.cpp
@@ -2489,8 +2489,8 @@ static void sg_load_players_basic(struct loaddata *loading)
   if (secfile_lookup_int_default(loading->file, -1,
                                  "players.shuffled_player_%d", 0)
       >= 0) {
-    int shuffled_players[player_slot_count()];
-    bool shuffled_player_set[player_slot_count()];
+    int shuffled_players[MAX_NUM_PLAYER_SLOTS];
+    bool shuffled_player_set[MAX_NUM_PLAYER_SLOTS];
 
     player_slots_iterate(pslot)
     {
@@ -2533,14 +2533,14 @@ static void sg_load_players_basic(struct loaddata *loading)
       // Insert missing numbers.
       int shuffle_index = player_count();
 
-      for (i = 0; i < player_slot_count(); i++) {
+      for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
         if (!shuffled_player_set[i]) {
           shuffled_players[shuffle_index] = i;
           shuffle_index++;
         }
         /* shuffle_index must not grow behind the size of shuffled_players.
          */
-        sg_failure_ret(shuffle_index <= player_slot_count(),
+        sg_failure_ret(shuffle_index <= MAX_NUM_PLAYER_SLOTS,
                        "Invalid player shuffle data!");
       }
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -3499,8 +3499,8 @@ static void sg_load_players_basic(struct loaddata *loading)
   if (secfile_lookup_int_default(loading->file, -1,
                                  "players.shuffled_player_%d", 0)
       >= 0) {
-    int shuffled_players[player_slot_count()];
-    bool shuffled_player_set[player_slot_count()];
+    int shuffled_players[MAX_NUM_PLAYER_SLOTS];
+    bool shuffled_player_set[MAX_NUM_PLAYER_SLOTS];
 
     player_slots_iterate(pslot)
     {
@@ -3543,14 +3543,14 @@ static void sg_load_players_basic(struct loaddata *loading)
       // Insert missing numbers.
       int shuffle_index = player_count();
 
-      for (i = 0; i < player_slot_count(); i++) {
+      for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
         if (!shuffled_player_set[i]) {
           shuffled_players[shuffle_index] = i;
           shuffle_index++;
         }
         /* shuffle_index must not grow behind the size of shuffled_players.
          */
-        sg_failure_ret(shuffle_index <= player_slot_count(),
+        sg_failure_ret(shuffle_index <= MAX_NUM_PLAYER_SLOTS,
                        "Invalid player shuffle data!");
       }
 

--- a/server/score.cpp
+++ b/server/score.cpp
@@ -424,7 +424,7 @@ void rank_users(bool interrupt)
   FILE *fp;
   int i, t_winner_score = 0;
   enum victory_state { VS_NONE, VS_LOSER, VS_WINNER };
-  enum victory_state plr_state[player_slot_count()];
+  enum victory_state plr_state[MAX_NUM_PLAYER_SLOTS];
   struct player *spacerace_winner = nullptr;
   struct team *t_winner = nullptr;
 
@@ -443,7 +443,7 @@ void rank_users(bool interrupt)
   }
 
   // initialize plr_state
-  for (i = 0; i < player_slot_count(); i++) {
+  for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
     plr_state[i] = VS_NONE;
   }
 

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -2414,7 +2414,7 @@ const char *aifill(int amount)
   }
 
   if (limit < player_count()) {
-    int removal = player_slot_count() - 1;
+    int removal = MAX_NUM_PLAYER_SLOTS - 1;
 
     while (limit < player_count() && 0 <= removal) {
       struct player *pplayer = player_by_number(removal);

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -854,7 +854,7 @@ enum rfc_status create_command_newcomer(const char *name, const char *ai,
     // remove player and thus free a player slot
     server_remove_player(pplayer);
     pplayer = nullptr;
-  } else if (player_count() == player_slot_count()) {
+  } else if (player_count() == MAX_NUM_PLAYER_SLOTS) {
     // [2] All player slots are used; try to remove a dead player.
     players_iterate(aplayer)
     {
@@ -3129,7 +3129,7 @@ static bool is_allowed_to_take(struct connection *requester,
       return false;
     }
 
-    if (player_count() >= player_slot_count()) {
+    if (player_count() >= MAX_NUM_PLAYER_SLOTS) {
       fc_strlcpy(msg,
                  _("You cannot take a new player because there "
                    "are no free player slots."),
@@ -3490,7 +3490,7 @@ static bool take_command(struct connection *caller, char *str, bool check)
               _("There is no free player slot for %s."), pconn->username);
     return res;
   }
-  fc_assert_action(player_count() <= player_slot_count(), return false);
+  fc_assert_action(player_count() <= MAX_NUM_PLAYER_SLOTS, return false);
 
   res = true;
   if (check) {
@@ -6030,7 +6030,7 @@ bool start_command(struct connection *caller, bool check, bool notify)
         int i;
         struct player *pplayer;
 
-        for (i = player_slot_count() - 1; i >= 0; i--) {
+        for (i = MAX_NUM_PLAYER_SLOTS - 1; i >= 0; i--) {
           pplayer = player_by_number(i);
           if (pplayer) {
             server_remove_player(pplayer);
@@ -7147,7 +7147,7 @@ static const char *playername_accessor(int idx)
  */
 static char *player_generator(const char *text, int state)
 {
-  return generic_generator(text, state, player_slot_count(),
+  return generic_generator(text, state, MAX_NUM_PLAYER_SLOTS,
                            playername_accessor);
 }
 

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -321,8 +321,8 @@ void send_research_info(const struct research *presearch,
 void found_new_tech(struct research *presearch, Tech_type_id tech_found,
                     bool was_discovery, bool saving_bulbs)
 {
-  int had_embassies[player_slot_count()];
-  bool could_switch[player_slot_count()][government_count()];
+  int had_embassies[MAX_NUM_PLAYER_SLOTS];
+  bool could_switch[MAX_NUM_PLAYER_SLOTS][government_count()];
   bool was_first = false;
   bool bonus_tech_hack = false;
   int i;

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2310,15 +2310,15 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
     wipe_unit(punit, ULR_KILLED, pvictor);
   } else { // unitcount > 1
     int i;
-    int num_killed[player_slot_count()];
-    int num_escaped[player_slot_count()];
-    struct unit *other_killed[player_slot_count()];
+    int num_killed[MAX_NUM_PLAYER_SLOTS];
+    int num_escaped[MAX_NUM_PLAYER_SLOTS];
+    struct unit *other_killed[MAX_NUM_PLAYER_SLOTS];
     struct tile *ptile = unit_tile(punit);
 
     fc_assert(unitcount > 1);
 
     // initialize
-    for (i = 0; i < player_slot_count(); i++) {
+    for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
       num_killed[i] = 0;
       other_killed[i] = nullptr;
       num_escaped[i] = 0;
@@ -2415,7 +2415,7 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
      *
      * Also if a large number of units die you don't find out what type
      * they all are. */
-    for (i = 0; i < player_slot_count(); i++) {
+    for (i = 0; i < MAX_NUM_PLAYER_SLOTS; i++) {
       if (num_killed[i] == 1) {
         if (i == player_index(pvictim)) {
           fc_assert(other_killed[i] == nullptr);
@@ -2478,7 +2478,7 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
     }
 
     // Inform the owner of the units that escaped.
-    for (i = 0; i < player_slot_count(); ++i) {
+    for (i = 0; i < MAX_NUM_PLAYER_SLOTS; ++i) {
       if (0 < num_escaped[i]) {
         notify_player(player_by_number(i), unit_tile(punit), E_UNIT_ESCAPED,
                       ftc_server,


### PR DESCRIPTION
It always returns a constant, 

Inspired from https://github.com/freeciv/freeciv/commit/62fb8c8f66baf67bbd7eebcb03982ffc5c024702, why call it once when you dont have to call it at all. 