### PR TITLE
Fix loading scenarios once installed

### DIFF
--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -71,10 +71,11 @@ static QStringList default_save_path()
 
 static QStringList default_scenario_path()
 {
-  return {QStringLiteral("."), QStringLiteral("data/scenarios"),
-          freeciv_storage_dir()
-              + QStringLiteral("/" DATASUBDIR "/scenarios"),
-          freeciv_storage_dir() + QStringLiteral("/scenarios")};
+  auto paths = default_data_path();
+  for (auto &path : paths) {
+    path += QStringLiteral("/scenarios");
+  }
+  return paths;
 }
 
 /* Both of these are stored in the local encoding.  The grouping_sep must


### PR DESCRIPTION
After it is installed, Freeciv21 is supposed to find its default set of
scenarios independent from where it's started from. Use default_data_path() to
build a list of paths to search in.

Closes #1133.

Here is the list of paths on my Linux machine for `freeciv21` installed in `/usr/local/`: `"./scenarios", "data/scenarios", "/home/louis/.local/share/freeciv21/3.0/scenarios", "/usr/local/share/freeciv21/scenarios", "/home/louis/.local/share/freeciv21/scenarios", "/usr/share/plasma/freeciv21/scenarios", "/home/louis/.local/share/flatpak/exports/share/freeciv21/scenarios", "/var/lib/flatpak/exports/share/freeciv21/scenarios", "/usr/local/share/freeciv21/scenarios", "/usr/share/freeciv21/scenarios", "/var/lib/snapd/desktop/freeciv21/scenarios"`
