### PR TITLE
Improve the layout of the "load game" page

### DIFF
--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -15,6 +15,7 @@
 // Qt
 #include <QDateTime>
 #include <QFileDialog>
+#include <qpushbutton.h>
 // utility
 #include "fcintl.h"
 // common
@@ -73,23 +74,16 @@ page_load::page_load(QWidget *parent, fc_client *c) : QWidget(parent)
   connect(ui.show_preview, &QCheckBox::stateChanged, this,
           &page_load::state_preview);
 
-  ui.bbrowse->setText(_("Browse..."));
-  ui.bbrowse->setIcon(
-      QApplication::style()->standardIcon(QStyle::SP_DirIcon));
+  auto browse = ui.buttons->button(QDialogButtonBox::Open);
+  browse->setText(_("Browse..."));
+  connect(browse, &QAbstractButton::clicked, this, &page_load::browse_saves);
 
-  connect(ui.bbrowse, &QAbstractButton::clicked, this,
-          &page_load::browse_saves);
+  connect(ui.buttons->button(QDialogButtonBox::Cancel),
+          &QAbstractButton::clicked, gui, &fc_client::slot_disconnect);
 
-  ui.bcancel->setText(_("Cancel"));
-  ui.bcancel->setIcon(
-      QApplication::style()->standardIcon(QStyle::SP_DialogCancelButton));
-  connect(ui.bcancel, &QAbstractButton::clicked, gui,
-          &fc_client::slot_disconnect);
-
-  ui.bload->setText(_("Load"));
-  ui.bload->setIcon(
-      QApplication::style()->standardIcon(QStyle::SP_DialogOkButton));
-  connect(ui.bload, &QAbstractButton::clicked, this,
+  auto load = ui.buttons->button(QDialogButtonBox::Ok);
+  load->setText(_("Load"));
+  connect(load, &QAbstractButton::clicked, this,
           &page_load::start_from_save);
 }
 

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -50,31 +50,22 @@ static struct terrain *char2terrain(char ch)
 
 page_load::page_load(QWidget *parent, fc_client *c) : QWidget(parent)
 {
-  QHeaderView *header;
-
-  QStringList sav;
   gui = c;
   ui.setupUi(this);
   ui.show_preview->setText(_("Show preview"));
   ui.load_pix->setProperty("themed_border", true);
   ui.load_pix->setFixedSize(0, 0);
-  sav << _("Choose Saved Game to Load") << _("Date");
   ui.load_save_text->setText(QLatin1String(""));
   ui.load_save_text->setTextFormat(Qt::RichText);
   ui.load_save_text->setWordWrap(true);
   ui.show_preview->setChecked(gui_options.gui_qt_show_preview);
-  ui.saves_load->setAlternatingRowColors(true);
   ui.saves_load->setRowCount(0);
+  QStringList sav;
+  sav << _("Choose Saved Game to Load") << _("Date");
   ui.saves_load->setColumnCount(sav.count());
   ui.saves_load->setHorizontalHeaderLabels(sav);
-  ui.saves_load->setProperty("showGrid", "false");
-  ui.saves_load->setProperty("selectionBehavior", "SelectRows");
-  ui.saves_load->setEditTriggers(QAbstractItemView::NoEditTriggers);
-  ui.saves_load->setSelectionMode(QAbstractItemView::SingleSelection);
-  ui.saves_load->verticalHeader()->setVisible(false);
-  header = ui.saves_load->horizontalHeader();
-  header->setSectionResizeMode(0, QHeaderView::Stretch);
-  header->setStretchLastSection(true);
+  ui.saves_load->horizontalHeader()->setSectionResizeMode(
+      0, QHeaderView::Stretch);
 
   connect(ui.saves_load->selectionModel(),
           &QItemSelectionModel::selectionChanged, this,

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -15,6 +15,7 @@
 // Qt
 #include <QDateTime>
 #include <QFileDialog>
+#include <qdatetime.h>
 #include <qpushbutton.h>
 // utility
 #include "fcintl.h"
@@ -110,7 +111,8 @@ void page_load::update_load_page()
     item->setText(info.fileName());
     ui.saves_load->setItem(row, 0, item);
     item = new QTableWidgetItem();
-    item->setText(info.lastModified().toString(QLocale().dateTimeFormat()));
+    item->setText(info.lastModified().toString(
+        QLocale().dateTimeFormat(QLocale::ShortFormat)));
     ui.saves_load->setItem(row, 1, item);
     row++;
   }

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -340,5 +340,14 @@ void page_load::slot_selection_changed(const QItemSelection &selected,
       }
     }
     ui.load_save_text->setText(final_str);
