### PR TITLE
Don't try to set the ruleset based on the tileset

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -585,17 +585,15 @@ int client_main(int argc, char *argv[])
   boot_help_texts(client_current_nation_set(), tileset_help(tileset));
 
   fill_topo_ts_default();
-
   if (!forced_tileset_name.isEmpty()) {
-    if (!tilespec_try_read(qUtf8Printable(forced_tileset_name), true, -1,
-                           true)) {
+    if (!tilespec_try_read(forced_tileset_name, true, -1)) {
       qCritical(_("Can't load requested tileset %s!"),
                 qUtf8Printable(forced_tileset_name));
       client_exit();
       return EXIT_FAILURE;
     }
   } else {
-    tilespec_try_read(gui_options.default_tileset_name, false, -1, true);
+    tilespec_try_read(QString(), false, -1);
   }
 
   audio_real_init(sound_set_name, music_set_name, sound_plugin_name);

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -200,7 +200,7 @@ static int find_next_free_port(int starting_port, int highest_port)
 bool client_start_server(const QString &user_name)
 {
   QStringList arguments;
-  QString trueFcser, ruleset, storage, port_buf, savesdir, scensdir;
+  QString trueFcser, storage, port_buf, savesdir, scensdir;
   char buf[512];
   int connect_tries = 0;
 
@@ -233,8 +233,6 @@ bool client_start_server(const QString &user_name)
     return false;
   }
 
-  ruleset = QString::fromUtf8(tileset_what_ruleset(tileset));
-
   // Set up the command-line parameters.
   port_buf = QString::number(internal_server_port);
   savesdir = QStringLiteral("%1/saves").arg(storage);
@@ -255,9 +253,6 @@ bool client_start_server(const QString &user_name)
   }
   if (savefile.isEmpty()) {
     arguments << QStringLiteral("--file") << savefile;
-  }
-  if (ruleset != nullptr) {
-    arguments << QStringLiteral("--ruleset") << ruleset;
   }
 
   // Look for a server binary
@@ -328,38 +323,6 @@ bool client_start_server(const QString &user_name)
                          _("You'll have to start one manually. Sorry..."));
 
     return false;
-  }
-
-  /* We set the topology to match the view.
-   *
-   * When a typical player launches a game, he wants the map orientation to
-   * match the tileset orientation.  So if you use an isometric tileset you
-   * get an iso-map and for a classic tileset you get a classic map.  In
-   * both cases the map wraps in the X direction by default.
-   *
-   * This works with hex maps too now.  A hex map always has
-   * tileset_is_isometric(tileset) return TRUE.  An iso-hex map has
-   * tileset_hex_height(tileset) != 0, while a non-iso hex map
-   * has tileset_hex_width(tileset) != 0.
-   *
-   * Setting the option here is a bit of a hack, but so long as the client
-   * has sufficient permissions to do so (it doesn't have HACK access yet) it
-   * is safe enough.  Note that if you load a savegame the topology will be
-   * set but then overwritten during the load.
-   *
-   * Don't send it now, it will be sent to the server when receiving the
-   * server setting infos. */
-  {
-    char topobuf[16];
-
-    fc_strlcpy(topobuf, "WRAPX", sizeof(topobuf));
-    if (tileset_is_isometric(tileset) && 0 == tileset_hex_height(tileset)) {
-      fc_strlcat(topobuf, "|ISO", sizeof(topobuf));
-    }
-    if (0 < tileset_hex_width(tileset) || 0 < tileset_hex_height(tileset)) {
-      fc_strlcat(topobuf, "|HEX", sizeof(topobuf));
-    }
-    desired_settable_option_update("topology", topobuf, false);
   }
 
   return true;

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -88,7 +88,6 @@ struct client_options gui_options = {
 
     /** Migrations **/
     false, //.first_boot =
-    "\0",  //.default_tileset_name =
     "\0",  //.default_tileset_overhead_name =
     "\0",  //.default_tileset_iso_name =
     false, //.gui_qt_migrated_from_2_5 =
@@ -4418,11 +4417,6 @@ void options_load()
       secfile_lookup_bool_default(sf, gui_options.gui_qt_migrated_from_2_5,
                                   "%s.migration_qt_from_2_5", prefix);
 
-  str =
-      secfile_lookup_str_default(sf, nullptr, "client.default_tileset_name");
-  if (str != nullptr) {
-    sz_strlcpy(gui_options.default_tileset_name, str);
-  }
   str = secfile_lookup_str_default(sf, nullptr,
                                    "client.default_tileset_overhead_name");
   if (str != nullptr) {
@@ -4530,11 +4524,6 @@ void options_save(option_save_log_callback log_cb)
   gui_options.gui_qt_increase_fonts = 0; // gui-enabled options
   client_options_iterate_all(poption) { client_option_save(poption, sf); }
   client_options_iterate_all_end;
-
-  if (gui_options.default_tileset_name[0] != '\0') {
-    secfile_insert_str(sf, gui_options.default_tileset_name,
-                       "client.default_tileset_name");
-  }
 
   message_options_save(sf, "client");
   options_dialogs_save(sf);
@@ -4878,10 +4867,6 @@ const char *tileset_name_for_topology(int topology_id)
     break;
   }
 
-  if (tsn == nullptr) {
-    tsn = gui_options.default_tileset_name;
-  }
-
   return tsn;
 }
 
