### PR TITLE
Allow implicit float to int conversions in sol2

### DIFF
--- a/dependencies/sol2/CMakeLists.txt
+++ b/dependencies/sol2/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_library(sol2 INTERFACE)
-target_compile_definitions(sol2 INTERFACE SOL_ALL_SAFETIES_ON=1)
+target_compile_definitions(sol2 INTERFACE
+                           SOL_ALL_SAFETIES_ON=1
+                           # Allow float -> int conversions
+                           SOL_NO_CHECK_NUMBER_PRECISION=1)
 target_include_directories(sol2 INTERFACE "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
tolua was implicitly converting floats to ints, but sol2 chokes on this. For
backward compatibility and to fix our own rulesets, disable this check in sol.

Closes #1161.