### PR TITLE
Prevent an assertion when observing 

### DIFF
--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -945,7 +945,7 @@ int unit_actions::update_actions()
 {
   current_unit = head_of_units_in_focus();
 
-  if (current_unit == nullptr) {
+  if (current_unit == nullptr || client.conn.playing == nullptr) {
     clear_layout();
     hide();
     return 0;

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -556,7 +556,7 @@ void hud_units::moveEvent(QMoveEvent *event)
 /**
    Update possible action for given units
  */
-void hud_units::update_actions(unit_list *punits)
+void hud_units::update_actions()
 {
   int num;
   int wwidth;

--- a/client/hudwidget.h
+++ b/client/hudwidget.h
@@ -211,7 +211,7 @@ class hud_units : public QFrame {
 public:
   hud_units(QWidget *parent);
   ~hud_units() override;
-  void update_actions(unit_list *punits);
+  void update_actions();
 
 protected:
   void moveEvent(QMoveEvent *event) override;

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -446,7 +446,7 @@ void map_view::find_place(int pos_x, int pos_y, int &w, int &h, int wdth,
 void update_unit_info_label(const std::vector<unit *> &unit_list)
 {
   if (queen()->unitinfo_wdg->isVisible()) {
-    queen()->unitinfo_wdg->update_actions(nullptr);
+    queen()->unitinfo_wdg->update_actions();
   }
 }
 

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -121,7 +121,7 @@ void real_menus_update(void)
       king()->menu_bar->update_bases_menu();
       gov_menu::update_all();
       go_act_menu::update_all();
-      queen()->unitinfo_wdg->update_actions(nullptr);
+      queen()->unitinfo_wdg->update_actions();
     }
   } else {
     king()->menuBar()->setVisible(false);

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -542,7 +542,7 @@ bool fc_game_tab_widget::event(QEvent *event)
           get_turn_done_button_state());
       queen()->mapview_wdg->resize(size.width(), size.height());
       queen()->city_overlay->resize(queen()->mapview_wdg->size());
-      queen()->unitinfo_wdg->update_actions(nullptr);
+      queen()->unitinfo_wdg->update_actions();
       queen()->units->update_units(false);
     }
 


### PR DESCRIPTION
When, after starting a game, the user does /observe to his own player,
client.conn.playing is null for a brief period of time. While it's null, one
can't evaluate whether actions are valid or not because we don't know who we
are playing. This was triggering an assertion in update_actions(); just skip it
when we're not playing anyone (same as when we don't have a focused unit).

Closes #457.