### PR TITLE
Widget Resizable now support multiple types of resize

### DIFF
--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -255,6 +255,12 @@ chat_widget::chat_widget(QWidget *parent)
 {
   QGridLayout *gl;
   setParent(parent);
+  setMinimumSize(200, 100);
+  setResizable(resizable_flag::top | resizable_flag::topLeft
+               | resizable_flag::topRight | resizable_flag::bottom
+               | resizable_flag::bottomLeft | resizable_flag::bottomRight
+               | resizable_flag::left | resizable_flag::right);
+
   gl = new QGridLayout;
   gl->setVerticalSpacing(0);
   gl->setMargin(0);
@@ -300,6 +306,7 @@ chat_widget::chat_widget(QWidget *parent)
 
   auto title = new QLabel(_("Chat"));
   title->setAlignment(Qt::AlignCenter);
+  title->setMouseTracking(true);
 
   gl->addWidget(mw, 0, 0, Qt::AlignLeft | Qt::AlignTop);
   gl->addWidget(title, 0, 1, 1, 2);

--- a/client/messagewin.cpp
+++ b/client/messagewin.cpp
@@ -36,12 +36,16 @@
 message_widget::message_widget(QWidget *parent)
 {
   setParent(parent);
+  setMinimumSize(200, 100);
   layout = new QGridLayout;
-  layout->setMargin(0);
+  layout->setMargin(2);
   setLayout(layout);
+  setResizable(resizable_flag::bottom | resizable_flag::bottomLeft
+               | resizable_flag::left);
 
   auto title = new QLabel(_("Messages"));
   title->setAlignment(Qt::AlignCenter);
+  title->setMouseTracking(true);
   layout->addWidget(title, 0, 1);
   layout->setColumnStretch(1, 100);
 

--- a/client/widgetdecorations.h
+++ b/client/widgetdecorations.h
@@ -12,6 +12,7 @@
 *************   V   ******************************************************/
 #pragma once
 
+#include <QFlags>
 #include <QFrame>
 #include <QLabel>
 #include <QRubberBand>
@@ -71,25 +72,53 @@ public:
 /**************************************************************************
   Abstract class for widgets that can be resized by dragging the edges.
 **************************************************************************/
+enum class resizable_flag : std::uint8_t {
+  none = 0,
+  top = 1,
+  topLeft = 2,
+  topRight = 4,
+  bottom = 8,
+  bottomLeft = 16,
+  bottomRight = 32,
+  left = 64,
+  right = 128
+};
+
 class resizable_widget : public fcwidget {
   Q_OBJECT
+
+  static constexpr int event_width = 25;
 
 signals:
   void resized(QRect rect);
 
+public:
+  // make widget resizable (multiple flags supported)
+  void setResizable(QFlags<resizable_flag> resizeFlags);
+
+  // get resizable flags
+  QFlags<resizable_flag> getResizable() const;
+
+  // remove resizable for widget
+  void removeResizable();
+
+  // check exist a resizable_type
+  bool hasResizable(resizable_flag flag) const;
+
 private:
-  QPoint cursor;
-  QSize last_size;
-  bool resize_mode;
-  bool resxy;
-  bool resx;
-  bool resy;
+  resizable_flag get_in_event_mouse(const QMouseEvent *event) const;
+
+  QPoint last_position{};
+  resizable_flag eventFlag{};
+  QFlags<resizable_flag> resizeFlags{};
 
 protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(QFlags<resizable_flag>)
 
 /**************************************************************************
   Widget allowing closing other widgets


### PR DESCRIPTION
Now we can support several types of "resizable" at the same time
Example:
```cpp
  setResizable(resizable_flag::top | resizable_flag::topLeft
               | resizable_flag::topRight | resizable_flag::bottom
               | resizable_flag::bottomLeft | resizable_flag::bottomRight
               | resizable_flag::left | resizable_flag::right);
```