### PR TITLE
Fix IP leak from server

### DIFF
--- a/common/networking/connection.cpp
+++ b/common/networking/connection.cpp
@@ -422,15 +422,12 @@ static void free_socket_packet_buffer(struct socket_packet_buffer *buf)
 const char *conn_description(const struct connection *pconn, bool is_private)
 {
   static char buffer[MAX_LEN_NAME * 2 + MAX_LEN_ADDR + 128];
-
-  const auto addr = is_private ? pconn->addr : conn_addr_public(pconn);
-
   buffer[0] = '\0';
 
   if (*pconn->username != '\0') {
     if (is_private) {
       fc_snprintf(buffer, sizeof(buffer), _("%s from %s"), pconn->username,
-                  qUtf8Printable(addr));
+                  qUtf8Printable(pconn->addr));
     } else {
       fc_snprintf(buffer, sizeof(buffer), "%s", pconn->username);
     }
@@ -458,16 +455,6 @@ const char *conn_description(const struct connection *pconn, bool is_private)
   }
 
   return buffer;
-}
-
-/**
- * Generate a fake hostname to tell publicly.
- */
-const char *conn_addr_public(const struct connection *pconn)
-{
-  static char buf[256];
-  snprintf(buf, 256, "user-%s-host", pconn->username);
-  return buf;
 }
 
 /**

--- a/common/networking/connection.h
+++ b/common/networking/connection.h
@@ -292,7 +292,6 @@ void conn_list_compression_thaw(const struct conn_list *pconn_list);
 
 const char *conn_description(const struct connection *pconn,
                              bool is_private = true);
-const char *conn_addr_public(const struct connection *pconn);
 bool conn_controls_player(const struct connection *pconn);
 bool conn_is_global_observer(const struct connection *pconn);
 enum cmdlevel conn_get_access(const struct connection *pconn);

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -265,13 +265,11 @@ void establish_new_connection(struct connection *pconn)
    * connection_attach()), otherwise pconn will receive it too. */
   if (conn_controls_player(pconn)) {
     package_event(&connect_info, nullptr, E_CONNECTION, ftc_server,
-                  _("%s has connected from %s (player %s)."),
-                  pconn->username, conn_addr_public(pconn),
+                  _("%s has connected (player %s)."), pconn->username,
                   player_name(conn_get_player(pconn)));
   } else {
     package_event(&connect_info, nullptr, E_CONNECTION, ftc_server,
-                  _("%s has connected from %s."), pconn->username,
-                  conn_addr_public(pconn));
+                  _("%s has connected."), pconn->username);
   }
   conn_list_iterate(game.est_connections, aconn)
   {
@@ -414,7 +412,7 @@ bool handle_login_request(struct connection *pconn,
     fc_snprintf(msg, sizeof(msg), _("Invalid username '%s'"), req->username);
     reject_new_connection(msg, pconn);
     qInfo(_("%s was rejected: Invalid name [%s]."), req->username,
-          conn_addr_public(pconn));
+          qUtf8Printable(pconn->addr));
     return false;
   }
 
@@ -438,7 +436,7 @@ bool handle_login_request(struct connection *pconn,
                   req->username);
       reject_new_connection(msg, pconn);
       qInfo(_("%s was rejected: Duplicate login name [%s]."), req->username,
-            conn_addr_public(pconn));
+            qUtf8Printable(pconn->addr));
       return false;
     }
   }
@@ -509,7 +507,7 @@ static void package_conn_info(struct connection *pconn,
   packet->access_level = pconn->access_level;
 
   sz_strlcpy(packet->username, pconn->username);
-  sz_strlcpy(packet->addr, conn_addr_public(pconn));
+  sz_strlcpy(packet->addr, "");
   sz_strlcpy(packet->capability, pconn->capability);
 }
 


### PR DESCRIPTION
Also remove `user-xxx-host` placeholders from server messages.

Closes #1069 