@@ -4957,15 +4942,15 @@ void fill_topo_ts_default()
                sizeof(gui_options.default_tileset_square_name));
     } else {
       log_debug("Setting tileset for square topologies.");
-      tilespec_try_read(nullptr, false, 0, false);
+      tilespec_try_read(QString(), false, 0);
     }
   }
   if (is_ts_option_unset("default_tileset_hex_name")) {
     log_debug("Setting tileset for hex topology.");
-    tilespec_try_read(nullptr, false, TF_HEX, false);
+    tilespec_try_read(QString(), false, TF_HEX);
   }
   if (is_ts_option_unset("default_tileset_isohex_name")) {
     log_debug("Setting tileset for isohex topology.");
-    tilespec_try_read(nullptr, false, TF_ISO | TF_HEX, false);
+    tilespec_try_read(QString(), false, TF_ISO | TF_HEX);
   }
 }

--- a/client/options.h
+++ b/client/options.h
@@ -62,9 +62,8 @@ struct client_options {
   bool save_options_on_exit;
 
   /** Migrations **/
-  bool first_boot;                /* There was no earlier options saved.
-                                   * This affects some migrations, but not all. */
-  char default_tileset_name[512]; // pre-2.6 had just this one tileset name
+  bool first_boot; /* There was no earlier options saved.
+                    * This affects some migrations, but not all. */
   char default_tileset_overhead_name[512]; /* 2.6 had separate tilesets for
                                               ... */
   char default_tileset_iso_name[512];      // ...overhead and iso topologies.

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -300,8 +300,6 @@ struct tileset {
 
   std::vector<tileset_log_entry> log;
 
-  char *for_ruleset;
-
   std::vector<std::unique_ptr<freeciv::layer>> layers;
   struct {
     freeciv::layer_special *background, *middleground, *foreground;
@@ -892,10 +890,8 @@ static void tileset_free_toplevel(struct tileset *t)
 
   delete[] t->summary;
   delete[] t->description;
-  delete[] t->for_ruleset;
   t->summary = nullptr;
   t->description = nullptr;
-  t->for_ruleset = nullptr;
 }
 
 /**
@@ -1670,13 +1666,6 @@ static struct tileset *tileset_read_toplevel(const QString &tileset_name,
       delete[] t->description;
       t->description = nullptr;
     }
-  }
-
-  tstr = secfile_lookup_str_default(file, nullptr, "tilespec.for_ruleset");
-  if (tstr != nullptr) {
-    t->for_ruleset = fc_strdup(tstr);
-  } else {
-    t->for_ruleset = nullptr;
   }
 
   sz_strlcpy(t->name, tileset_name.toUtf8().data());
@@ -5668,11 +5657,6 @@ const char *tileset_summary(struct tileset *t) { return t->summary; }
    Return tileset description body
  */
 const char *tileset_description(struct tileset *t) { return t->description; }
-
-/**
-   Return what ruleset this tileset is primarily meant for
- */
-char *tileset_what_ruleset(struct tileset *t) { return t->for_ruleset; }
 
 /**
    Return tileset topology index

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -924,7 +924,7 @@ void tileset_free(struct tileset *t)
    Returns TRUE iff tileset with suggested tileset_name was loaded.
  */
 bool tilespec_try_read(const QString &tileset_name, bool verbose,
-                       int topo_id, bool global_default)
+                       int topo_id)
 {
   bool original;
 
@@ -964,10 +964,6 @@ bool tilespec_try_read(const QString &tileset_name, bool verbose,
     original = true;
   }
   option_set_default_ts(tileset);
-
-  if (global_default) {
-    sz_strlcpy(gui_options.default_tileset_name, tileset_basename(tileset));
-  }
 
   return original;
 }
@@ -1137,10 +1133,6 @@ void tilespec_reread_callback(struct option *poption)
   }
 
   tileset_name = option_str_get(poption);
