### PR TITLE
Remember the previous window state when leaving fullscreen

### DIFF
--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -2488,15 +2488,12 @@ void enable_interface(bool enable)
  */
 void mr_menu::slot_fullscreen()
 {
-  if (!gui_options.gui_qt_fullscreen) {
-    king()->showFullScreen();
-    queen()->game_tab_widget->showFullScreen();
-  } else {
-    // FIXME Doesnt return properly, probably something with sidebar
-    king()->showNormal();
-    queen()->game_tab_widget->showNormal();
-  }
   gui_options.gui_qt_fullscreen = !gui_options.gui_qt_fullscreen;
+  if (gui_options.gui_qt_fullscreen) {
+    king()->setWindowState(king()->windowState() | Qt::WindowFullScreen);
+  } else {
+    king()->setWindowState(king()->windowState() & ~Qt::WindowFullScreen);
+  }
 }
 
 /**


### PR DESCRIPTION
Tested on Linux (KWin/X11) only.

Closes #1094.