### PR TITLE
More colorful cities

### DIFF
--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -131,11 +131,7 @@ static const char edge_name[EDGE_COUNT][3] = {"ns", "we", "ud", "lr"};
 
 #define MAX_NUM_LAYERS 3
 
-struct city_style_threshold {
-  QPixmap *sprite;
-};
-
-using styles = std::vector<city_style_threshold>;
+using styles = std::vector<QPixmap *>;
 using city_sprite = std::vector<styles>;
 
 struct river_sprites {
@@ -2490,7 +2486,7 @@ static QPixmap *get_city_sprite(const city_sprite &city_sprite,
   }
   img_index = CLIP(0, img_index, num_thresholds - 1);
 
-  return thresholds[img_index].sprite;
+  return thresholds[img_index];
 }
 
 /**
@@ -5288,7 +5284,7 @@ const QPixmap *get_sample_city_sprite(const struct tileset *t, int style_idx)
   if (num_thresholds == 0) {
     return nullptr;
   } else {
-    return (t->sprites.city.tile[style_idx].back().sprite);
+    return (t->sprites.city.tile[style_idx].back());
   }
 }
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -170,7 +170,6 @@ struct named_sprites {
   struct {
     std::unique_ptr<freeciv::colorizer> icon[U_LAST];
     std::unique_ptr<freeciv::colorizer> facing[U_LAST][DIR8_MAGIC_MAX];
-    int replaced_hue; // -1 means no replacement
   } units;
 
   struct sprite_vector nation_flag;
@@ -354,6 +353,7 @@ struct tileset {
   QHash<QString, struct small_sprite *> *sprite_hash;
   QHash<QString, int> *estyle_hash;
   struct named_sprites sprites;
+  int replaced_hue; // -1 means no replacement
   struct color_system *color_system;
   struct extra_type_list *style_lists[ESTYLE_COUNT];
 
@@ -1830,7 +1830,7 @@ static struct tileset *tileset_read_toplevel(const char *tileset_name,
   t->unit_tile_height = secfile_lookup_int_default(file, t->full_tile_height,
                                                    "tilespec.unit_height");
   // Hue to be replaced in unit graphics
-  t->sprites.units.replaced_hue =
+  t->replaced_hue =
       secfile_lookup_int_default(file, -1, "tilespec.replaced_hue");
 
   if (!secfile_lookup_int(file, &t->small_sprite_width,
@@ -2509,8 +2509,8 @@ static styles load_city_thresholds_sprites(struct tileset *t, QString tag,
     const auto buffer = QStringLiteral("%1_%2_%3")
                             .arg(gfx_in_use, tag, QString::number(size));
     if (const auto sprite = load_sprite(t, buffer)) {
-      thresholds.push_back(std::make_unique<freeciv::colorizer>(
-          *sprite, t->sprites.units.replaced_hue));
+      thresholds.push_back(
+          std::make_unique<freeciv::colorizer>(*sprite, t->replaced_hue));
     } else if (size == 0) {
       if (gfx_in_use == graphic) {
         // Try again with graphic_alt.
@@ -3144,8 +3144,8 @@ static bool tileset_setup_unit_direction(struct tileset *t, int uidx,
     return false;
   }
 
-  t->sprites.units.facing[uidx][dir] = std::make_unique<freeciv::colorizer>(
-      *sprite, t->sprites.units.replaced_hue);
+  t->sprites.units.facing[uidx][dir] =
+      std::make_unique<freeciv::colorizer>(*sprite, t->replaced_hue);
   return true;
 }
 
@@ -3160,8 +3160,8 @@ static bool tileset_setup_unit_type_from_tag(struct tileset *t, int uidx,
   auto icon = load_sprite(t, tag);
   has_icon = icon != nullptr;
   if (has_icon) {
-    t->sprites.units.icon[uidx] = std::make_unique<freeciv::colorizer>(
-        *icon, t->sprites.units.replaced_hue);
+    t->sprites.units.icon[uidx] =
+        std::make_unique<freeciv::colorizer>(*icon, t->replaced_hue);
   }
 
 #define LOAD_FACING_SPRITE(dir)                                             \

--- a/data/alio.tilespec
+++ b/data/alio.tilespec
@@ -58,8 +58,8 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/amplio.tilespec
+++ b/data/amplio.tilespec
@@ -49,8 +49,8 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -49,8 +49,8 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/cimpletoon.tilespec
+++ b/data/cimpletoon.tilespec
@@ -52,8 +52,8 @@ occupied_offset_y = 0
 unit_offset_x = 19
 unit_offset_y = 18
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -52,8 +52,8 @@ occupied_offset_y = 0
 unit_offset_x = 4
 unit_offset_y = 21
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -54,8 +54,8 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -52,8 +52,8 @@ occupied_offset_y = 0
 unit_offset_x = 21
 unit_offset_y = 13
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -51,8 +51,8 @@ occupied_offset_y = 0
 unit_offset_x = 21
 unit_offset_y = 13
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/toonhex.tilespec
+++ b/data/toonhex.tilespec
@@ -56,8 +56,8 @@ occupied_offset_y = 0
 unit_offset_x = 34
 unit_offset_y = 38
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -50,8 +50,8 @@ occupied_offset_y = 0
 unit_offset_x = 0
 unit_offset_y = 0
 
-; colors with this (HSL) hue will be replaced by the player color in unit
-; sprites (-1 to disable)
+; colors with this (HSL) hue will be replaced by the player color in city and
+; unit sprites (-1 to disable)
 replaced_hue = -1
 
 ; offset of the normal activity icons


### PR DESCRIPTION
Equivalent of #1095 for cities.

Partially modified amplio2 sprites for testing: [cities.zip](https://github.com/longturn/freeciv21/files/9077601/cities.zip) (`replaced_hue = 300`, magenta).