### PR TITLE
Add tilespec support for more colorful units

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(
   climap.cpp
   climisc.cpp
   clinet.cpp
+  colorizer.cpp
   colors.cpp
   colors_common.cpp
   connectdlg.cpp

--- a/client/colorizer.cpp
+++ b/client/colorizer.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "colorizer.h"
+
+#include <QBrush>
+#include <QPainter>
+
+namespace freeciv {
+
+/**
+ * @class colorizer Swaps colors in QPixmap
+ *
+ * Starting from a base pixmap, this class generates new pixmaps with one
+ * color replaced (for instance, all pink pixels changed to green).
+ */
+
+/**
+ * Creates a colorizer that will replace every pixel of the given hue.
+ * Passing a negative hue disables colorization.
+ */
+colorizer::colorizer(const QPixmap &base, int hue_to_replace,
+                     QObject *parent)
+    : QObject(parent), m_base(base), m_base_image(base.toImage()),
+      m_hue_to_replace(hue_to_replace)
+{
+}
+
+/**
+ * Returns a pixmap with some pixels changed to the target color. The pixmap
+ * is cached for later use.
+ */
+const QPixmap *colorizer::pixmap(const QColor &color) const
+{
+  // Easy cases with nothing to do
+  if (m_hue_to_replace < 0 || !color.isValid()) {
+    return &m_base;
+  }
+
+  // Draw it if we don't have it yet
+  if (m_cache.count(color.rgba()) == 0) {
+    auto new_hue = color.hslHue();
+    auto image = m_base_image.copy();
+
+    // Iterate through pixels and replace the hue
+    for (int x = 0; x < image.width(); ++x) {
+      for (int y = 0; y < image.height(); ++y) {
+        auto pixel = image.pixelColor(x, y);
+        if (pixel.hslHue() == m_hue_to_replace) {
+          image.setPixelColor(x, y,
+                              QColor::fromHsl(new_hue, pixel.hslSaturation(),
+                                              pixel.lightness()));
+        }
+      }
+    }
+
+    m_cache[color.rgba()] = QPixmap::fromImage(image);
+  }
+
+  return &m_cache[color.rgba()];
+}
+
+} // namespace freeciv

--- a/client/colorizer.h
+++ b/client/colorizer.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include <QBitmap>
+#include <QColor>
+#include <QPixmap>
+
+#include <map>
+
+namespace freeciv {
+
+class colorizer : public QObject {
+  Q_OBJECT
+
+public:
+  explicit colorizer(const QPixmap &base, int hue_to_replace,
+                     QObject *parent = nullptr);
+  virtual ~colorizer() = default;
+
+  /// Returns the base pixmap used by this colorizer
+  QPixmap base() const { return m_base; }
+
+  const QPixmap *pixmap(const QColor &color) const;
+
+private:
+  QPixmap m_base;
+  QImage m_base_image;
+  int m_hue_to_replace;
+  mutable std::map<QRgb, QPixmap> m_cache;
+};
+
+} // namespace freeciv

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3641,6 +3641,72 @@ void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
 }
 
 /**
+ * Returns the sprite used to represent a given activity on the map.
+ */
+const QPixmap *get_activity_sprite(const struct tileset *t,
+                                   enum unit_activity activity,
+                                   extra_type *target)
+{
+  switch (activity) {
+  case ACTIVITY_MINE:
+    if (target == nullptr) {
+      return t->sprites.unit.plant;
+    } else {
+      return t->sprites.extras[extra_index(target)].activity;
+    }
+    break;
+  case ACTIVITY_PLANT:
+    return t->sprites.unit.plant;
+    break;
+  case ACTIVITY_IRRIGATE:
+    if (target == nullptr) {
+      return t->sprites.unit.irrigate;
+    } else {
+      return t->sprites.extras[extra_index(target)].activity;
+    }
+    break;
+  case ACTIVITY_CULTIVATE:
+    return t->sprites.unit.irrigate;
+    break;
+  case ACTIVITY_POLLUTION:
+  case ACTIVITY_FALLOUT:
+    return t->sprites.extras[extra_index(target)].rmact;
+    break;
+  case ACTIVITY_PILLAGE:
+    return t->sprites.unit.pillage;
+    break;
+  case ACTIVITY_EXPLORE:
+    // Drawn below as the server side agent.
+    break;
+  case ACTIVITY_FORTIFIED:
+    return t->sprites.unit.fortified;
+    break;
+  case ACTIVITY_FORTIFYING:
+    return t->sprites.unit.fortifying;
+    break;
+  case ACTIVITY_SENTRY:
+    return t->sprites.unit.sentry;
+    break;
+  case ACTIVITY_GOTO:
+    return t->sprites.unit.go_to;
+    break;
+  case ACTIVITY_TRANSFORM:
+    return t->sprites.unit.transform;
+    break;
+  case ACTIVITY_BASE:
+  case ACTIVITY_GEN_ROAD:
+    return t->sprites.extras[extra_index(target)].activity;
+    break;
+  case ACTIVITY_CONVERT:
+    return t->sprites.unit.convert;
+    break;
+  default:
+    break;
+  }
+  return nullptr;
+}
+
+/**
    Fill in the sprite array for the unit.
  */
 void fill_unit_sprite_array(const struct tileset *t,
@@ -3676,71 +3742,12 @@ void fill_unit_sprite_array(const struct tileset *t,
     ADD_SPRITE_FULL(t->sprites.unit.loaded);
   }
 
-  if (punit->activity != ACTIVITY_IDLE) {
-    QPixmap *s = nullptr;
-
-    switch (punit->activity) {
-    case ACTIVITY_MINE:
-      if (punit->activity_target == nullptr) {
-        s = t->sprites.unit.plant;
-      } else {
-        s = t->sprites.extras[extra_index(punit->activity_target)].activity;
-      }
-      break;
-    case ACTIVITY_PLANT:
-      s = t->sprites.unit.plant;
-      break;
-    case ACTIVITY_IRRIGATE:
-      if (punit->activity_target == nullptr) {
-        s = t->sprites.unit.irrigate;
-      } else {
-        s = t->sprites.extras[extra_index(punit->activity_target)].activity;
-      }
-      break;
-    case ACTIVITY_CULTIVATE:
-      s = t->sprites.unit.irrigate;
-      break;
-    case ACTIVITY_POLLUTION:
-    case ACTIVITY_FALLOUT:
-      s = t->sprites.extras[extra_index(punit->activity_target)].rmact;
-      break;
-    case ACTIVITY_PILLAGE:
-      s = t->sprites.unit.pillage;
-      break;
-    case ACTIVITY_EXPLORE:
-      // Drawn below as the server side agent.
-      break;
-    case ACTIVITY_FORTIFIED:
-      s = t->sprites.unit.fortified;
-      break;
-    case ACTIVITY_FORTIFYING:
-      s = t->sprites.unit.fortifying;
-      break;
-    case ACTIVITY_SENTRY:
-      s = t->sprites.unit.sentry;
-      break;
-    case ACTIVITY_GOTO:
-      s = t->sprites.unit.go_to;
-      break;
-    case ACTIVITY_TRANSFORM:
-      s = t->sprites.unit.transform;
-      break;
-    case ACTIVITY_BASE:
-    case ACTIVITY_GEN_ROAD:
-      s = t->sprites.extras[extra_index(punit->activity_target)].activity;
-      break;
-    case ACTIVITY_CONVERT:
-      s = t->sprites.unit.convert;
-      break;
-    default:
-      break;
-    }
-
-    if (s != nullptr) {
-      sprs.emplace_back(t, s, true,
-                        FULL_TILE_X_OFFSET + t->activity_offset_x,
-                        FULL_TILE_Y_OFFSET + t->activity_offset_y);
-    }
+  // Activity sprite
+  if (auto sprite =
+          get_activity_sprite(t, punit->activity, punit->activity_target)) {
+    sprs.emplace_back(t, sprite, true,
+                      FULL_TILE_X_OFFSET + t->activity_offset_x,
+                      FULL_TILE_Y_OFFSET + t->activity_offset_y);
   }
 
   {

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -20,6 +20,8 @@
 #include "layer.h"
 #include "options.h"
 
+#include <QColor>
+
 struct base_type;
 struct help_item;
 struct resource_type;
@@ -236,7 +238,8 @@ const QPixmap *get_government_sprite(const struct tileset *t,
                                      const struct government *gov);
 const QPixmap *get_unittype_sprite(const struct tileset *t,
                                    const struct unit_type *punittype,
-                                   enum direction8 facing);
+                                   enum direction8 facing,
+                                   const QColor &replace = QColor());
 const QPixmap *get_sample_city_sprite(const struct tileset *t,
                                       int style_idx);
 const QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype);

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -222,6 +222,9 @@ const QPixmap *get_city_flag_sprite(const struct tileset *t,
 void build_tile_data(const struct tile *ptile, struct terrain *pterrain,
                      struct terrain **tterrain_near,
                      bv_extras *textras_near);
+const QPixmap *get_activity_sprite(const struct tileset *t,
+                                   enum unit_activity activity,
+                                   extra_type *target);
 const QPixmap *get_nation_flag_sprite(const struct tileset *t,
                                       const struct nation_type *nation);
 const QPixmap *get_nation_shield_sprite(const struct tileset *t,

--- a/data/alio.tilespec
+++ b/data/alio.tilespec
@@ -58,6 +58,10 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 74
 activity_offset_y = 28

--- a/data/amplio.tilespec
+++ b/data/amplio.tilespec
@@ -49,6 +49,10 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -49,6 +49,10 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 49
 activity_offset_y = 0

--- a/data/cimpletoon.tilespec
+++ b/data/cimpletoon.tilespec
@@ -52,6 +52,10 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -52,6 +52,10 @@ occupied_offset_y = 0
 unit_offset_x = 4
 unit_offset_y = 21
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -54,6 +54,10 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 74
 activity_offset_y = 28

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -52,6 +52,10 @@ occupied_offset_y = 0
 unit_offset_x = 21
 unit_offset_y = 13
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -51,6 +51,10 @@ occupied_offset_y = 0
 unit_offset_x = 21
 unit_offset_y = 13
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0

--- a/data/toonhex.tilespec
+++ b/data/toonhex.tilespec
@@ -56,6 +56,10 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 74
 activity_offset_y = 28

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -50,6 +50,10 @@ occupied_offset_y = 0
 unit_offset_x = 0
 unit_offset_y = 0
 
+; colors with this (HSL) hue will be replaced by the player color in unit
+; sprites (-1 to disable)
+replaced_hue = -1
+
 ; offset of the normal activity icons
 activity_offset_x = 0
 activity_offset_y = 0


### PR DESCRIPTION
Implements #429 for units. No tileset supports it yet (I have WIP changes for amplio2 but it will take more time and a different kind of review).

Will rebase once we get #1083 

**Testing it**
* Open `units.png` for your favorite tileset and draw in magenta over the units (`#ff00ff` or any color with the same HSL hue)
* Set `replaced_hue = 300` in the `tilespec`
* Load a game with many units and many nations and check how units are colored with the player color!
* Look around other places where units are displayed to check for weird displays (I don't think any of them uses the player color)