### PR TITLE
Refactor unit map layers

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
   layer_darkness.cpp
   layer_special.cpp
   layer_terrain.cpp
+  layer_units.cpp
   layer.cpp
   luaconsole.cpp
   luaconsole_common.cpp

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -38,6 +38,7 @@
 #include "helpdlg.h"
 #include "qtg_cxxside.h"
 #include "sprite.h"
+#include "tilespec.h"
 
 #define MAX_HELP_TEXT_SIZE 8192
 #define REQ_LABEL_NEVER _("(Never)")
@@ -850,7 +851,6 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
   char buffer[MAX_HELP_TEXT_SIZE];
   int upkeep, max_upkeep;
   struct advance *tech;
-  QPixmap *canvas;
   const struct unit_type *obsolete;
   struct unit_type *utype, *max_utype;
   QString str;
@@ -866,12 +866,8 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
     max_utype = uclass_max_values(utype->uclass);
 
     // Unit icon
-    canvas = new QPixmap(tileset_full_tile_width(tileset),
-                         tileset_full_tile_height(tileset));
-    canvas->fill(Qt::transparent);
-    put_unittype(utype, canvas, 0, 0);
-    add_info_pixmap(canvas);
-    delete canvas;
+    add_info_pixmap(
+        get_unittype_sprite(tileset, utype, direction8_invalid()));
 
     add_info_progress(_("Attack:"), utype->attack_strength, 0,
                       max_utype->attack_strength);

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -23,6 +23,7 @@
 #include "nation.h"
 #include "research.h"
 #include "tile.h"
+#include "tilespec.h"
 #include "unit.h"
 #include "unitlist.h"
 // client
@@ -1697,24 +1698,22 @@ void hud_unit_combat::init_images(bool redraw)
   QImage crdimg, acrimg, at, dt;
   QRect dr, ar;
   QPainter p;
-  QPixmap *defender_pixmap;
-  QPixmap *attacker_pixmap;
   int w;
 
   focus = false;
   w = 3 * hud_scale * tileset_unit_height(tileset) / 2;
   setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
   setFixedSize(2 * w, w);
