### PR TITLE
Introduce a map renderer class

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(
   plrdlg_common.cpp
   pregameoptions.cpp
   ratesdlg.cpp
+  renderer.cpp
   repodlgs_common.cpp
   reqtree.cpp
   sciencedlg.cpp

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -32,6 +32,9 @@ class QPaintEvent;
 class QPainter;
 
 class fcwidget;
+namespace freeciv {
+class renderer;
+}
 
 bool is_point_in_area(int x, int y, int px, int py, int pxe, int pye);
 void draw_calculated_trade_routes(QPainter *painter);
@@ -51,7 +54,6 @@ class map_view : public QWidget {
 
 public:
   map_view();
-  void paint(QPainter *painter, QPaintEvent *event);
   void find_place(int pos_x, int pos_y, int &w, int &h, int wdth, int hght,
                   int recursive_nr, bool direction = false);
   void resume_searching(int pos_x, int pos_y, int &w, int &h, int wdtht,
@@ -63,7 +65,7 @@ public:
 
   bool menu_click;
 
-  double scale() const { return m_scale; }
+  double scale() const;
 
   freeciv::tileset_debugger *debugger() const { return m_debugger; }
 
@@ -89,6 +91,7 @@ protected:
   void mouseMoveEvent(QMouseEvent *event) override;
   void focusOutEvent(QFocusEvent *event) override;
   void leaveEvent(QEvent *event) override;
+  void resizeEvent(QResizeEvent *event) override;
 
 private slots:
   void set_scale_now(double scale);
@@ -98,6 +101,7 @@ private:
   bool stored_autocenter;
   int cursor_frame{0};
   int cursor;
+  freeciv::renderer *m_renderer;
   double m_scale = 1;
   std::unique_ptr<QPropertyAnimation> m_scale_animation;
   QPointer<freeciv::tileset_debugger> m_debugger = nullptr;

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -513,7 +513,6 @@ bool fc_game_tab_widget::event(QEvent *event)
                           ? static_cast<QResizeEvent *>(event)->size()
                           : this->size();
     if (event->type() == QEvent::Resize) {
-      map_canvas_resized(size.width(), size.height());
       queen()->message->resize(
           qRound((size.width() * king()->qt_settings.chat_fwidth)),
           qRound((size.height() * king()->qt_settings.chat_fheight)));

--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "renderer.h"
+
+#include "mapview_common.h"
+
+namespace freeciv {
+
+/**
+ * @class renderer
+ * @brief Renders the map on widgets
+ *
+ * This class is used to draw the map. It can handle zoom via the @ref scale
+ * property.
+ *
+ * @property scale By how much the map is scaled before being drawn (a scale
+ * of 2 means that everything is 2x bigger)
+ */
+
+/**
+ * Constructor.
+ */
+renderer::renderer(QObject *parent) : QObject(parent) {}
+
+/**
+ * Changes the scale of the rendering (zooms in or out).
+ */
+void renderer::set_scale(double scale)
+{
+  m_scale = scale;
+
+  // When zoomed in, we pretend that the canvas is smaller than it actually
+  // is. This makes text look bad, but everything else is drawn correctly.
+  map_canvas_resized(m_viewport_size.width() / m_scale,
+                     m_viewport_size.height() / m_scale);
+}
+
+/**
+ * Instructs the renderer to draw a viewport with a different size.
+ */
+void renderer::set_viewport_size(const QSize &size)
+{
+  m_viewport_size = size;
+
+  // When zoomed in, we pretend that the canvas is smaller than it actually
+  // is. This makes text look bad, but everything else is drawn correctly.
+  map_canvas_resized(m_viewport_size.width() / m_scale,
+                     m_viewport_size.height() / m_scale);
+}
+
+/**
+ * Renders the specified region of the visible portion of the map on @c
+ * painter.
+ * @see @ref render(QPainter&, const QRect&)
+ */
+void renderer::render(QPainter &painter, const QRegion &region) const
+{
+  for (const auto &rect : region) {
+    render(painter, rect);
+  }
+}
+
+/**
+ * Renders the specified area of the visible portion of the map on @c
+ * painter. This is meant to be used directly from @c paintEvent, so the
+ * position of
+ * @c area is relative to the @ref viewport.
+ */
+void renderer::render(QPainter &painter, const QRect &area) const
+{
+  if (scale() != 1) {
+    painter.setRenderHint(QPainter::SmoothPixmapTransform);
+  }
+
+  auto mapview_rect =
+      QRectF(area.left() / scale(), area.top() / scale(),
+             area.width() / scale(), area.height() / scale());
+  painter.drawPixmap(area, *mapview.store, mapview_rect);
+}
+
+} // namespace freeciv

--- a/client/renderer.h
+++ b/client/renderer.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QPainter>
+#include <QRect>
+#include <QRegion>
+#include <QSize>
+
+namespace freeciv {
+
+class renderer : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(double scale READ scale WRITE set_scale);
+
+public:
+  explicit renderer(QObject *parent = nullptr);
+  virtual ~renderer() = default;
+
+  /// The scale (zoom) at which rendering is performed
+  double scale() const { return m_scale; }
+  void set_scale(double scale);
+
+  /// The current dimensions of the viewport
+  QSize viewport_size() const { return m_viewport_size; }
+  void set_viewport_size(const QSize &size);
+
+  void render(QPainter &painter, const QRegion &region) const;
+  void render(QPainter &painter, const QRect &area) const;
+
+private:
+  double m_scale = 1.0;
+  QSize m_viewport_size;
+};
+
+} // namespace freeciv


### PR DESCRIPTION
It is meant to incorporate the functionality of mapview_common needed to draw
the map. Right now it delegates most (all) of its work to mapview_common.

Developed on top of many patches from #1169 but auto rebase worked fine so I'm making a PR to `master`.