### PR TITLE
Fix new Coverity warnings

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -3100,11 +3100,6 @@ QVariant production_item::data() const
 }
 
 /**
-   Sets data for item, must be declared.
- */
-bool production_item::setData() { return false; }
-
-/**
    Constructor for city production model
  */
 city_production_model::city_production_model(struct city *pcity, bool f,
@@ -3219,27 +3214,6 @@ void city_production_model::populate()
   city_target_list << pi;
   sh.setX(2 * sh.y() + sh.x());
   sh.setX(qMin(sh.x(), 250));
-}
-
-/**
-   Sets data in model
- */
-bool city_production_model::setData(const QModelIndex &index,
-                                    const QVariant &value, int role)
-{
-  Q_UNUSED(value)
-  if (!index.isValid() || role != Qt::DisplayRole
-      || role != Qt::ToolTipRole) {
-    return false;
-  }
-
-  if (index.row() >= 0 && index.row() < rowCount() && index.column() >= 0
-      && index.column() < columnCount()) {
-    bool change = city_target_list[index.row()]->setData();
-    return change;
-  }
-
-  return false;
 }
 
 /**

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -204,7 +204,6 @@ public:
   ~production_item() override;
   inline int columnCount() const { return 1; }
   QVariant data() const;
-  bool setData();
 
 private:
   struct universal *target;
@@ -233,8 +232,6 @@ public:
   }
   QVariant data(const QModelIndex &index,
                 int role = Qt::DisplayRole) const override;
-  bool setData(const QModelIndex &index, const QVariant &value,
-               int role = Qt::DisplayRole) override;
   void populate();
   QPoint sh;
 

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -328,7 +328,9 @@ void map_view::shortcut_pressed(shortcut_id id)
     break;
 
   case SC_MAKE_LINK:
-    queen()->chat->make_link(ptile);
+    if (ptile != nullptr) {
+      queen()->chat->make_link(ptile);
+    }
     break;
 
   case SC_BUY_MAP:

--- a/common/mapimg.cpp
+++ b/common/mapimg.cpp
@@ -2627,11 +2627,6 @@ static bv_pixel pixel_border_rect(const struct tile *ptile,
 
   fc_assert_ret_val(ptile != nullptr, pixel);
 
-  if (nullptr == ptile) {
-    // no tile
-    return pixel;
-  }
-
   owner = mapimg.mapimg_tile_owner(ptile, pplayer, knowledge);
   if (nullptr == owner) {
     // no border
@@ -2856,11 +2851,6 @@ static bv_pixel pixel_border_hexa(const struct tile *ptile,
   BV_CLR_ALL(pixel);
 
   fc_assert_ret_val(ptile != nullptr, pixel);
-
-  if (nullptr == ptile) {
-    // no tile
-    return pixel;
-  }
 
   owner = mapimg.mapimg_tile_owner(ptile, pplayer, knowledge);
   if (nullptr == owner) {
@@ -3100,11 +3090,6 @@ static bv_pixel pixel_border_isohexa(const struct tile *ptile,
   BV_CLR_ALL(pixel);
 
   fc_assert_ret_val(ptile != nullptr, pixel);
-
-  if (nullptr == ptile) {
-    // no tile
-    return pixel;
-  }
 
   owner = mapimg.mapimg_tile_owner(ptile, pplayer, knowledge);
   if (nullptr == owner) {

--- a/common/nation.cpp
+++ b/common/nation.cpp
@@ -17,6 +17,7 @@
 
 // utility
 #include "fcintl.h"
+#include "name_translation.h"
 #include "support.h"
 
 // common
@@ -472,8 +473,9 @@ Nation_type_id nation_index(const struct nation_type *pnation)
  */
 nation_type::nation_type()
 {
-  item_number = 0;
-  translation_domain = nullptr;
+  name_init(&adjective);
+  name_init(&noun_plural);
+
   leaders = nation_leader_list_new_full(nation_leader_destroy);
   sets = nation_set_list_new();
   groups = nation_group_list_new();
@@ -485,6 +487,8 @@ nation_type::nation_type()
     server.conflicts_with = nation_list_new();
     // server.rgb starts out nullptr
     server.traits = new trait_limits[TRAIT_COUNT];
+  } else {
+    client.is_pickable = true;
   }
 }
 