-  defender_pixmap =
-      new QPixmap(tileset_unit_width(tileset), tileset_unit_height(tileset));
-  defender_pixmap->fill(Qt::transparent);
+  QPixmap defender_pixmap(tileset_unit_width(tileset),
+                          tileset_unit_height(tileset));
   if (defender != nullptr) {
     if (!redraw) {
-      put_unit(defender, defender_pixmap, 0, 0);
+      put_unit(defender, &defender_pixmap, 0, 0);
     } else {
-      put_unittype(type_defender, defender_pixmap, 0, 0);
+      defender_pixmap =
+          *get_unittype_sprite(tileset, type_defender, direction8_invalid());
     }
-    dimg = defender_pixmap->toImage();
+    dimg = defender_pixmap.toImage();
     dr = zealous_crop_rect(dimg);
     crdimg = dimg.copy(dr);
     dimg = crdimg.scaledToHeight(w, Qt::SmoothTransformation);
@@ -1728,16 +1727,17 @@ void hud_unit_combat::init_images(bool redraw)
     dimg = dt;
   }
   dimg = dimg.scaled(w, w, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-  attacker_pixmap =
-      new QPixmap(tileset_unit_width(tileset), tileset_unit_height(tileset));
-  attacker_pixmap->fill(Qt::transparent);
+  QPixmap attacker_pixmap(tileset_unit_width(tileset),
+                          tileset_unit_height(tileset));
+  attacker_pixmap.fill(Qt::transparent);
   if (attacker != nullptr) {
     if (!redraw) {
-      put_unit(attacker, attacker_pixmap, 0, 0);
+      put_unit(attacker, &attacker_pixmap, 0, 0);
     } else {
-      put_unittype(type_attacker, attacker_pixmap, 0, 0);
+      attacker_pixmap =
+          *get_unittype_sprite(tileset, type_attacker, direction8_invalid());
     }
-    aimg = attacker_pixmap->toImage();
+    aimg = attacker_pixmap.toImage();
     ar = zealous_crop_rect(aimg);
     acrimg = aimg.copy(ar);
     aimg = acrimg.scaledToHeight(w, Qt::SmoothTransformation);
@@ -1751,8 +1751,6 @@ void hud_unit_combat::init_images(bool redraw)
     aimg = at;
   }
   aimg = aimg.scaled(w, w, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-  delete defender_pixmap;
-  delete attacker_pixmap;
 }
 
 /****************************************************************************

--- a/client/layer.cpp
+++ b/client/layer.cpp
@@ -30,10 +30,10 @@ namespace freeciv {
 std::vector<drawn_sprite>
 layer::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                          const tile_corner *pcorner, const unit *punit,
-                         const city *pcity, const unit_type *putype) const
+                         const city *pcity) const
 {
   return ::fill_sprite_array(m_ts, m_layer, ptile, pedge, pcorner, punit,
-                             pcity, putype);
+                             pcity);
 }
 
 /**

--- a/client/layer.cpp
+++ b/client/layer.cpp
@@ -29,11 +29,9 @@ namespace freeciv {
 
 std::vector<drawn_sprite>
 layer::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                         const tile_corner *pcorner, const unit *punit,
-                         const city *pcity) const
+                         const tile_corner *pcorner, const unit *punit) const
 {
-  return ::fill_sprite_array(m_ts, m_layer, ptile, pedge, pcorner, punit,
-                             pcity);
+  return ::fill_sprite_array(m_ts, m_layer, ptile, pedge, pcorner, punit);
 }
 
 /**

--- a/client/layer.h
+++ b/client/layer.h
@@ -147,7 +147,7 @@ public:
   virtual std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity, const unit_type *putype) const;
+                    const city *pcity) const;
 
   /**
    * Initializes data specific to one player. This allows to cache tiles

--- a/client/layer.h
+++ b/client/layer.h
@@ -146,8 +146,7 @@ public:
 
   virtual std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const;
+                    const tile_corner *pcorner, const unit *punit) const;
 
   /**
    * Initializes data specific to one player. This allows to cache tiles

--- a/client/layer_background.cpp
+++ b/client/layer_background.cpp
@@ -28,8 +28,10 @@ layer_background::layer_background(struct tileset *ts)
 
 std::vector<drawn_sprite> layer_background::fill_sprite_array(
     const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity) const
+    const unit *punit) const
 {
+  const auto pcity = tile_city(ptile);
+
   // Set up background color.
   player *owner = nullptr;
   if (gui_options.solid_color_behind_units) {

--- a/client/layer_background.cpp
+++ b/client/layer_background.cpp
@@ -28,7 +28,7 @@ layer_background::layer_background(struct tileset *ts)
 
 std::vector<drawn_sprite> layer_background::fill_sprite_array(
     const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+    const unit *punit, const city *pcity) const
 {
   // Set up background color.
   player *owner = nullptr;

--- a/client/layer_background.h
+++ b/client/layer_background.h
@@ -30,8 +30,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 
   void initialize_player(const player *player) override;
   void free_player(int player_id) override;

--- a/client/layer_background.h
+++ b/client/layer_background.h
@@ -29,8 +29,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 
   void initialize_player(const player *player) override;
   void free_player(int player_id) override;

--- a/client/layer_base_flags.cpp
+++ b/client/layer_base_flags.cpp
@@ -35,12 +35,11 @@ layer_base_flags::layer_base_flags(struct tileset *ts, int offset_x,
 
 std::vector<drawn_sprite> layer_base_flags::fill_sprite_array(
     const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity) const
+    const unit *punit) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
   Q_UNUSED(punit);
-  Q_UNUSED(pcity);
 
   if (ptile == nullptr) {
     return {};

--- a/client/layer_base_flags.cpp
+++ b/client/layer_base_flags.cpp
@@ -35,13 +35,12 @@ layer_base_flags::layer_base_flags(struct tileset *ts, int offset_x,
 
 std::vector<drawn_sprite> layer_base_flags::fill_sprite_array(
     const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+    const unit *punit, const city *pcity) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
   Q_UNUSED(punit);
   Q_UNUSED(pcity);
-  Q_UNUSED(putype);
 
   if (ptile == nullptr) {
     return {};

--- a/client/layer_base_flags.h
+++ b/client/layer_base_flags.h
@@ -24,8 +24,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 
 private:
   int m_offset_x, m_offset_y;

--- a/client/layer_base_flags.h
+++ b/client/layer_base_flags.h
@@ -25,8 +25,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 
 private:
   int m_offset_x, m_offset_y;

--- a/client/layer_darkness.cpp
+++ b/client/layer_darkness.cpp
@@ -31,7 +31,7 @@ layer_darkness::layer_darkness(struct tileset *ts)
 std::vector<drawn_sprite>
 layer_darkness::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                                   const tile_corner *pcorner,
-                                  const unit *punit, const city *pcity) const
+                                  const unit *punit) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
@@ -41,7 +41,7 @@ layer_darkness::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
   }
 
   // Don't draw darkness when the solid background is used
-  if (!solid_background(ptile, punit, pcity)) {
+  if (!solid_background(ptile, punit, tile_city(ptile))) {
     return {};
   }
 

--- a/client/layer_darkness.cpp
+++ b/client/layer_darkness.cpp
@@ -28,13 +28,13 @@ layer_darkness::layer_darkness(struct tileset *ts)
 {
 }
 
-std::vector<drawn_sprite> layer_darkness::fill_sprite_array(
-    const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+std::vector<drawn_sprite>
+layer_darkness::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
+                                  const tile_corner *pcorner,
+                                  const unit *punit, const city *pcity) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
-  Q_UNUSED(putype);
 
   if (!ptile) {
     return {};

--- a/client/layer_darkness.h
+++ b/client/layer_darkness.h
@@ -68,8 +68,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 
 private:
   darkness_style m_style;

--- a/client/layer_darkness.h
+++ b/client/layer_darkness.h
@@ -69,8 +69,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 
 private:
   darkness_style m_style;

--- a/client/layer_special.cpp
+++ b/client/layer_special.cpp
@@ -39,15 +39,15 @@ void layer_special::set_sprite(const extra_type *extra, const QString &tag,
   }
 }
 
-std::vector<drawn_sprite> layer_special::fill_sprite_array(
-    const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+std::vector<drawn_sprite>
+layer_special::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
+                                 const tile_corner *pcorner,
+                                 const unit *punit, const city *pcity) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
   Q_UNUSED(punit);
   Q_UNUSED(pcity);
-  Q_UNUSED(putype);
 
   if (ptile == nullptr) {
     return {};

--- a/client/layer_special.cpp
+++ b/client/layer_special.cpp
@@ -42,12 +42,11 @@ void layer_special::set_sprite(const extra_type *extra, const QString &tag,
 std::vector<drawn_sprite>
 layer_special::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                                  const tile_corner *pcorner,
-                                 const unit *punit, const city *pcity) const
+                                 const unit *punit) const
 {
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
   Q_UNUSED(punit);
-  Q_UNUSED(pcity);
 
   if (ptile == nullptr) {
     return {};

--- a/client/layer_special.h
+++ b/client/layer_special.h
@@ -32,8 +32,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 
   void reset_ruleset() override;
 

--- a/client/layer_special.h
+++ b/client/layer_special.h
@@ -33,8 +33,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 
   void reset_ruleset() override;
 

--- a/client/layer_terrain.cpp
+++ b/client/layer_terrain.cpp
@@ -689,9 +689,10 @@ void layer_terrain::initialize_blending(const terrain *terrain,
 /**
  * \implements layer::fill_sprite_array
  */
-std::vector<drawn_sprite> layer_terrain::fill_sprite_array(
-    const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+std::vector<drawn_sprite>
+layer_terrain::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
+                                 const tile_corner *pcorner,
+                                 const unit *punit, const city *pcity) const
 {
   if (ptile == nullptr) {
     return {};

--- a/client/layer_terrain.cpp
+++ b/client/layer_terrain.cpp
@@ -692,7 +692,7 @@ void layer_terrain::initialize_blending(const terrain *terrain,
 std::vector<drawn_sprite>
 layer_terrain::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                                  const tile_corner *pcorner,
-                                 const unit *punit, const city *pcity) const
+                                 const unit *punit) const
 {
   if (ptile == nullptr) {
     return {};
@@ -704,7 +704,7 @@ layer_terrain::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
   }
 
   // Don't draw terrain when the solid background is used
-  if (solid_background(ptile, punit, pcity)) {
+  if (solid_background(ptile, punit, tile_city(ptile))) {
     return {};
   }
 

--- a/client/layer_terrain.h
+++ b/client/layer_terrain.h
@@ -81,8 +81,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 
 private:
   matching_group *group(const QString &name);

--- a/client/layer_terrain.h
+++ b/client/layer_terrain.h
@@ -80,8 +80,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 
 private:
   matching_group *group(const QString &name);

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -25,27 +25,28 @@ layer_units::layer_units(struct tileset *ts, mapview_layer layer)
 {
 }
 
-std::vector<drawn_sprite> layer_units::fill_sprite_array(
-    const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
-    const unit *punit, const city *pcity, const unit_type *putype) const
+std::vector<drawn_sprite>
+layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
+                               const tile_corner *pcorner, const unit *punit,
+                               const city *pcity) const
 {
+  // We need to have something to draw
+  if (!punit) {
+    return {};
+  }
+
   std::vector<drawn_sprite> sprs;
 
   /* Unit drawing is disabled when the view options are turned off,
    * but only where we're drawing on the mapview. */
   bool do_draw_unit =
-      (punit
-       && (gui_options.draw_units || !ptile
-           || (gui_options.draw_focus_unit && unit_is_in_focus(punit))));
+      gui_options.draw_units
+      || (gui_options.draw_focus_unit && unit_is_in_focus(punit));
 
   if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
     const bool stacked = ptile && (unit_list_size(ptile->units) > 1);
     const bool backdrop = !pcity;
     fill_unit_sprite_array(tileset(), sprs, ptile, punit, stacked, backdrop);
-  } else if (putype != nullptr && type() == LAYER_UNIT) {
-    // Only the sprite for the unit type.
-    fill_unit_type_sprite_array(tileset(), sprs, putype,
-                                direction8_invalid());
   }
 
   return sprs;

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -39,7 +39,7 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
   }
 
   // Only draw the focused unit on LAYER_FOCUS_UNIT
-  if (type() != LAYER_FOCUS_UNIT && unit_is_in_focus(punit)) {
+  if ((type() == LAYER_FOCUS_UNIT) != unit_is_in_focus(punit)) {
     return {};
   }
 

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -44,9 +44,8 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
       || (gui_options.draw_focus_unit && unit_is_in_focus(punit));
 
   if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
-    const bool stacked = ptile && (unit_list_size(ptile->units) > 1);
     const bool backdrop = !pcity;
-    fill_unit_sprite_array(tileset(), sprs, ptile, punit, stacked, backdrop);
+    fill_unit_sprite_array(tileset(), sprs, ptile, punit, backdrop);
   }
 
   return sprs;

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -30,6 +30,9 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                                const tile_corner *pcorner,
                                const unit *punit) const
 {
+  Q_UNUSED(pedge);
+  Q_UNUSED(pcorner);
+
   // We need to have something to draw
   if (!punit) {
     return {};

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "layer_units.h"
+
+#include "control.h"
+#include "options.h"
+#include "tilespec.h"
+
+/**
+ * \class freeciv::layer_units
+ * \brief Draws units on the map.
+ */
+
+namespace freeciv {
+
+/**
+ * Constructor
+ */
+layer_units::layer_units(struct tileset *ts, mapview_layer layer)
+    : freeciv::layer(ts, layer)
+{
+}
+
+std::vector<drawn_sprite> layer_units::fill_sprite_array(
+    const tile *ptile, const tile_edge *pedge, const tile_corner *pcorner,
+    const unit *punit, const city *pcity, const unit_type *putype) const
+{
+  std::vector<drawn_sprite> sprs;
+
+  /* Unit drawing is disabled when the view options are turned off,
+   * but only where we're drawing on the mapview. */
+  bool do_draw_unit =
+      (punit
+       && (gui_options.draw_units || !ptile
+           || (gui_options.draw_focus_unit && unit_is_in_focus(punit))));
+
+  if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
+    const bool stacked = ptile && (unit_list_size(ptile->units) > 1);
+    const bool backdrop = !pcity;
+    fill_unit_sprite_array(tileset(), sprs, ptile, punit, stacked, backdrop);
+  } else if (putype != nullptr && type() == LAYER_UNIT) {
+    // Only the sprite for the unit type.
+    fill_unit_type_sprite_array(tileset(), sprs, putype,
+                                direction8_invalid());
+  }
+
+  return sprs;
+}
+
+} // namespace freeciv

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -33,23 +33,18 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
   Q_UNUSED(pedge);
   Q_UNUSED(pcorner);
 
-  // We need to have something to draw
-  if (!punit) {
+  // Should we draw anything in the first place?
+  if (!do_draw_unit(ptile, punit)) {
+    return {};
+  }
+
+  // Only draw the focused unit on LAYER_FOCUS_UNIT
+  if (type() != LAYER_FOCUS_UNIT && unit_is_in_focus(punit)) {
     return {};
   }
 
   std::vector<drawn_sprite> sprs;
-
-  /* Unit drawing is disabled when the view options are turned off,
-   * but only where we're drawing on the mapview. */
-  bool do_draw_unit =
-      gui_options.draw_units
-      || (gui_options.draw_focus_unit && unit_is_in_focus(punit));
-
-  if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
-    fill_unit_sprite_array(tileset(), sprs, ptile, punit);
-  }
-
+  fill_unit_sprite_array(tileset(), sprs, ptile, punit);
   return sprs;
 }
 

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -44,8 +44,7 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
       || (gui_options.draw_focus_unit && unit_is_in_focus(punit));
 
   if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
-    const bool backdrop = !tile_city(ptile);
-    fill_unit_sprite_array(tileset(), sprs, ptile, punit, backdrop);
+    fill_unit_sprite_array(tileset(), sprs, ptile, punit);
   }
 
   return sprs;