-
-  /* As it's going to be 'current' tileset, make it global default if
-   * options saved. */
-  sz_strlcpy(gui_options.default_tileset_name, tileset_name);
 
   fc_assert_ret(nullptr != tileset_name && tileset_name[0] != '\0');
   tileset_update = true;

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -117,11 +117,12 @@ bool tileset_has_error(const struct tileset *t);
 
 void finish_loading_sprites(struct tileset *t);
 
-bool tilespec_try_read(const char *tileset_name, bool verbose, int topo_id,
+bool tilespec_try_read(const QString &name, bool verbose, int topo_id,
                        bool global_default);
-bool tilespec_reread(const char *tileset_name, bool game_fully_initialized);
+bool tilespec_reread(const QString &tileset_name,
+                     bool game_fully_initialized);
 void tilespec_reread_callback(struct option *poption);
-void tilespec_reread_frozen_refresh(const char *tname);
+void tilespec_reread_frozen_refresh(const QString &name);
 
 void tileset_setup_specialist_type(struct tileset *t, Specialist_type_id id);
 void tileset_setup_unit_type(struct tileset *t, struct unit_type *punittype);

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -117,8 +117,7 @@ bool tileset_has_error(const struct tileset *t);
 
 void finish_loading_sprites(struct tileset *t);
 
-bool tilespec_try_read(const QString &name, bool verbose, int topo_id,
-                       bool global_default);
+bool tilespec_try_read(const QString &name, bool verbose, int topo_id);
 bool tilespec_reread(const QString &tileset_name,
                      bool game_fully_initialized);
 void tilespec_reread_callback(struct option *poption);

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -318,6 +318,5 @@ const char *tileset_name_get(struct tileset *t);
 const char *tileset_version(struct tileset *t);
 const char *tileset_summary(struct tileset *t);
 const char *tileset_description(struct tileset *t);
-char *tileset_what_ruleset(struct tileset *t);
 int tileset_topo_index(struct tileset *t);
 help_item *tileset_help(struct tileset *t);

--- a/data/alio.tilespec
+++ b/data/alio.tilespec
@@ -24,9 +24,6 @@ Tileset containing graphics suitable for playing with alien ruleset.\
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-for_ruleset = "alien"
-
 ; Basic tile sizes:
 normal_tile_width  = 126
 normal_tile_height = 64

--- a/data/amplio.tilespec
+++ b/data/amplio.tilespec
@@ -18,9 +18,6 @@ summary = _("Older variant of the current default tileset, Amplio2")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 96
 normal_tile_height = 48

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -18,9 +18,6 @@ summary = _("Large isometric tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 96
 normal_tile_height = 48

--- a/data/cimpletoon.tilespec
+++ b/data/cimpletoon.tilespec
@@ -21,9 +21,6 @@ direction the unit is facing.\
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 96
 normal_tile_height = 48

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -18,9 +18,6 @@ summary = _("Small hex tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 40
 normal_tile_height = 72

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -20,9 +20,6 @@ summary = _("Large iso-hex tileset, similar to Amplio.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 126
 normal_tile_height = 64

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -18,9 +18,6 @@ summary = _("Small iso-hex tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 64
 normal_tile_height = 32

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -18,9 +18,6 @@ summary = _("Isometric tileset based on Trident tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 64
 normal_tile_height = 32

--- a/data/toonhex.tilespec
+++ b/data/toonhex.tilespec
@@ -22,9 +22,6 @@ and Cimpletoon's units with orientation.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 126
 normal_tile_height = 64

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -17,9 +17,6 @@ summary = _("Small overhead tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
-; What is the primary ruleset this tileset is meant for.
-;for_ruleset = ""
-
 ; Basic tile sizes:
 normal_tile_width  = 30
 normal_tile_height = 30


### PR DESCRIPTION
The last used tileset was saved in the options file, but that value wasn't shown anywhere in the interface. It was then used *instead* of the tileset configured in the settings when the topology matched. This was a source of confusion. Get rid of this behavior by removing the hidden option.

---

The tileset in pregame isn't well defined because the topology isn't known yet. Always start servers with the default ruleset, and load a tileset based on that.

If the user want to spawn a client with a given ruleset, they can use the `-r` option.
