### PR TITLE
Use std::vector for the list of focused units

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -656,9 +656,6 @@ void unit_list_item::create_menu()
 
   m_menu = new QMenu;
 
-  auto *units = unit_list_new();
-  unit_list_append(units, m_unit);
-
   auto *activate_and_close_action = new QAction(_("Activate unit"), this);
   connect(activate_and_close_action, &QAction::triggered, this,
           &unit_list_item::activate_and_close_dialog);
@@ -693,20 +690,20 @@ void unit_list_item::create_menu()
     m_menu->addAction(change_homecity_action);
   }
 
-  if (units_can_load(units)) {
+  if (units_can_load({m_unit})) {
     auto *load_action = new QAction(_("Load"), this);
     connect(load_action, &QAction::triggered, this, &unit_list_item::load);
     m_menu->addAction(load_action);
   }
 
-  if (units_can_unload(units)) {
+  if (units_can_unload({m_unit})) {
     auto *unload_action = new QAction(_("Unload"), this);
     connect(unload_action, &QAction::triggered, this,
             &unit_list_item::unload);
     m_menu->addAction(unload_action);
   }
 
-  if (units_are_occupied(units)) {
+  if (units_are_occupied({m_unit})) {
     auto *unload_all_action =
         new QAction(_("Unload All From Transporter"), this);
     connect(unload_all_action, &QAction::triggered, this,
@@ -714,14 +711,12 @@ void unit_list_item::create_menu()
     m_menu->addAction(unload_all_action);
   }
 
-  if (units_can_upgrade(units)) {
+  if (units_can_upgrade({m_unit})) {
     auto *upgrade_action = new QAction(_("Upgrade Unit"), this);
     connect(upgrade_action, &QAction::triggered, this,
             &unit_list_item::upgrade);
     m_menu->addAction(upgrade_action);
   }
-
-  unit_list_destroy(units);
 }
 
 /**
@@ -738,10 +733,7 @@ bool unit_list_item::can_issue_orders() const
 void unit_list_item::disband()
 {
   if (can_issue_orders()) {
-    auto *units = unit_list_new();
-    unit_list_append(units, m_unit);
-    popup_disband_dialog(units);
-    unit_list_destroy(units);
+    popup_disband_dialog({m_unit});
   }
 }
 
@@ -781,10 +773,7 @@ void unit_list_item::unload_all()
 void unit_list_item::upgrade()
 {
   if (can_issue_orders()) {
-    auto *units = unit_list_new();
-    unit_list_append(units, m_unit);
-    popup_upgrade_dialog(units);
-    unit_list_destroy(units);
+    popup_upgrade_dialog({m_unit});
   }
 }
 

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -916,7 +916,7 @@ void set_client_state(enum client_states newstate)
 
     update_info_label();
     unit_focus_update();
-    update_unit_info_label(nullptr);
+    update_unit_info_label({});
 
     break;
   }

--- a/client/climisc.cpp
+++ b/client/climisc.cpp
@@ -17,6 +17,7 @@
 ***********************************************************************/
 
 #include <QBitArray>
+#include <algorithm>
 #include <cstdarg>
 #include <cstdlib>
 #include <cstring>
@@ -1054,19 +1055,13 @@ void cityrep_buy(struct city *pcity)
 /**
    Returns TRUE if any of the units can do the connect activity.
  */
-bool can_units_do_connect(struct unit_list *punits,
+bool can_units_do_connect(const std::vector<unit *> &units,
                           enum unit_activity activity,
                           struct extra_type *tgt)
 {
-  unit_list_iterate(punits, punit)
-  {
-    if (can_unit_do_connect(punit, activity, tgt)) {
-      return true;
-    }
-  }
-  unit_list_iterate_end;
-
-  return false;
+  return std::any_of(units.begin(), units.end(), [&](const auto unit) {
+    return can_unit_do_connect(unit, activity, tgt);
+  });
 }
 
 /**

--- a/client/climisc.h
+++ b/client/climisc.h
@@ -95,7 +95,7 @@ struct city *get_nearest_city(const struct unit *punit, int *sq_dist);
 
 void cityrep_buy(struct city *pcity);
 
-bool can_units_do_connect(struct unit_list *punits,
+bool can_units_do_connect(const std::vector<unit *> &units,
                           enum unit_activity activity,
                           struct extra_type *tgt);
 

--- a/client/control.h
+++ b/client/control.h
@@ -68,7 +68,8 @@ void do_unit_connect(struct tile *ptile, enum unit_activity activity,
 void do_map_click(struct tile *ptile, enum quickselect_type qtype);
 void control_mouse_cursor(struct tile *ptile);
 
-void set_hover_state(struct unit_list *punits, enum cursor_hover_state state,
+void set_hover_state(const std::vector<unit *> &units,
+                     enum cursor_hover_state state,
                      enum unit_activity connect_activity,
                      struct extra_type *tgt, int last_tgt,
                      int goto_last_sub_tgt, action_id goto_last_action,
@@ -98,7 +99,7 @@ void request_unit_fortify(struct unit *punit);
 void request_unit_goto(enum unit_orders last_order, action_id act_id,
                        int sub_tgt_id);
 void request_unit_move_done();
-void request_unit_paradrop(struct unit_list *punits);
+void request_unit_paradrop(const std::vector<unit *> &units);
 void request_unit_patrol();
 void request_unit_pillage(struct unit *punit);
 void request_unit_sentry(struct unit *punit);
@@ -107,7 +108,7 @@ void request_unit_airlift(struct unit *punit, struct city *pcity);
 void request_units_return();
 void request_unit_upgrade(struct unit *punit);
 void request_unit_convert(struct unit *punit);
-void request_units_wait(struct unit_list *punits);
+void request_units_wait(const std::vector<unit *> &units);
 void request_unit_wakeup(struct unit *punit);
 
 enum unit_select_type_mode { SELTYPE_SINGLE, SELTYPE_SAME, SELTYPE_ALL };
@@ -118,7 +119,7 @@ enum unit_select_location_mode {
   SELLOC_WORLD // World.
 };
 
-void request_unit_select(struct unit_list *punits,
+void request_unit_select(const std::vector<unit *> &punits,
                          enum unit_select_type_mode seltype,
                          enum unit_select_location_mode selloc);
 
@@ -142,7 +143,7 @@ void clear_unit_orders(struct unit *punit);
 bool unit_is_in_focus(const struct unit *punit);
 struct unit *get_focus_unit_on_tile(const struct tile *ptile);
 struct unit *head_of_units_in_focus();
-struct unit_list *get_units_in_focus();
+std::vector<unit *> &get_units_in_focus();
 int get_num_units_in_focus();
 
 void unit_focus_set(struct unit *punit);
@@ -154,7 +155,7 @@ void unit_focus_advance();
 void unit_focus_update();
 
 void auto_center_on_focus_unit();
-void update_unit_pix_label(struct unit_list *punitlist);
+void update_unit_pix_label(const std::vector<unit *> &units);
 
 unit *find_visible_unit(const ::tile *ptile);
 void set_units_in_combat(struct unit *pattacker, struct unit *pdefender);

--- a/client/dialogs.h
+++ b/client/dialogs.h
@@ -88,10 +88,11 @@ protected:
 ***************************************************************************/
 class disband_box : public hud_message_box {
   Q_OBJECT
-  struct unit_list *cpunits;
+  const std::vector<unit *> cpunits;
 
 public:
-  explicit disband_box(struct unit_list *punits, QWidget *parent = 0);
+  explicit disband_box(const std::vector<unit *> &punits,
+                       QWidget *parent = 0);
   ~disband_box() override;
 private slots:
   void disband_clicked();
@@ -219,7 +220,7 @@ private slots:
 
 void popup_revolution_dialog(struct government *government = nullptr);
 void revolution_response(struct government *government);
-void popup_upgrade_dialog(struct unit_list *punits);
-void popup_disband_dialog(struct unit_list *punits);
+void popup_upgrade_dialog(const std::vector<unit *> &punits);
+void popup_disband_dialog(const std::vector<unit *> &punits);
 bool try_default_unit_action(QVariant q1, QVariant q2);
 bool try_default_city_action(QVariant q1, QVariant q2);

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -241,7 +241,7 @@ static void goto_fill_parameter_base(struct pf_parameter *parameter,
    Enter the goto state: activate, prepare PF-template and add the
    initial part.
  */
-void enter_goto_state(struct unit_list *punits)
+void enter_goto_state(const std::vector<unit *> &units)
 {
   fc_assert_ret(!goto_is_active());
 
@@ -249,13 +249,11 @@ void enter_goto_state(struct unit_list *punits)
   cancel_selection_rectangle();
 
   // Initialize path finders
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     // This calls path_finder::path_finder(punit) behind the scenes
     // Need to do this because path_finder isn't copy-assignable
     goto_finders.emplace(punit->id, punit);
   }
-  unit_list_iterate_end;
 }
 
 /**

--- a/client/goto.h
+++ b/client/goto.h
@@ -29,7 +29,7 @@ enum goto_tile_state {
 void init_client_goto();
 void free_client_goto();
 
-void enter_goto_state(struct unit_list *punits);
+void enter_goto_state(const std::vector<unit *> &units);
 void exit_goto_state();
 
 void goto_unit_killed(struct unit *punit);

--- a/client/gotodlg.cpp
+++ b/client/gotodlg.cpp
@@ -147,14 +147,12 @@ void goto_dialog::item_selected(const QItemSelection &sl,
   dest = game_city_by_number(city_id);
   center_tile_mapcanvas(city_tile(dest));
   can_airlift = false;
-  unit_list_iterate(get_units_in_focus(), punit)
-  {
+  for (const auto punit : get_units_in_focus()) {
     if (unit_can_airlift_to(punit, dest)) {
       can_airlift = true;
       break;
     }
   }
-  unit_list_iterate_end;
 
   if (can_airlift) {
     airlift_city->setEnabled(true);
@@ -273,13 +271,11 @@ void goto_dialog::airlift_to()
   pdest = game_city_by_number(
       goto_tab->item(goto_tab->currentRow(), 0)->data(Qt::UserRole).toInt());
   if (pdest) {
-    unit_list_iterate(get_units_in_focus(), punit)
-    {
+    for (const auto punit : get_units_in_focus()) {
       if (unit_can_airlift_to(punit, pdest)) {
         request_unit_airlift(punit, pdest);
       }
     }
-    unit_list_iterate_end;
   }
 }
 
@@ -297,11 +293,9 @@ void goto_dialog::go_to_city()
   pdest = game_city_by_number(
       goto_tab->item(goto_tab->currentRow(), 0)->data(Qt::UserRole).toInt());
   if (pdest) {
-    unit_list_iterate(get_units_in_focus(), punit)
-    {
+    for (const auto punit : get_units_in_focus()) {
       send_goto_tile(punit, pdest->tile);
     }
-    unit_list_iterate_end;
   }
 }
 

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -647,8 +647,7 @@ void hud_units::update_actions(unit_list *punits)
                        QString::number(unit_type_get(punit)->hp));
   num = unit_list_size(punit->tile->units);
   snum = QString::number(unit_list_size(punit->tile->units) - 1);
-  if (unit_list_size(get_units_in_focus()) > 1) {
-    int n = unit_list_size(get_units_in_focus());
+  if (const auto n = get_units_in_focus().size(); n > 1) {
     // TRANS: preserve leading space; always at least 2
     text_str =
         text_str

--- a/client/include/dialogs_g.h
+++ b/client/include/dialogs_g.h
@@ -65,8 +65,6 @@ void popup_bribe_dialog(struct unit *actor, struct unit *punit, int cost,
 void popup_sabotage_dialog(struct unit *actor, struct city *pcity,
                            const struct action *paction);
 void popup_pillage_dialog(struct unit *punit, bv_extras extras);
-void popup_upgrade_dialog(struct unit_list *punits);
-void popup_disband_dialog(struct unit_list *punits);
 void popup_tileset_suggestion_dialog(void);
 void popup_soundset_suggestion_dialog(void);
 void popup_musicset_suggestion_dialog(void);

--- a/client/include/mapview_g.h
+++ b/client/include/mapview_g.h
@@ -23,7 +23,7 @@
 #include "mapview_common.h"
 
 void update_info_label(void);
-void update_unit_info_label(struct unit_list *punitlist);
+void update_unit_info_label(const std::vector<unit *> &unit_list);
 void update_mouse_cursor(enum cursor_type new_cursor_type);
 void update_turn_done_button(bool do_restore);
 void update_city_descriptions(void);

--- a/client/mapctrl_common.cpp
+++ b/client/mapctrl_common.cpp
@@ -348,7 +348,6 @@ void update_turn_done_button_state()
 void update_line(int canvas_x, int canvas_y)
 {
   struct tile *ptile;
-  struct unit_list *punits;
 
   switch (hover_state) {
   case HOVER_GOTO:
@@ -360,11 +359,10 @@ void update_line(int canvas_x, int canvas_y)
     break;
   case HOVER_GOTO_SEL_TGT:
     ptile = canvas_pos_to_tile(canvas_x, canvas_y);
-    punits = get_units_in_focus();
     fc_assert_ret(ptile);
-    set_hover_state(punits, hover_state, connect_activity, connect_tgt,
-                    ptile->index, goto_last_sub_tgt, goto_last_action,
-                    goto_last_order);
+    set_hover_state(get_units_in_focus(), hover_state, connect_activity,
+                    connect_tgt, ptile->index, goto_last_sub_tgt,
+                    goto_last_action, goto_last_order);
     break;
   case HOVER_NONE:
   case HOVER_PARADROP:

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -247,8 +247,8 @@ void map_view::show_debugger()
     connect(m_debugger, &freeciv::tileset_debugger::tile_picking_requested,
             [](bool active) {
               if (active) {
-                set_hover_state(nullptr, HOVER_DEBUG_TILE, ACTIVITY_LAST,
-                                nullptr, NO_TARGET, NO_TARGET, ACTION_NONE,
+                set_hover_state({}, HOVER_DEBUG_TILE, ACTIVITY_LAST, nullptr,
+                                NO_TARGET, NO_TARGET, ACTION_NONE,
                                 ORDER_LAST);
               } else if (!active && hover_state == HOVER_DEBUG_TILE) {
                 clear_hover_state();
@@ -445,7 +445,7 @@ void map_view::find_place(int pos_x, int pos_y, int &w, int &h, int wdth,
    prompt etc).  And it may call update_unit_pix_label() to update the
    icons for units on this tile.
  */
-void update_unit_info_label(struct unit_list *punitlist)
+void update_unit_info_label(const std::vector<unit *> &unit_list)
 {
   if (queen()->unitinfo_wdg->isVisible()) {
     queen()->unitinfo_wdg->update_actions(nullptr);

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -583,7 +583,6 @@ void handle_city_info(const struct packet_city_info *packet)
   bool shield_stock_changed = false;
   bool production_changed = false;
   bool trade_routes_changed = false;
-  struct unit_list *pfocus_units = get_units_in_focus();
   struct city *pcity = game_city_by_number(packet->id);
   struct tile_list *worked_tiles = nullptr;
   struct tile *pcenter = index_to_tile(&(wld.map), packet->tile);
@@ -878,14 +877,12 @@ void handle_city_info(const struct packet_city_info *packet)
 
   // Update focus unit info label if necessary.
   if (name_changed) {
-    unit_list_iterate(pfocus_units, pfocus_unit)
-    {
+    for (const auto pfocus_unit : get_units_in_focus()) {
       if (pfocus_unit->homecity == pcity->id) {
-        update_unit_info_label(pfocus_units);
+        update_unit_info_label(get_units_in_focus());
         break;
       }
     }
-    unit_list_iterate_end;
   }
 
   // Update the science dialog if necessary.

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -317,8 +317,7 @@ const QString popup_info_text(struct tile *ptile)
              + qendl();
     }
 
-    unit_list_iterate(get_units_in_focus(), pfocus_unit)
-    {
+    for (const auto &pfocus_unit : get_units_in_focus()) {
       struct city *hcity = game_city_by_number(pfocus_unit->homecity);
 
       if (utype_can_do_action(unit_type_get(pfocus_unit), ACTION_TRADE_ROUTE)
@@ -332,7 +331,6 @@ const QString popup_info_text(struct tile *ptile)
                + qendl();
       }
     }
-    unit_list_iterate_end;
   }
   {
     const char *infratext = get_infrastructure_text(ptile->extras);
@@ -437,8 +435,7 @@ const QString popup_info_text(struct tile *ptile)
       }
     }
 
-    unit_list_iterate(get_units_in_focus(), pfocus_unit)
-    {
+    for (const auto pfocus_unit : get_units_in_focus()) {
       int att_chance = FC_INFINITY, def_chance = FC_INFINITY;
       bool found = false;
 
@@ -465,7 +462,6 @@ const QString popup_info_text(struct tile *ptile)
                + qendl();
       }
     }
-    unit_list_iterate_end;
 
     /* TRANS: A is attack power, D is defense power, FP is firepower,
      * HP is hitpoints (current and max). */
@@ -602,7 +598,7 @@ const QString unit_description(struct unit *punit)
    for those that can.
    Returns nullptr if an airlift is not possible for any of the units.
  */
-const QString get_airlift_text(const struct unit_list *punits,
+const QString get_airlift_text(const std::vector<unit *> &units,
                                const struct city *pdest)
 {
   QString str;
@@ -615,8 +611,7 @@ const QString get_airlift_text(const struct unit_list *punits,
   } best = AL_IMPOSSIBLE;
   int cur = 0, max = 0;
 
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     enum texttype tthis = AL_IMPOSSIBLE;
     enum unit_airlift_result result;
 
@@ -684,7 +679,6 @@ const QString get_airlift_text(const struct unit_list *punits,
     // Now take the most optimistic view.
     best = MAX(best, tthis);
   }
-  unit_list_iterate_end;
 
   switch (best) {
   case AL_IMPOSSIBLE:
@@ -1115,20 +1109,19 @@ const QString get_info_label_text_popup()
    Returns TRUE iff any units can be upgraded.
  */
 bool get_units_upgrade_info(char *buf, size_t bufsz,
-                            struct unit_list *punits)
+                            const std::vector<unit *> &punits)
 {
-  if (unit_list_size(punits) == 0) {
+  if (punits.empty()) {
     fc_snprintf(buf, bufsz, _("No units to upgrade!"));
     return false;
-  } else if (unit_list_size(punits) == 1) {
-    return (UU_OK == unit_upgrade_info(unit_list_front(punits), buf, bufsz));
+  } else if (punits.size() == 1) {
+    return (UU_OK == unit_upgrade_info(punits.front(), buf, bufsz));
   } else {
     int upgrade_cost = 0;
     int num_upgraded = 0;
     int min_upgrade_cost = FC_INFINITY;
 
-    unit_list_iterate(punits, punit)
-    {
+    for (const auto punit : punits) {
       if (unit_owner(punit) == client_player()
           && UU_OK == unit_upgrade_test(punit, false)) {
         const struct unit_type *from_unittype = unit_type_get(punit);
@@ -1142,7 +1135,6 @@ bool get_units_upgrade_info(char *buf, size_t bufsz,
         min_upgrade_cost = MIN(min_upgrade_cost, cost);
       }
     }
-    unit_list_iterate_end;
     if (num_upgraded == 0) {
       fc_snprintf(buf, bufsz, _("None of these units may be upgraded."));
       return false;

--- a/client/text.h
+++ b/client/text.h
@@ -10,6 +10,12 @@
 **************************************************************************/
 #pragma once
 
+#include "fc_types.h"
+
+#include <QString>
+
+#include <vector>
+
 struct player_spaceship;
 
 /****************************************************************************
@@ -19,7 +25,7 @@ const QString get_tile_output_text(const struct tile *ptile);
 const QString popup_info_text(struct tile *ptile);
 const QString get_nearest_city_text(struct city *pcity, int sq_dist);
 const QString unit_description(struct unit *punit);
-const QString get_airlift_text(const struct unit_list *punits,
+const QString get_airlift_text(const std::vector<unit *> &units,
                                const struct city *pdest);
 const QString science_dialog_text();
 const QString get_science_target_text(double *percent);
@@ -27,7 +33,7 @@ const QString get_science_goal_text(Tech_type_id goal);
 const QString get_info_label_text(bool moreinfo);
 const QString get_info_label_text_popup();
 bool get_units_upgrade_info(char *buf, size_t bufsz,
-                            struct unit_list *punits);
+                            const std::vector<unit *> &punits);
 const QString get_spaceship_descr(struct player_spaceship *pship);
 QString get_score_text(const struct player *pplayer);
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -4238,7 +4238,6 @@ static void fill_grid_sprite_array(const struct tileset *t,
     bool known[NUM_EDGE_TILES], city[NUM_EDGE_TILES];
     bool unit[NUM_EDGE_TILES], worked[NUM_EDGE_TILES];
     int i;
-    struct unit_list *pfocus_units = get_units_in_focus();
 
     for (i = 0; i < NUM_EDGE_TILES; i++) {
       int dummy_x, dummy_y;
@@ -4248,8 +4247,7 @@ static void fill_grid_sprite_array(const struct tileset *t,
       known[i] = tile && client_tile_get_known(tile) != TILE_UNKNOWN;
       unit[i] = false;
       if (tile && !citymode) {
-        unit_list_iterate(pfocus_units, pfocus_unit)
-        {
+        for (const auto pfocus_unit : get_units_in_focus()) {
           if (unit_drawn_with_city_outline(pfocus_unit, false)) {
             struct tile *utile = unit_tile(pfocus_unit);
             int radius = game.info.init_city_radius_sq
@@ -4265,7 +4263,6 @@ static void fill_grid_sprite_array(const struct tileset *t,
             }
           }
         }
-        unit_list_iterate_end;
       }
       worked[i] = false;
 
@@ -4342,16 +4339,12 @@ static void fill_grid_sprite_array(const struct tileset *t,
 
     if (gui_options.draw_native && citymode == nullptr) {
       bool native = true;
-      struct unit_list *pfocus_units = get_units_in_focus();
-
-      unit_list_iterate(pfocus_units, pfocus)
-      {
+      for (const auto pfocus : get_units_in_focus()) {
         if (!is_native_tile(unit_type_get(pfocus), ptile)) {
           native = false;
           break;
         }
       }
-      unit_list_iterate_end;
 
       if (!native) {
         if (t->sprites.grid.nonnative != nullptr) {

--- a/common/unitlist.cpp
+++ b/common/unitlist.cpp
@@ -86,16 +86,14 @@ void unit_list_sort_ord_city(struct unit_list *punitlist)
 /**
    Return TRUE if the function returns true for any of the units.
  */
-bool can_units_do(const struct unit_list *punits,
+bool can_units_do(const std::vector<unit *> &units,
                   bool(can_fn)(const struct unit *punit))
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (can_fn(punit)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -103,20 +101,18 @@ bool can_units_do(const struct unit_list *punits,
 /**
    Returns TRUE if any of the units can do the activity.
  */
-bool can_units_do_activity(const struct unit_list *punits,
+bool can_units_do_activity(const std::vector<unit *> &units,
                            enum unit_activity activity)
 {
   // Make sure nobody uses these old activities any more
   fc_assert_ret_val(
       activity != ACTIVITY_FORTRESS && activity != ACTIVITY_AIRBASE, false);
 
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (can_unit_do_activity(punit, activity)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -124,17 +120,15 @@ bool can_units_do_activity(const struct unit_list *punits,
 /**
    Returns TRUE if any of the units can do the targeted activity.
  */
-bool can_units_do_activity_targeted(const struct unit_list *punits,
+bool can_units_do_activity_targeted(const std::vector<unit *> &units,
                                     enum unit_activity activity,
                                     struct extra_type *pextra)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (can_unit_do_activity_targeted(punit, activity, pextra)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -142,10 +136,9 @@ bool can_units_do_activity_targeted(const struct unit_list *punits,
 /**
    Returns TRUE if any of the units can build any road.
  */
-bool can_units_do_any_road(const struct unit_list *punits)
+bool can_units_do_any_road(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     extra_type_by_cause_iterate(EC_ROAD, pextra)
     {
       struct road_type *proad = extra_road_get(pextra);
@@ -156,7 +149,6 @@ bool can_units_do_any_road(const struct unit_list *punits)
     }
     extra_type_by_cause_iterate_end;
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -164,11 +156,10 @@ bool can_units_do_any_road(const struct unit_list *punits)
 /**
    Returns TRUE if any of the units can build base with given gui_type.
  */
-bool can_units_do_base_gui(const struct unit_list *punits,
+bool can_units_do_base_gui(const std::vector<unit *> &units,
                            enum base_gui_type base_gui)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     struct base_type *pbase =
         get_base_by_gui_type(base_gui, punit, unit_tile(punit));
 
@@ -177,7 +168,6 @@ bool can_units_do_base_gui(const struct unit_list *punits,
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -188,16 +178,14 @@ bool can_units_do_base_gui(const struct unit_list *punits,
    If has_flag is false, returns true iff any of the units don't have the
    flag.
  */
-bool units_have_type_flag(const struct unit_list *punits,
+bool units_have_type_flag(const std::vector<unit *> &units,
                           enum unit_type_flag_id flag, bool has_flag)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (EQ(has_flag, unit_has_type_flag(punit, flag))) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -205,19 +193,17 @@ bool units_have_type_flag(const struct unit_list *punits,
 /**
    Does the list contain any cityfounder units
  */
-bool units_contain_cityfounder(const struct unit_list *punits)
+bool units_contain_cityfounder(const std::vector<unit *> &units)
 {
   if (game.scenario.prevent_new_cities) {
     return false;
   }
 
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (EQ(true, unit_can_do_action(punit, ACTION_FOUND_CITY))) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -229,16 +215,14 @@ bool units_contain_cityfounder(const struct unit_list *punits)
    If has_flag is false, returns true iff any of the units are unable do
    the specified action.
  */
-bool units_can_do_action(const struct unit_list *punits, action_id act_id,
+bool units_can_do_action(const std::vector<unit *> &units, action_id act_id,
                          bool can_do)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (EQ(can_do, unit_can_do_action(punit, act_id))) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -246,15 +230,13 @@ bool units_can_do_action(const struct unit_list *punits, action_id act_id,
 /**
    Return TRUE iff any of the units is a transporter that is occupied.
  */
-bool units_are_occupied(const struct unit_list *punits)
+bool units_are_occupied(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (get_transporter_occupancy(punit) > 0) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -262,15 +244,13 @@ bool units_are_occupied(const struct unit_list *punits)
 /**
    Returns TRUE iff any of these units can load.
  */
-bool units_can_load(const struct unit_list *punits)
+bool units_can_load(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (unit_can_load(punit)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -278,17 +258,15 @@ bool units_can_load(const struct unit_list *punits)
 /**
    Return TRUE iff any of these units can unload.
  */
-bool units_can_unload(const struct unit_list *punits)
+bool units_can_unload(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (unit_transported(punit)
         && can_unit_unload(punit, unit_transport_get(punit))
         && can_unit_exist_at_tile(&(wld.map), punit, unit_tile(punit))) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -297,16 +275,14 @@ bool units_can_unload(const struct unit_list *punits)
    Return TRUE iff any of the units' tiles have the activity running
    on them.
  */
-bool units_have_activity_on_tile(const struct unit_list *punits,
+bool units_have_activity_on_tile(const std::vector<unit *> &units,
                                  enum unit_activity activity)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (is_unit_activity_on_tile(activity, unit_tile(punit))) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -315,15 +291,13 @@ bool units_have_activity_on_tile(const struct unit_list *punits,
    Return TRUE iff any of the units can be upgraded to another unit type
    (for money)
  */
-bool units_can_upgrade(const struct unit_list *punits)
+bool units_can_upgrade(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (UU_OK == unit_upgrade_test(punit, false)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
@@ -331,39 +305,35 @@ bool units_can_upgrade(const struct unit_list *punits)
 /**
    Return TRUE iff any of the units can convert to another unit type
  */
-bool units_can_convert(const struct unit_list *punits)
+bool units_can_convert(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (utype_can_do_action(unit_type_get(punit), ACTION_CONVERT)
         && unit_can_convert(punit)) {
       return true;
     }
   }
-  unit_list_iterate_end;
 
   return false;
 }
 
 // Return TRUE if any of the units is in city
-bool any_unit_in_city(const struct unit_list *punits)
+bool any_unit_in_city(const std::vector<unit *> &units)
 {
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (tile_city(unit_tile(punit))) {
       return true;
     }
   }
-  unit_list_iterate_end;
+
   return false;
 }
 
-bool units_on_the_same_tile(const struct unit_list *punits)
+bool units_on_the_same_tile(const std::vector<unit *> &units)
 {
   struct tile *ptile = nullptr;
 
-  unit_list_iterate(punits, punit)
-  {
+  for (const auto punit : units) {
     if (!ptile) {
       ptile = punit->tile;
     }
@@ -371,6 +341,6 @@ bool units_on_the_same_tile(const struct unit_list *punits)
       return false;
     }
   }
-  unit_list_iterate_end;
+
   return true;
 }

--- a/common/unitlist.h
+++ b/common/unitlist.h
@@ -15,6 +15,8 @@
 #include "unit.h"     // for diplomat_actions
 #include "unittype.h" // for unit_type_flag_id
 
+#include <vector>
+
 // get 'struct unit_list' and related functions:
 #define SPECLIST_TAG unit
 #define SPECLIST_TYPE struct unit
@@ -60,28 +62,28 @@ struct unit *unit_list_find(const struct unit_list *punitlist, int unit_id);
 void unit_list_sort_ord_map(struct unit_list *punitlist);
 void unit_list_sort_ord_city(struct unit_list *punitlist);
 
-bool can_units_do(const struct unit_list *punits,
+bool can_units_do(const std::vector<unit *> &units,
                   bool(can_fn)(const struct unit *punit));
-bool can_units_do_activity(const struct unit_list *punits,
+bool can_units_do_activity(const std::vector<unit *> &units,
                            enum unit_activity activity);
-bool can_units_do_activity_targeted(const struct unit_list *punits,
+bool can_units_do_activity_targeted(const std::vector<unit *> &units,
                                     enum unit_activity activity,
                                     struct extra_type *pextra);
-bool can_units_do_any_road(const struct unit_list *punits);
-bool can_units_do_base_gui(const struct unit_list *punits,
+bool can_units_do_any_road(const std::vector<unit *> &units);
+bool can_units_do_base_gui(const std::vector<unit *> &units,
                            enum base_gui_type base_gui);
-bool units_have_type_flag(const struct unit_list *punits,
+bool units_have_type_flag(const std::vector<unit *> &units,
                           enum unit_type_flag_id flag, bool has_flag);
-bool units_contain_cityfounder(const struct unit_list *punits);
-bool units_can_do_action(const struct unit_list *punits, action_id act_id,
+bool units_contain_cityfounder(const std::vector<unit *> &units);
+bool units_can_do_action(const std::vector<unit *> &units, action_id act_id,
                          bool can_do);
-bool units_are_occupied(const struct unit_list *punits);
-bool units_can_load(const struct unit_list *punits);
-bool units_can_unload(const struct unit_list *punits);
-bool units_have_activity_on_tile(const struct unit_list *punits,
+bool units_are_occupied(const std::vector<unit *> &units);
+bool units_can_load(const std::vector<unit *> &units);
+bool units_can_unload(const std::vector<unit *> &units);
+bool units_have_activity_on_tile(const std::vector<unit *> &units,
                                  enum unit_activity activity);
 
-bool units_can_upgrade(const struct unit_list *punits);
-bool units_can_convert(const struct unit_list *punits);
-bool any_unit_in_city(const struct unit_list *punits);
-bool units_on_the_same_tile(const struct unit_list *punits);
+bool units_can_upgrade(const std::vector<unit *> &units);
+bool units_can_convert(const std::vector<unit *> &units);
+bool any_unit_in_city(const std::vector<unit *> &units);
+bool units_on_the_same_tile(const std::vector<unit *> &units);


### PR DESCRIPTION
I would like to have some decent container to use in #805 (if several units are
selected, I want the right click menu to apply to all of them, which will
require a container).

Change focus_units (=get_units_in_focus()) to be a std::vector<unit *>. This
has implications in a lot of places, which are also modified to use
std::vector.

**Test:**
Do everything you an with your units.