--- a/client/layer_units.cpp
+++ b/client/layer_units.cpp
@@ -27,8 +27,8 @@ layer_units::layer_units(struct tileset *ts, mapview_layer layer)
 
 std::vector<drawn_sprite>
 layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                               const tile_corner *pcorner, const unit *punit,
-                               const city *pcity) const
+                               const tile_corner *pcorner,
+                               const unit *punit) const
 {
   // We need to have something to draw
   if (!punit) {
@@ -44,7 +44,7 @@ layer_units::fill_sprite_array(const tile *ptile, const tile_edge *pedge,
       || (gui_options.draw_focus_unit && unit_is_in_focus(punit));
 
   if (do_draw_unit && XOR(type() == LAYER_UNIT, unit_is_in_focus(punit))) {
-    const bool backdrop = !pcity;
+    const bool backdrop = !tile_city(ptile);
     fill_unit_sprite_array(tileset(), sprs, ptile, punit, backdrop);
   }
 

--- a/client/layer_units.h
+++ b/client/layer_units.h
@@ -18,8 +18,7 @@ public:
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
                     const tile_corner *pcorner, const unit *punit,
-                    const city *pcity,
-                    const unit_type *putype) const override;
+                    const city *pcity) const override;
 };
 
 } // namespace freeciv

