### PR TITLE
Revert "Temporarily disable builds on Ubuntu 22.04"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,11 +17,10 @@ jobs:
         os: [ubuntu-latest]
         compiler: [gcc, clang]
         build_type: ["", Release, Debug, RelWithDebInfo]
-        # See issue #1043
-        #include:
-          #- os: ubuntu-22.04
-            #compiler: gcc
-            #build_type: Debug
+        include:
+          - os: ubuntu-22.04
+            compiler: gcc
+            build_type: Debug
         exclude:
           - compiler: clang
             build_type: RelWithDebInfo


### PR DESCRIPTION
Looks like the issue was fixed upstream.
This reverts commit aeb24ebf786fe1e503efc1ba8b1d20747364b14b.

Closes #1043 