### PR TITLE
Fix build with NLS enabled

### DIFF
--- a/utility/fcintl.h
+++ b/utility/fcintl.h
@@ -14,8 +14,9 @@
 
 #include <clocale>
 
-#include "shared.h"  // bool
-#include "support.h" // fc__attribute
+#include "fc_config.h" // FREECIV_ENABLE_NLS
+#include "shared.h"    // bool
+#include "support.h"   // fc__attribute
 
 #ifdef FREECIV_ENABLE_NLS
 


### PR DESCRIPTION
We need to include fc_config.h in fcintl.h to control enabling NLS. Else we're
defining "textdomain" as nothing, which doesn't play nice with libintl.h.