--- a/client/layer_units.h
+++ b/client/layer_units.h
@@ -17,8 +17,8 @@ public:
 
   std::vector<drawn_sprite>
   fill_sprite_array(const tile *ptile, const tile_edge *pedge,
-                    const tile_corner *pcorner, const unit *punit,
-                    const city *pcity) const override;
+                    const tile_corner *pcorner,
+                    const unit *punit) const override;
 };
 
 } // namespace freeciv

--- a/client/layer_units.h
+++ b/client/layer_units.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include "layer.h"
+
+namespace freeciv {
+
+class layer_units : public layer {
+public:
+  explicit layer_units(struct tileset *ts, mapview_layer layer);
+  virtual ~layer_units() = default;
+
+  std::vector<drawn_sprite>
+  fill_sprite_array(const tile *ptile, const tile_edge *pedge,
+                    const tile_corner *pcorner, const unit *punit,
+                    const city *pcity,
+                    const unit_type *putype) const override;
+};
+
+} // namespace freeciv

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -984,14 +984,12 @@ void put_one_element(QPixmap *pcanvas,
                      const std::unique_ptr<freeciv::layer> &layer,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
-                     const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y)
+                     const struct unit *punit, int canvas_x, int canvas_y)
 {
   bool city_mode = false;
   bool city_unit = false;
   int dummy_x, dummy_y;
-  auto sprites =
-      layer->fill_sprite_array(ptile, pedge, pcorner, punit, pcity);
+  auto sprites = layer->fill_sprite_array(ptile, pedge, pcorner, punit);
   bool fog = (ptile && gui_options.draw_fog_of_war
               && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile));
   if (ptile) {
@@ -1025,7 +1023,7 @@ void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
   canvas_y += (tileset_unit_height(tileset) - tileset_tile_height(tileset));
   for (const auto &layer : tileset_get_layers(tileset)) {
     put_one_element(pcanvas, layer, nullptr, nullptr, nullptr, punit,
-                    nullptr, canvas_x, canvas_y);
+                    canvas_x, canvas_y);
   }
 }
 
