### PR TITLE
Scroll the messages window per pixel

### DIFF
--- a/client/messagewin.cpp
+++ b/client/messagewin.cpp
@@ -52,6 +52,7 @@ message_widget::message_widget(QWidget *parent)
   mesg_table = new QListWidget;
   mesg_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
   mesg_table->setSelectionMode(QAbstractItemView::SingleSelection);
+  mesg_table->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
   mesg_table->setTextElideMode(Qt::ElideNone);
   mesg_table->setWordWrap(true);
   layout->addWidget(mesg_table, 1, 0, 1, 3);


### PR DESCRIPTION
Scrolling per item results in jumpy behavior, especially with messages of
varying height. This in turn results in scrolling being hard on imprecise
devices that generate many scroll events, like touchpads.

This was found to be the underlying issue in a request to add arrows to scroll
bars, #1162.

Closes #1162.