### PR TITLE
Remove static calls to units_reports

### DIFF
--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -64,7 +64,6 @@
 extern void popdown_all_spaceships_dialogs();
 extern void popdown_players_report();
 extern void popdown_economy_report();
-extern void popdown_units_report();
 extern void popdown_science_report();
 extern void popdown_city_report();
 extern void popdown_endgame_report();
@@ -3507,7 +3506,6 @@ void popdown_all_game_dialogs(void)
   popdown_players_report();
   popdown_all_spaceships_dialogs();
   popdown_economy_report();
-  popdown_units_report();
   popdown_science_report();
   popdown_city_report();
   popdown_endgame_report();

--- a/client/include/repodlgs_g.h
+++ b/client/include/repodlgs_g.h
@@ -22,7 +22,6 @@
 void science_report_dialog_popup(bool raise);
 void science_report_dialog_redraw(void);
 void economy_report_dialog_popup();
-void units_report_dialog_popup(bool raise);
 void endgame_report_dialog_start(const struct packet_endgame_report *packet);
 void endgame_report_dialog_player(
     const struct packet_endgame_player *packet);

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -63,9 +63,10 @@
 #include "shortcuts.h"
 #include "spaceshipdlg.h"
 #include "sprite.h"
+#include "top_bar.h"
+#include "unitreport.h"
 
 extern void popup_endgame_report();
-extern void toggle_units_report();
 static void enable_interface(bool enable);
 
 void option_dialog_popup(const char *name, const struct option_set *poptset);
@@ -1096,8 +1097,13 @@ void mr_menu::setup_menus()
   connect(act, &QAction::triggered, this, &mr_menu::slot_show_map);
 
   act = menu->addAction(_("Units"));
+  act->setCheckable(true);
   act->setShortcut(QKeySequence(tr("F2")));
-  connect(act, &QAction::triggered, this, &toggle_units_report);
+  connect(act, &QAction::toggled, queen()->units, &QWidget::setVisible);
+  connect(act, &QAction::toggled, queen()->sw_cunit,
+          &QAbstractButton::setChecked);
+  connect(queen()->sw_cunit, &QAbstractButton::toggled, act,
+          &QAction::setChecked);
 
   // TRANS: Also menu item, but 'headers' should be good enough.
   act = menu->addAction(Q_("?header:Players"));

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -43,6 +43,7 @@
 #include "minimap_panel.h"
 #include "plrdlg.h"
 #include "top_bar.h"
+#include "unitreport.h"
 #include "voteinfo_bar.h"
 
 int last_center_capital = 0;
@@ -79,9 +80,13 @@ pageGame::pageGame(QWidget *parent)
   sw_indicators = new indicators_widget();
   connect(sw_indicators, &QAbstractButton::clicked, top_bar_indicators_menu);
 
-  sw_cunit =
-      new top_bar_widget(_("Units"), QLatin1String(""), toggle_units_report);
+  units = new units_reports(mapview_wdg);
+  units->hide();
+  sw_cunit = new top_bar_widget(_("Units"), QLatin1String(""), nullptr);
   sw_cunit->setIcon(fcIcons::instance()->getIcon(QStringLiteral("units")));
+  sw_cunit->setCheckable(true);
+  connect(sw_cunit, &QAbstractButton::toggled, units, &QWidget::setVisible);
+
   sw_cities = new top_bar_widget(_("Cities"), QStringLiteral("CTS"),
                                  city_report_dialog_popup);
   sw_cities->setIcon(fcIcons::instance()->getIcon(QStringLiteral("cities")));
@@ -539,6 +544,7 @@ bool fc_game_tab_widget::event(QEvent *event)
       queen()->mapview_wdg->resize(size.width(), size.height());
       queen()->city_overlay->resize(queen()->mapview_wdg->size());
       queen()->unitinfo_wdg->update_actions(nullptr);
+      queen()->units->update_units(false);
     }
 
     /*

--- a/client/page_game.h
+++ b/client/page_game.h
@@ -31,6 +31,7 @@ class goto_dialog;
 class tax_rates_widget;
 class top_bar;
 class top_bar_widget;
+class units_reports;
 class units_select;
 class xvote;
 
@@ -78,6 +79,8 @@ public:
   map_view *mapview_wdg;
   ::minimap_panel *minimap_panel;
   city_dialog *city_overlay;
+  units_reports *units;
+  top_bar_widget *sw_cunit;
   xvote *x_vote;
   civstatus *civ_status;
   top_bar_widget *sw_diplo;
@@ -91,7 +94,6 @@ private:
   QMap<QString, QWidget *> opened_repo_dlgs;
   QTimer *update_info_timer;
   top_bar_widget *sw_cities;
-  top_bar_widget *sw_cunit;
   gold_widget *sw_economy;
   top_bar_widget *sw_map;
   tax_rates_widget *sw_tax;

--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -236,8 +236,10 @@ void top_bar_widget::setTooltip(const QString &tooltip)
 void top_bar_widget::paintEvent(QPaintEvent *event)
 {
   // HACK Should improve this logic, paintEvent is NOT the right place.
-  int i = queen()->gimmeIndexOf(page);
-  setChecked(i == queen()->game_tab_widget->currentIndex());
+  if (!page.isEmpty()) {
+    int i = queen()->gimmeIndexOf(page);
+    setChecked(i == queen()->game_tab_widget->currentIndex());
+  }
 
   QToolButton::paintEvent(event);
 
@@ -279,12 +281,12 @@ void top_bar_widget::mousePressEvent(QMouseEvent *event)
 {
   if (event->button() == Qt::LeftButton && left_click != nullptr) {
     left_click();
-  }
-  if (event->button() == Qt::RightButton && right_click != nullptr) {
+  } else if (event->button() == Qt::RightButton && right_click != nullptr) {
     right_click();
-  }
-  if (event->button() == Qt::RightButton && right_click == nullptr) {
+  } else if (event->button() == Qt::RightButton && right_click == nullptr) {
     queen()->game_tab_widget->setCurrentIndex(0);
+  } else {
+    QToolButton::mousePressEvent(event);
   }
 }
 

--- a/client/unitreport.h
+++ b/client/unitreport.h
@@ -81,32 +81,26 @@ class units_reports : public fcwidget {
   Q_OBJECT
 
   close_widget *cw;
-  explicit units_reports();
   QHBoxLayout *scroll_layout;
   QScrollArea *scroll;
   QWidget scroll_widget;
-  static units_reports *m_instance;
   units_waiting *uw;
 
 public:
+  explicit units_reports(QWidget *parent = nullptr);
   ~units_reports() override;
-  static units_reports *instance();
-  static void drop();
   void clear_layout();
   void init_layout();
   void update_units(bool show = false);
   void add_item(unittype_item *item);
   void update_menu() override;
-  static bool exists();
   QHBoxLayout *layout;
   QList<unittype_item *> unittype_list;
 
 protected:
+  void hideEvent(QHideEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void paintEvent(QPaintEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
-  void hideEvent(QHideEvent *event) override;
+  void showEvent(QShowEvent *event) override;
 };
-
-void popdown_units_report();
-void toggle_units_report();


### PR DESCRIPTION
`units_reports` is the units list widget. This replaces static functions to pop it open and close it with Qt signals and slots.

Widgets are better managed by their parents: this way the parent knows exactly
when and why its children change (well, signals and slots might break this in
principle, but the parent knows how it connects them).