@@ -1043,7 +1041,7 @@ void put_terrain(struct tile *ptile, QPixmap *pcanvas, int canvas_x,
       (tileset_full_tile_height(tileset) - tileset_tile_height(tileset));
   for (const auto &layer : tileset_get_layers(tileset)) {
     put_one_element(pcanvas, layer, ptile, nullptr, nullptr, nullptr,
-                    nullptr, canvas_x, canvas_y);
+                    canvas_x, canvas_y);
   }
 }
 
@@ -1171,8 +1169,8 @@ static void put_one_tile(QPixmap *pcanvas,
       || (editor_is_active() && editor_tile_is_selected(ptile))) {
     struct unit *punit = get_drawable_unit(tileset, ptile);
 
-    put_one_element(pcanvas, layer, ptile, nullptr, nullptr, punit,
-                    tile_city(ptile), canvas_x, canvas_y);
+    put_one_element(pcanvas, layer, ptile, nullptr, nullptr, punit, canvas_x,
+                    canvas_y);
   }
 }
 
@@ -1376,10 +1374,10 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
         put_one_tile(mapview.store, layer, ptile, cx, cy);
       } else if (pedge) {
         put_one_element(mapview.store, layer, nullptr, pedge, nullptr,
-                        nullptr, nullptr, cx, cy);
+                        nullptr, cx, cy);
       } else if (pcorner) {
         put_one_element(mapview.store, layer, nullptr, nullptr, pcorner,
-                        nullptr, nullptr, cx, cy);
+                        nullptr, cx, cy);
       } else {
         // This can happen, for instance for unreal tiles.
       }

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -985,14 +985,13 @@ void put_one_element(QPixmap *pcanvas,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
                      const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y,
-                     const struct unit_type *putype)
+                     int canvas_x, int canvas_y)
 {
   bool city_mode = false;
   bool city_unit = false;
   int dummy_x, dummy_y;
   auto sprites =
-      layer->fill_sprite_array(ptile, pedge, pcorner, punit, pcity, putype);
+      layer->fill_sprite_array(ptile, pedge, pcorner, punit, pcity);
   bool fog = (ptile && gui_options.draw_fog_of_war
               && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile));
   if (ptile) {
@@ -1026,7 +1025,7 @@ void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
   canvas_y += (tileset_unit_height(tileset) - tileset_tile_height(tileset));
   for (const auto &layer : tileset_get_layers(tileset)) {
     put_one_element(pcanvas, layer, nullptr, nullptr, nullptr, punit,
-                    nullptr, canvas_x, canvas_y, nullptr);
+                    nullptr, canvas_x, canvas_y);
   }
 }
 
@@ -1042,7 +1041,7 @@ void put_city(struct city *pcity, QPixmap *pcanvas, int canvas_x,
       (tileset_full_tile_height(tileset) - tileset_tile_height(tileset));
   for (const auto &layer : tileset_get_layers(tileset)) {
     put_one_element(pcanvas, layer, nullptr, nullptr, nullptr, nullptr,
-                    pcity, canvas_x, canvas_y, nullptr);
+                    pcity, canvas_x, canvas_y);
   }
 }
 
@@ -1060,7 +1059,7 @@ void put_terrain(struct tile *ptile, QPixmap *pcanvas, int canvas_x,
       (tileset_full_tile_height(tileset) - tileset_tile_height(tileset));
   for (const auto &layer : tileset_get_layers(tileset)) {
     put_one_element(pcanvas, layer, ptile, nullptr, nullptr, nullptr,
-                    nullptr, canvas_x, canvas_y, nullptr);
+                    nullptr, canvas_x, canvas_y);
   }
 }
 
@@ -1189,7 +1188,7 @@ static void put_one_tile(QPixmap *pcanvas,
     struct unit *punit = get_drawable_unit(tileset, ptile);
 
     put_one_element(pcanvas, layer, ptile, nullptr, nullptr, punit,
-                    tile_city(ptile), canvas_x, canvas_y, nullptr);
+                    tile_city(ptile), canvas_x, canvas_y);
   }
 }
 