+
+    ui.load_save_text->show();
+    ui.load_pix->show();
+    ui.buttons->button(QDialogButtonBox::Ok)->setEnabled(true);
+  } else {
+    // Couldn't load the save. Clear the preview and prevent loading it.
+    ui.load_save_text->hide();
+    ui.load_pix->hide();
+    ui.buttons->button(QDialogButtonBox::Ok)->setEnabled(false);
   }
 }

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -91,7 +91,6 @@ page_load::page_load(QWidget *parent, fc_client *c) : QWidget(parent)
       QApplication::style()->standardIcon(QStyle::SP_DialogOkButton));
   connect(ui.bload, &QAbstractButton::clicked, this,
           &page_load::start_from_save);
-  setLayout(ui.vertLayout);
 }
 
 page_load::~page_load() = default;

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -116,6 +116,10 @@ void page_load::update_load_page()
     ui.saves_load->setItem(row, 1, item);
     row++;
   }
+
+  if (!files.isEmpty()) {
+    ui.saves_load->setCurrentCell(0, 0); // Select the latest save
+  }
 }
 
 /**

--- a/client/page_load.ui
+++ b/client/page_load.ui
@@ -37,6 +37,30 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <property name="showGrid">
+       <bool>false</bool>
+      </property>
+      <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="horizontalHeaderStretchLastSection">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
      </widget>
     </item>
     <item>

--- a/client/page_load.ui
+++ b/client/page_load.ui
@@ -19,114 +19,130 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QWidget" name="verticalLayoutWidget_2">
-   <property name="geometry">
-    <rect>
-     <x>1</x>
-     <y>10</y>
-     <width>651</width>
-     <height>511</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="vertLayout">
-    <item>
-     <widget class="QTableWidget" name="saves_load">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="editTriggers">
-       <set>QAbstractItemView::NoEditTriggers</set>
-      </property>
-      <property name="alternatingRowColors">
-       <bool>true</bool>
-      </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::SingleSelection</enum>
-      </property>
-      <property name="selectionBehavior">
-       <enum>QAbstractItemView::SelectRows</enum>
-      </property>
-      <property name="showGrid">
-       <bool>false</bool>
-      </property>
-      <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-       <bool>true</bool>
-      </attribute>
-      <attribute name="horizontalHeaderStretchLastSection">
-       <bool>true</bool>
-      </attribute>
-      <attribute name="verticalHeaderVisible">
-       <bool>false</bool>
-      </attribute>
-     </widget>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QPushButton" name="bload">
-        <property name="text">
-         <string>load</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="bbrowse">
-        <property name="text">
-         <string>browse</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="bcancel">
-        <property name="text">
-         <string>cancel</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QLabel" name="load_pix">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string>loadpix</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QCheckBox" name="show_preview">
-        <property name="text">
-         <string>cstate</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="load_save_text">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>load_save_text</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="show_preview">
+       <property name="text">
+        <string>cstate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="load_save_text">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>load_save_text</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="load_pix">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>loadpix</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0" rowspan="4">
+      <widget class="QTableWidget" name="saves_load">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+       <property name="showGrid">
+        <bool>false</bool>
+       </property>
+       <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="horizontalHeaderStretchLastSection">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="verticalHeaderVisible">
+        <bool>false</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="bbrowse">
+       <property name="text">
+        <string>browse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="bcancel">
+       <property name="text">
+        <string>cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="bload">
+       <property name="text">
+        <string>load</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/client/page_load.ui
+++ b/client/page_load.ui
@@ -24,6 +24,12 @@
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="1">
       <widget class="QCheckBox" name="show_preview">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>25</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>cstate</string>
        </property>
@@ -72,7 +78,7 @@
       <widget class="QTableWidget" name="saves_load">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
+         <horstretch>75</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>

--- a/client/page_load.ui
+++ b/client/page_load.ui
@@ -105,42 +105,11 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="bbrowse">
-       <property name="text">
-        <string>browse</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="bcancel">
-       <property name="text">
-        <string>cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="bload">
-       <property name="text">
-        <string>load</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Open</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This PR changes the layout of the "load game" screen to jump around less. There are still huge improvements to be made but I think it's a good start.

The new layout looks like this:
![image](https://user-images.githubusercontent.com/22327575/181930175-49022f41-1248-478f-a5fe-9a2097526b55.png)


After #1165.
Related to #115.