--- a/common/nation.h
+++ b/common/nation.h
@@ -10,6 +10,8 @@
 **************************************************************************/
 #pragma once
 
+#include <array>
+
 #include "name_translation.h"
 // utility
 #include "iterator.h"
@@ -73,18 +75,18 @@ struct nation_type;
 
 // Pointer values are allocated on load then freed in free_nations().
 struct nation_type {
-  Nation_type_id item_number;
-  char *translation_domain;
+  Nation_type_id item_number = 0;
+  char *translation_domain = nullptr;
   struct name_translation adjective;
   struct name_translation noun_plural;
   char flag_graphic_str[MAX_LEN_NAME];
   char flag_graphic_alt[MAX_LEN_NAME];
-  struct nation_leader_list *leaders;
-  struct nation_style *style;
-  char *legend; // may be empty
+  struct nation_leader_list *leaders = nullptr;
+  struct nation_style *style = nullptr;
+  char *legend = nullptr; // may be empty
 
-  bool is_playable;
-  enum barbarian_type barb_type;
+  bool is_playable = true;
+  enum barbarian_type barb_type = NOT_A_BARBARIAN;
 
   // Sets which this nation is assigned to
   struct nation_set_list *sets;
@@ -92,15 +94,15 @@ struct nation_type {
   // Groups which this nation is assigned to
   struct nation_group_list *groups;
 
-  struct player *player; // Who's using the nation, or nullptr.
+  struct player *player = nullptr; // Who's using the nation, or nullptr.
 
   // Items given to this nation at game start.
   // (Only used in the client for documentation purposes.)
   int init_techs[MAX_NUM_TECH_LIST];
   int init_buildings[MAX_NUM_BUILDING_LIST];
-  struct government
-      *init_government; // use game default_government if nullptr
-  struct unit_type *init_units[MAX_NUM_UNIT_LIST];
+  government *init_government =
+      nullptr; // use game default_government if nullptr
+  std::array<unit_type *, MAX_NUM_UNIT_LIST> init_units = {nullptr};
 
   union {
     struct {

--- a/server/auth.cpp
+++ b/server/auth.cpp
@@ -35,11 +35,6 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 #define GUEST_NAME "guest"
 
 #define MIN_PASSWORD_LEN 6 // minimum length of password
-#define MIN_PASSWORD_CAPS                                                   \
-  0                         /* minimum number of capital letters required   \
-                             */
-#define MIN_PASSWORD_NUMS 0 // minimum number of numbers required
-
 #define MAX_AUTH_TRIES 3
 #define MAX_WAIT_TIME 300 // max time we'll wait on a password
 
@@ -295,8 +290,6 @@ static void get_unique_guest_name(char *name)
  */
 static bool is_good_password(const char *password, char *msg)
 {
-  int i, num_caps = 0, num_nums = 0;
-
   // check password length
   if (strlen(password) < MIN_PASSWORD_LEN) {
     fc_snprintf(msg, MAX_LEN_MSG,
@@ -306,34 +299,14 @@ static bool is_good_password(const char *password, char *msg)
     return false;
   }
 
-  fc_snprintf(msg, MAX_LEN_MSG,
-              _("The password must have at least %d capital letters, %d "
-                "numbers, and be at minimum %d [printable] characters long. "
-                "Try again."),
-              MIN_PASSWORD_CAPS, MIN_PASSWORD_NUMS, MIN_PASSWORD_LEN);
-
-  for (i = 0; i < qstrlen(password); i++) {
-    if (QChar::isUpper(password[i])) {
-      num_caps++;
-    }
-    if (QChar::isDigit(password[i])) {
-      num_nums++;
-    }
-  }
-
-  // check number of capital letters
-  if (num_caps < MIN_PASSWORD_CAPS) {
-    return false;
-  }
-
-  // check number of numbers
-  if (num_nums < MIN_PASSWORD_NUMS) {
-    return false;
-  }
-
   if (!is_ascii_name(password)) {
+    fc_snprintf(msg, MAX_LEN_MSG,
+                _("Your password contains illegal characters. Try again."));
     return false;
   }
+
+  // Make sure the message doesn't contain garbage.
+  msg[0] = '\0';
 
   return true;
 }

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -597,24 +597,20 @@ static bool lookup_building(struct section_file *file, const char *prefix,
    items). If the vector is not found and the required parameter is set,
    we report it as an error, otherwise we just punt.
  */
-static bool lookup_unit_list(struct section_file *file, const char *prefix,
-                             const char *entry, struct unit_type **output,
-                             const char *filename)
+static bool lookup_unit_list(
+    struct section_file *file, const char *prefix, const char *entry,
+    std::array<unit_type *, MAX_NUM_UNIT_LIST> &output, const char *filename)
 {
   const char **slist;
   size_t nval;
   int i;
   bool ok = true;
 
-  // pre-fill with nullptr:
-  for (i = 0; i < MAX_NUM_UNIT_LIST; i++) {
-    output[i] = nullptr;
-  }
+  output.fill(nullptr);
   slist = secfile_lookup_str_vec(file, &nval, "%s.%s", prefix, entry);
   if (nval == 0) {
     // 'No vector' is considered same as empty vector
     delete[] slist;
-    slist = nullptr;
     return true;
   }
   if (nval > MAX_NUM_UNIT_LIST) {
@@ -624,7 +620,6 @@ static bool lookup_unit_list(struct section_file *file, const char *prefix,
     ok = false;
   } else if (nval == 1 && strcmp(slist[0], "") == 0) {
     delete[] slist;
-    slist = nullptr;
     return true;
   }
   if (ok) {
@@ -8281,7 +8276,7 @@ static void send_ruleset_nations(struct conn_list *dest)
       }
     }
     packet.init_techs_count = i;
-    fc_assert(ARRAY_SIZE(packet.init_units) == ARRAY_SIZE(n.init_units));
+    fc_assert(ARRAY_SIZE(packet.init_units) == n.init_units.size());
     for (i = 0; i < MAX_NUM_UNIT_LIST; i++) {
       const struct unit_type *t = n.init_units[i];
       if (t) {

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -644,6 +644,7 @@ static bool manual_command(struct tag_types *tag_info)
       break;
 
     case MANUAL_COUNT:
+      Q_UNREACHABLE();
       break;
     } // switch
 

--- a/tools/ruleutil/rulesave.cpp
+++ b/tools/ruleutil/rulesave.cpp
@@ -284,17 +284,20 @@ static bool save_building_list(struct section_file *sfile, int *input,
    Save units vector. Input is nullptr terminated array of units
    to save.
  */
-static bool save_unit_list(struct section_file *sfile,
-                           struct unit_type **input, const char *path,
-                           const char *entry)
+static bool
+save_unit_list(struct section_file *sfile,
+               const std::array<unit_type *, MAX_NUM_UNIT_LIST> &input,
+               const char *path, const char *entry)
 {
   const char *unit_names[MAX_NUM_UNIT_LIST];
   int set_count;
-  int i;
 
   set_count = 0;
-  for (i = 0; i < MAX_NUM_UNIT_LIST && input[i] != nullptr; i++) {
-    unit_names[set_count++] = utype_rule_name(input[i]);
+  for (const auto &utype : input) {
+    if (utype == nullptr) {
+      break;
+    }
+    unit_names[set_count++] = utype_rule_name(utype);
   }
 
   if (set_count > 0) {


### PR DESCRIPTION
A handful of Coverity warnings popped up in the last month. This should clear them all.

Special thanks to Synopsis for 55336e7b7bc37cb046c78a259fa6a99dbb985266: *The client was crashing when Ctrl+Alt+clicking outside of the map (this shortcut is bound to the "create link" action).*