@@ -1393,10 +1392,10 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
         put_one_tile(mapview.store, layer, ptile, cx, cy);
       } else if (pedge) {
         put_one_element(mapview.store, layer, nullptr, pedge, nullptr,
-                        nullptr, nullptr, cx, cy, nullptr);
+                        nullptr, nullptr, cx, cy);
       } else if (pcorner) {
         put_one_element(mapview.store, layer, nullptr, nullptr, pcorner,
-                        nullptr, nullptr, cx, cy, nullptr);
+                        nullptr, nullptr, cx, cy);
       } else {
         // This can happen, for instance for unreal tiles.
       }

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1030,22 +1030,6 @@ void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
 }
 
 /**
-   Draw the given city onto the canvas store at the given location.  The
-   area of drawing is
-   tileset_full_tile_height(tileset) x tileset_full_tile_width(tileset).
- */
-void put_city(struct city *pcity, QPixmap *pcanvas, int canvas_x,
-              int canvas_y)
-{
-  canvas_y +=
-      (tileset_full_tile_height(tileset) - tileset_tile_height(tileset));
-  for (const auto &layer : tileset_get_layers(tileset)) {
-    put_one_element(pcanvas, layer, nullptr, nullptr, nullptr, nullptr,
-                    pcity, canvas_x, canvas_y);
-  }
-}
-
-/**
    Draw the given tile terrain onto the canvas store at the given location.
    The area of drawing is
    tileset_full_tile_height(tileset) x tileset_full_tile_width(tileset)

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1031,20 +1031,6 @@ void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
 }
 
 /**
-   Draw the given unit onto the canvas store at the given location. The area
-   of drawing is tileset_unit_height(tileset) x tileset_unit_width(tileset).
- */
-void put_unittype(const struct unit_type *putype, QPixmap *pcanvas,
-                  int canvas_x, int canvas_y)
-{
-  canvas_y += (tileset_unit_height(tileset) - tileset_tile_height(tileset));
-  for (const auto &layer : tileset_get_layers(tileset)) {
-    put_one_element(pcanvas, layer, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, canvas_x, canvas_y, putype);
-  }
-}
-
-/**
    Draw the given city onto the canvas store at the given location.  The
    area of drawing is
    tileset_full_tile_height(tileset) x tileset_full_tile_width(tileset).

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -256,8 +256,6 @@ bool tile_visible_and_not_on_border_mapcanvas(struct tile *ptile);
 
 void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
               int canvas_y);
-void put_unittype(const struct unit_type *putype, QPixmap *pcanvas,
-                  int canvas_x, int canvas_y);
 void put_city(struct city *pcity, QPixmap *pcanvas, int canvas_x,
               int canvas_y);
 void put_terrain(struct tile *ptile, QPixmap *pcanvas, int canvas_x,

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -273,8 +273,7 @@ void put_one_element(QPixmap *pcanvas, enum mapview_layer layer,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
                      const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y,
-                     const struct unit_type *putype);
+                     int canvas_x, int canvas_y);
 
 void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
                        const std::vector<drawn_sprite> &sprites, bool fog,

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -256,8 +256,6 @@ bool tile_visible_and_not_on_border_mapcanvas(struct tile *ptile);
 
 void put_unit(const struct unit *punit, QPixmap *pcanvas, int canvas_x,
               int canvas_y);
-void put_city(struct city *pcity, QPixmap *pcanvas, int canvas_x,
-              int canvas_y);
 void put_terrain(struct tile *ptile, QPixmap *pcanvas, int canvas_x,
                  int canvas_y);
 

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -270,8 +270,7 @@ void put_nuke_mushroom_pixmaps(struct tile *ptile);
 void put_one_element(QPixmap *pcanvas, enum mapview_layer layer,
                      const struct tile *ptile, const struct tile_edge *pedge,
                      const struct tile_corner *pcorner,
-                     const struct unit *punit, const struct city *pcity,
-                     int canvas_x, int canvas_y);
+                     const struct unit *punit, int canvas_x, int canvas_y);
 
 void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
                        const std::vector<drawn_sprite> &sprites, bool fog,

--- a/client/tileset_debugger.cpp
+++ b/client/tileset_debugger.cpp
@@ -138,8 +138,7 @@ void tileset_debugger::set_tile(const ::tile *t)
         || (editor_is_active() && editor_tile_is_selected(t))) {
       unit = get_drawable_unit(tileset, t);
     }
-    const auto sprites =
-        layer->fill_sprite_array(t, nullptr, nullptr, unit, tile_city(t));
+    const auto sprites = layer->fill_sprite_array(t, nullptr, nullptr, unit);
 
     if (sprites.empty()) {
       continue;

--- a/client/tileset_debugger.cpp
+++ b/client/tileset_debugger.cpp
@@ -138,8 +138,8 @@ void tileset_debugger::set_tile(const ::tile *t)
         || (editor_is_active() && editor_tile_is_selected(t))) {
       unit = get_drawable_unit(tileset, t);
     }
-    const auto sprites = layer->fill_sprite_array(t, nullptr, nullptr, unit,
-                                                  tile_city(t), nullptr);
+    const auto sprites =
+        layer->fill_sprite_array(t, nullptr, nullptr, unit, tile_city(t));
 
     if (sprites.empty()) {
       continue;

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3645,8 +3645,7 @@ void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
  */
 void fill_unit_sprite_array(const struct tileset *t,
                             std::vector<drawn_sprite> &sprs,
-                            const tile *ptile, const struct unit *punit,
-                            bool backdrop)
+                            const tile *ptile, const struct unit *punit)
 {
   const struct unit_type *ptype = unit_type_get(punit);
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3646,9 +3646,8 @@ void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
 void fill_unit_sprite_array(const struct tileset *t,
                             std::vector<drawn_sprite> &sprs,
                             const tile *ptile, const struct unit *punit,
-                            bool stack, bool backdrop)
+                            bool backdrop)
 {
-  int ihp;
   const struct unit_type *ptype = unit_type_get(punit);
 
   if (ptile && unit_is_in_focus(punit) && !t->sprites.unit.select.empty()) {
@@ -3807,7 +3806,8 @@ void fill_unit_sprite_array(const struct tileset *t,
     ADD_SPRITE_FULL(t->sprites.unit.tired);
   }
 
-  if (stack || punit->client.occupied) {
+  if ((ptile && unit_list_size(ptile->units) > 1)
+      || punit->client.occupied) {
     ADD_SPRITE_FULL(t->sprites.unit.stack);
   }
 
@@ -3815,7 +3815,7 @@ void fill_unit_sprite_array(const struct tileset *t,
     ADD_SPRITE_FULL(t->sprites.unit.vet_lev[punit->veteran]);
   }
 
-  ihp = ((t->sprites.unit.hp_bar.size() - 1) * punit->hp) / ptype->hp;
+  auto ihp = ((t->sprites.unit.hp_bar.size() - 1) * punit->hp) / ptype->hp;
   ihp = CLIP(0, ihp, t->sprites.unit.hp_bar.size() - 1); // Safety
   ADD_SPRITE_FULL(t->sprites.unit.hp_bar[ihp]);
 }

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3657,7 +3657,8 @@ void fill_unit_sprite_array(const struct tileset *t,
                       t->select_offset_x, t->select_offset_y);
   }
 
-  if (backdrop) {
+  // Flag
+  if (!ptile || !tile_city(ptile)) {
     if (!gui_options.solid_color_behind_units) {
       sprs.emplace_back(t, get_unit_nation_flag_sprite(t, punit), true,
                         FULL_TILE_X_OFFSET + t->unit_flag_offset_x,

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -4579,13 +4579,16 @@ std::vector<drawn_sprite>
 fill_sprite_array(struct tileset *t, enum mapview_layer layer,
                   const struct tile *ptile, const struct tile_edge *pedge,
                   const struct tile_corner *pcorner,
-                  const struct unit *punit, const struct city *pcity)
+                  const struct unit *punit)
 {
   int tileno, dir;
   bv_extras textras_near[8]{};
   bv_extras textras;
   struct terrain *tterrain_near[8] = {nullptr};
   struct terrain *pterrain = nullptr;
+
+  const auto pcity = tile_city(ptile);
+
   /* Unit drawing is disabled when the view options are turned off,
    * but only where we're drawing on the mapview. */
   bool do_draw_unit =
@@ -5594,7 +5597,7 @@ fill_basic_terrain_layer_sprite_array(struct tileset *t, int layer,
   auto sprs = std::vector<drawn_sprite>();
   for (const auto &layer : t->layers) {
     const auto lsprs =
-        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr, nullptr);
+        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr);
     // Merge by hand because drawn_sprite isn't copyable (but it is
     // copy-constructible)
     for (const auto &sprite : lsprs) {
@@ -5622,7 +5625,7 @@ fill_basic_extra_sprite_array(const struct tileset *t,
   auto sprs = std::vector<drawn_sprite>();
   for (const auto &layer : t->layers) {
     const auto lsprs =
-        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr, nullptr);
+        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr);
     // Merge by hand because drawn_sprite isn't copyable (but it is
     // copy-constructible)
     for (const auto &sprite : lsprs) {

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3641,20 +3641,6 @@ void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
 }
 
 /**
-   Fill in the sprite array for the unit type.
- */
-void fill_unit_type_sprite_array(const struct tileset *t,
-                                 std::vector<drawn_sprite> &sprs,
-                                 const struct unit_type *putype,
-                                 enum direction8 facing)
-{
-  auto uspr = get_unittype_sprite(t, putype, facing);
-
-  sprs.emplace_back(t, uspr, true, FULL_TILE_X_OFFSET + t->unit_offset_x,
-                    FULL_TILE_Y_OFFSET + t->unit_offset_y);
-}
-
-/**
    Fill in the sprite array for the unit.
  */
 void fill_unit_sprite_array(const struct tileset *t,
@@ -3683,7 +3669,9 @@ void fill_unit_sprite_array(const struct tileset *t,
   }
 
   // Add the sprite for the unit type.
-  fill_unit_type_sprite_array(t, sprs, ptype, punit->facing);
+  const auto uspr = get_unittype_sprite(t, ptype, punit->facing);
+  sprs.emplace_back(t, uspr, true, FULL_TILE_X_OFFSET + t->unit_offset_x,
+                    FULL_TILE_Y_OFFSET + t->unit_offset_y);
 
   if (t->sprites.unit.loaded && unit_transported(punit)) {
     ADD_SPRITE_FULL(t->sprites.unit.loaded);
@@ -4590,8 +4578,7 @@ std::vector<drawn_sprite>
 fill_sprite_array(struct tileset *t, enum mapview_layer layer,
                   const struct tile *ptile, const struct tile_edge *pedge,
                   const struct tile_corner *pcorner,
-                  const struct unit *punit, const struct city *pcity,
-                  const struct unit_type *putype)
+                  const struct unit *punit, const struct city *pcity)
 {
   int tileno, dir;
   bv_extras textras_near[8]{};
@@ -5605,8 +5592,8 @@ fill_basic_terrain_layer_sprite_array(struct tileset *t, int layer,
 
   auto sprs = std::vector<drawn_sprite>();
   for (const auto &layer : t->layers) {
-    const auto lsprs = layer->fill_sprite_array(tile, nullptr, nullptr,
-                                                nullptr, nullptr, nullptr);
+    const auto lsprs =
+        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr, nullptr);
     // Merge by hand because drawn_sprite isn't copyable (but it is
     // copy-constructible)
     for (const auto &sprite : lsprs) {
@@ -5633,8 +5620,8 @@ fill_basic_extra_sprite_array(const struct tileset *t,
 
   auto sprs = std::vector<drawn_sprite>();
   for (const auto &layer : t->layers) {
-    const auto lsprs = layer->fill_sprite_array(tile, nullptr, nullptr,
-                                                nullptr, nullptr, nullptr);
+    const auto lsprs =
+        layer->fill_sprite_array(tile, nullptr, nullptr, nullptr, nullptr);
     // Merge by hand because drawn_sprite isn't copyable (but it is
     // copy-constructible)
     for (const auto &sprite : lsprs) {

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -264,8 +264,7 @@ fill_basic_extra_sprite_array(const struct tileset *t,
                               const struct extra_type *pextra);
 void fill_unit_sprite_array(const struct tileset *t,
                             std::vector<drawn_sprite> &sprs,
-                            const tile *ptile, const struct unit *punit,
-                            bool backdrop);
+                            const tile *ptile, const struct unit *punit);
 
 bool is_extra_drawing_enabled(struct extra_type *pextra);
 const QPixmap *get_event_sprite(const struct tileset *t,

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -150,8 +150,7 @@ std::vector<drawn_sprite>
 fill_sprite_array(struct tileset *t, enum mapview_layer layer,
                   const struct tile *ptile, const struct tile_edge *pedge,
                   const struct tile_corner *pcorner,
-                  const struct unit *punit, const struct city *pcity,
-                  const struct unit_type *putype);
+                  const struct unit *punit, const struct city *pcity);
 std::vector<drawn_sprite>
 fill_basic_terrain_layer_sprite_array(struct tileset *t, int layer,
                                       struct terrain *pterrain);
@@ -263,10 +262,6 @@ const QPixmap *get_basic_fog_sprite(const struct tileset *t);
 std::vector<drawn_sprite>
 fill_basic_extra_sprite_array(const struct tileset *t,
                               const struct extra_type *pextra);
-void fill_unit_type_sprite_array(const struct tileset *t,
-                                 std::vector<drawn_sprite> &sprs,
-                                 const struct unit_type *putype,
-                                 enum direction8 facing);
 void fill_unit_sprite_array(const struct tileset *t,
                             std::vector<drawn_sprite> &sprs,
                             const tile *ptile, const struct unit *punit,

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -263,6 +263,15 @@ const QPixmap *get_basic_fog_sprite(const struct tileset *t);
 std::vector<drawn_sprite>
 fill_basic_extra_sprite_array(const struct tileset *t,
                               const struct extra_type *pextra);
+void fill_unit_type_sprite_array(const struct tileset *t,
+                                 std::vector<drawn_sprite> &sprs,
+                                 const struct unit_type *putype,
+                                 enum direction8 facing);
+void fill_unit_sprite_array(const struct tileset *t,
+                            std::vector<drawn_sprite> &sprs,
+                            const tile *ptile, const struct unit *punit,
+                            bool stack, bool backdrop);
+
 bool is_extra_drawing_enabled(struct extra_type *pextra);
 const QPixmap *get_event_sprite(const struct tileset *t,
                                 enum event_type event);

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -150,7 +150,7 @@ std::vector<drawn_sprite>
 fill_sprite_array(struct tileset *t, enum mapview_layer layer,
                   const struct tile *ptile, const struct tile_edge *pedge,
                   const struct tile_corner *pcorner,
-                  const struct unit *punit, const struct city *pcity);
+                  const struct unit *punit);
 std::vector<drawn_sprite>
 fill_basic_terrain_layer_sprite_array(struct tileset *t, int layer,
                                       struct terrain *pterrain);

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -265,7 +265,7 @@ fill_basic_extra_sprite_array(const struct tileset *t,
 void fill_unit_sprite_array(const struct tileset *t,
                             std::vector<drawn_sprite> &sprs,
                             const tile *ptile, const struct unit *punit,
-                            bool stack, bool backdrop);
+                            bool backdrop);
 
 bool is_extra_drawing_enabled(struct extra_type *pextra);
 const QPixmap *get_event_sprite(const struct tileset *t,

--- a/common/tile.cpp
+++ b/common/tile.cpp
@@ -74,6 +74,10 @@ void tile_set_owner(struct tile *ptile, struct player *pplayer,
  */
 struct city *tile_city(const struct tile *ptile)
 {
+  if (!ptile) {
+    return nullptr;
+  }
+
   struct city *pcity = ptile->worked;
 
   if (nullptr != pcity && is_city_center(pcity, ptile)) {


### PR DESCRIPTION
This PR refactors the code that draws units on the map and some code around it. I wanted to implement #429 but figured that some refactoring was needed first. This PR introduces no behavior change.

**Things to check**
* Are units still drawn where they should?
* Do options like drawing only the focused unit still work as intended?
* Does it crash?