### PR TITLE
Add the city size and citizen happiness next to other city stats

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -938,8 +938,6 @@ void city_label::set_city(city *pciti) { pcity = pciti; }
 
 city_info::city_info(QWidget *parent) : QWidget(parent)
 {
-  int iter;
-  QLabel *ql;
   QStringList info_list;
 
   QGridLayout *info_grid_layout = new QGridLayout();
@@ -953,16 +951,17 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
   info_grid_layout->setSpacing(0);
   info_grid_layout->setContentsMargins(0, 0, 0, 0);
 
-  fc_assert(info_list.count() == NUM_INFO_FIELDS);
-  for (iter = 0; iter < NUM_INFO_FIELDS; iter++) {
-    ql = new QLabel(info_list[iter], this);
+  for (int i = 0; i < info_list.size(); i++) {
+    auto ql = new QLabel(info_list[i], this);
     ql->setFont(small_font);
     ql->setProperty(fonts::notify_label, "true");
-    info_grid_layout->addWidget(ql, iter, 0);
-    qlt[iter] = new QLabel(this);
-    qlt[iter]->setFont(small_font);
-    qlt[iter]->setProperty(fonts::notify_label, "true");
-    info_grid_layout->addWidget(qlt[iter], iter, 1);
+    info_grid_layout->addWidget(ql, i, 0);
+
+    ql = new QLabel(this);
+    ql->setFont(small_font);
+    ql->setProperty(fonts::notify_label, "true");
+    info_grid_layout->addWidget(ql, i, 1);
+    m_labels.push_back(ql);
   }
   setLayout(info_grid_layout);
 }
@@ -971,7 +970,7 @@ void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
 {
   int illness = 0;
   char buffer[512];
-  char buf[2 * NUM_INFO_FIELDS][512];
+  char buf[2 * m_labels.size()][512];
   int granaryturns;
 
   enum {
@@ -1074,15 +1073,15 @@ void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
 
   get_city_dialog_output_text(pcity, O_FOOD, buffer, sizeof(buffer));
 
-  for (int i = 0; i < NUM_INFO_FIELDS; i++) {
+  for (int i = 0; i < m_labels.size(); i++) {
     int j = 2 * i;
 
-    qlt[i]->setText(QString(buf[2 * i]));
+    m_labels[i]->setText(QString(buf[2 * i]));
 
     if (j != GROWTH && j != GRANARY && j != WASTE && j != CORRUPTION
         && j != STEAL) {
-      qlt[i]->setToolTip("<pre>" + QString(buf[2 * i + 1]).toHtmlEscaped()
-                         + "</pre>");
+      m_labels[i]->setToolTip(
+          "<pre>" + QString(buf[2 * i + 1]).toHtmlEscaped() + "</pre>");
     }
   }
 

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -973,6 +973,7 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
     return label;
   };
 
+  m_size = create_labels(_("Citizens:"));
   m_food = create_labels(_("Food:"));
   m_production = create_labels(_("Prod:"));
   m_trade = create_labels(_("Trade:"));
@@ -992,6 +993,9 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
 
 void city_info::update_labels(struct city *pcity)
 {
+  m_size->setText(QString::asprintf("%3d", pcity->size));
+  m_size->setToolTip(get_city_dialog_size_text(pcity));
+
   m_food->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_FOOD],
                                     pcity->surplus[O_FOOD]));
   m_food->setToolTip(get_city_dialog_output_text(pcity, O_FOOD));

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -877,22 +877,33 @@ void cityIconInfoLabel::updateText()
   }
 
   labs[1].setText(QString::number(pcity->surplus[O_FOOD]));
+  labs[0].setToolTip(get_city_dialog_output_text(pcity, O_FOOD));
+  labs[1].setToolTip(get_city_dialog_output_text(pcity, O_FOOD));
+
   labs[3].setText(QString::number(pcity->surplus[O_SHIELD]));
-  labs[9].setText(QString::number(pcity->surplus[O_TRADE]));
+  labs[2].setToolTip(get_city_dialog_output_text(pcity, O_SHIELD));
+  labs[3].setToolTip(get_city_dialog_output_text(pcity, O_SHIELD));
+
   labs[5].setText(QString::number(pcity->surplus[O_GOLD]));
+  labs[4].setToolTip(get_city_dialog_output_text(pcity, O_GOLD));
+  labs[5].setToolTip(get_city_dialog_output_text(pcity, O_GOLD));
+
   labs[7].setText(QString::number(pcity->surplus[O_SCIENCE]));
+  labs[6].setToolTip(get_city_dialog_output_text(pcity, O_SCIENCE));
+  labs[7].setToolTip(get_city_dialog_output_text(pcity, O_SCIENCE));
+
+  labs[9].setText(QString::number(pcity->surplus[O_TRADE]));
+  labs[8].setToolTip(get_city_dialog_output_text(pcity, O_TRADE));
+  labs[9].setToolTip(get_city_dialog_output_text(pcity, O_TRADE));
+
   if (city_turns_to_grow(pcity) < 1000) {
     grow_time = QString::number(city_turns_to_grow(pcity));
   } else {
     grow_time = QStringLiteral("∞");
   }
   labs[11].setText(grow_time);
-}
-
-void cityIconInfoLabel::updateTooltip(int nr, const QString &tooltipText)
-{
-  labs[nr].setToolTip(tooltipText);
-  labs[nr + 1].setToolTip(tooltipText);
+  labs[10].setToolTip(get_city_dialog_growth_value(pcity));
+  labs[11].setToolTip(get_city_dialog_growth_value(pcity));
 }
 
 /**
@@ -939,143 +950,107 @@ void city_label::set_city(city *pciti) { pcity = pciti; }
 
 city_info::city_info(QWidget *parent) : QWidget(parent)
 {
-  QStringList info_list;
-
   QGridLayout *info_grid_layout = new QGridLayout();
-  auto small_font = fcFont::instance()->getFont(fonts::notify_label);
-  info_list << _("Food:") << _("Prod:") << _("Trade:") << _("Gold:")
-            << _("Luxury:") << _("Science:") << _("Granary:")
-            << _("Change in:") << _("Corruption:") << _("Waste:")
-            << _("Culture:") << _("Pollution:") << _("Plague risk:")
-            << _("Tech Stolen:") << _("Airlift:");
-  setFont(small_font);
   info_grid_layout->setSpacing(0);
   info_grid_layout->setContentsMargins(0, 0, 0, 0);
-
-  for (int i = 0; i < info_list.size(); i++) {
-    auto ql = new QLabel(info_list[i], this);
-    ql->setFont(small_font);
-    ql->setProperty(fonts::notify_label, "true");
-    info_grid_layout->addWidget(ql, i, 0);
-
-    ql = new QLabel(this);
-    ql->setFont(small_font);
-    ql->setProperty(fonts::notify_label, "true");
-    info_grid_layout->addWidget(ql, i, 1);
-    m_labels.push_back(ql);
-  }
   setLayout(info_grid_layout);
-}
 
-void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
-{
-  int illness = 0;
-  QString buffer;
-  QString buf[2 * m_labels.size()];
-  int granaryturns;
+  auto small_font = fcFont::instance()->getFont(fonts::notify_label);
 
-  enum {
-    FOOD = 0,
-    SHIELD = 2,
-    TRADE = 4,
-    GOLD = 6,
-    LUXURY = 8,
-    SCIENCE = 10,
-    GRANARY = 12,
-    GROWTH = 14,
-    CORRUPTION = 16,
-    WASTE = 18,
-    CULTURE = 20,
-    POLLUTION = 22,
-    ILLNESS = 24,
-    STEAL = 26,
-    AIRLIFT = 28,
+  // We use this to shorten the code below, as it would otherwise be very
+  // repetitive. It creates a label for the description and another for the
+  // value, and returns the second.
+  const auto create_labels = [&](const char *title) {
+    auto label = new QLabel(title, this);
+    label->setFont(small_font);
+    label->setProperty(fonts::notify_label, "true");
+    info_grid_layout->addWidget(label, info_grid_layout->rowCount(), 0);
+
+    label = new QLabel(this);
+    label->setFont(small_font);
+    label->setProperty(fonts::notify_label, "true");
+    info_grid_layout->addWidget(label, info_grid_layout->rowCount() - 1, 1);
+    return label;
   };
 
-  // fill the buffers with the necessary info
-  buf[FOOD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_FOOD],
-                                pcity->surplus[O_FOOD]);
-  buf[SHIELD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_SHIELD],
-                                  pcity->surplus[O_SHIELD]);
-  buf[TRADE] = QString::asprintf("%3d (%+4d)", pcity->prod[O_TRADE],
-                                 pcity->surplus[O_TRADE]);
-  buf[GOLD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_GOLD],
-                                pcity->surplus[O_GOLD]);
-  buf[LUXURY] = QString::asprintf("%3d (%+4d)", pcity->prod[O_LUXURY],
-                                  pcity->surplus[O_LUXURY]);
-  buf[SCIENCE] = QString::asprintf("%3d (%+4d)", pcity->prod[O_SCIENCE],
-                                   pcity->surplus[O_SCIENCE]);
-  buf[GRANARY] = QString::asprintf("%4d/%-4d", pcity->food_stock,
-                                   city_granary_size(city_size_get(pcity)));
+  m_food = create_labels(_("Food:"));
+  m_production = create_labels(_("Prod:"));
+  m_trade = create_labels(_("Trade:"));
+  m_gold = create_labels(_("Gold:"));
+  m_luxury = create_labels(_("Luxury:"));
+  m_science = create_labels(_("Science:"));
+  m_granary = create_labels(_("Granary:"));
+  m_growth = create_labels(_("Change in:"));
+  m_corruption = create_labels(_("Corruption:"));
+  m_waste = create_labels(_("Waste:"));
+  m_culture = create_labels(_("Culture:"));
+  m_pollution = create_labels(_("Pollution:"));
+  m_plague = create_labels(_("Plague risk:"));
+  m_stolen = create_labels(_("Tech Stolen:"));
+  m_airlift = create_labels(_("Airlift:"));
+}
 
-  buf[FOOD + 1] = get_city_dialog_output_text(pcity, O_FOOD);
-  buf[SHIELD + 1] = get_city_dialog_output_text(pcity, O_SHIELD);
-  buf[TRADE + 1] = get_city_dialog_output_text(pcity, O_TRADE);
-  buf[GOLD + 1] = get_city_dialog_output_text(pcity, O_GOLD);
-  buf[SCIENCE + 1] = get_city_dialog_output_text(pcity, O_SCIENCE);
-  buf[LUXURY + 1] = get_city_dialog_output_text(pcity, O_LUXURY);
-  buf[CULTURE + 1] = get_city_dialog_culture_text(pcity);
-  buf[POLLUTION + 1] = get_city_dialog_pollution_text(pcity);
-  buf[ILLNESS + 1] = get_city_dialog_illness_text(pcity);
+void city_info::update_labels(struct city *pcity)
+{
+  m_food->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_FOOD],
+                                    pcity->surplus[O_FOOD]));
+  m_food->setToolTip(get_city_dialog_output_text(pcity, O_FOOD));
 
-  granaryturns = city_turns_to_grow(pcity);
+  m_production->setText(QString::asprintf(
+      "%3d (%+4d)", pcity->prod[O_SHIELD], pcity->surplus[O_SHIELD]));
+  m_production->setToolTip(get_city_dialog_output_text(pcity, O_SHIELD));
 
-  if (granaryturns == 0) {
-    // TRANS: city growth is blocked.  Keep short.
-    buf[GROWTH] = _("blocked");
-  } else if (granaryturns == FC_INFINITY) {
-    // TRANS: city is not growing.  Keep short.
-    buf[GROWTH] = _("never");
-  } else {
-    /* A negative value means we'll have famine in that many turns.
-       But that's handled down below. */
-    // TRANS: city growth turns.  Keep short.
-    buf[GROWTH] = QString::asprintf(
-        PL_("%d turn", "%d turns", abs(granaryturns)), abs(granaryturns));
-  }
+  m_trade->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_TRADE],
+                                     pcity->surplus[O_TRADE]));
+  m_trade->setToolTip(get_city_dialog_output_text(pcity, O_TRADE));
 
-  buf[CORRUPTION] = QString::asprintf("%4d", pcity->waste[O_TRADE]);
-  buf[WASTE] = QString::asprintf("%4d", pcity->waste[O_SHIELD]);
-  buf[CULTURE] = QString::asprintf("%4d", pcity->client.culture);
-  buf[POLLUTION] = QString::asprintf("%4d", pcity->pollution);
+  m_gold->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_GOLD],
+                                    pcity->surplus[O_GOLD]));
+  m_gold->setToolTip(get_city_dialog_output_text(pcity, O_GOLD));
+
+  m_luxury->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_LUXURY],
+                                      pcity->surplus[O_LUXURY]));
+  m_luxury->setToolTip(get_city_dialog_output_text(pcity, O_LUXURY));
+
+  m_science->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_SCIENCE],
+                                       pcity->surplus[O_SCIENCE]));
+  m_science->setToolTip(get_city_dialog_output_text(pcity, O_SCIENCE));
+
+  m_granary->setText(
+      QString::asprintf("%4d/%-4d", pcity->food_stock,
+                        city_granary_size(city_size_get(pcity))));
+
+  m_growth->setText(get_city_dialog_growth_value(pcity));
+
+  m_corruption->setText(QString::asprintf("%4d", pcity->waste[O_TRADE]));
+
+  m_waste->setText(QString::asprintf("%4d", pcity->waste[O_SHIELD]));
+
+  m_culture->setText(QString::asprintf("%4d", pcity->client.culture));
+  m_culture->setToolTip(get_city_dialog_culture_text(pcity));
+
+  m_pollution->setText(QString::asprintf("%4d", pcity->pollution));
+  m_pollution->setToolTip(get_city_dialog_pollution_text(pcity));
 
   if (!game.info.illness_on) {
-    buf[ILLNESS] = QStringLiteral(" -.-");
+    m_plague->setText(QStringLiteral(" -.-"));
   } else {
-    illness = city_illness_calc(pcity, nullptr, nullptr, nullptr, nullptr);
+    auto illness =
+        city_illness_calc(pcity, nullptr, nullptr, nullptr, nullptr);
     // illness is in tenth of percent
-    buf[ILLNESS] =
-        QString::asprintf("%4.1f%%", static_cast<float>(illness) / 10.0);
+    m_plague->setText(
+        QString::asprintf("%4.1f%%", static_cast<float>(illness) / 10.0));
   }
+  m_plague->setToolTip(get_city_dialog_illness_text(pcity));
+
   if (pcity->steal) {
-    buf[STEAL] = QString::asprintf(_("%d times"), pcity->steal);
+    m_stolen->setText(QString::asprintf(_("%d times"), pcity->steal));
   } else {
-    buf[STEAL] = QString::asprintf(_("Not stolen"));
+    m_stolen->setText(QString::asprintf(_("Not stolen")));
   }
 
-  buf[AIRLIFT] = get_city_dialog_airlift_value(pcity);
-  buf[AIRLIFT + 1] = get_city_dialog_airlift_text(pcity);
-
-  buffer = get_city_dialog_output_text(pcity, O_FOOD);
-
-  for (int i = 0; i < m_labels.size(); i++) {
-    int j = 2 * i;
-
-    m_labels[i]->setText(QString(buf[2 * i]));
-
-    if (j != GROWTH && j != GRANARY && j != WASTE && j != CORRUPTION
-        && j != STEAL) {
-      m_labels[i]->setToolTip(
-          "<pre>" + QString(buf[2 * i + 1]).toHtmlEscaped() + "</pre>");
-    }
-  }
-
-  ciil->updateTooltip(0, buf[FOOD + 1]);
-  ciil->updateTooltip(2, buf[SHIELD + 1]);
-  ciil->updateTooltip(4, buf[GOLD + 1]);
-  ciil->updateTooltip(6, buf[SCIENCE + 1]);
-  ciil->updateTooltip(8, buf[TRADE + 1]);
-  ciil->updateTooltip(10, buf[GROWTH]);
+  m_airlift->setText(get_city_dialog_airlift_value(pcity));
+  m_airlift->setToolTip(get_city_dialog_airlift_text(pcity));
 }
 
 governor_sliders::governor_sliders(QWidget *parent) : QGroupBox(parent)
@@ -2157,7 +2132,7 @@ void city_dialog::update_nation_table()
  */
 void city_dialog::update_info_label()
 {
-  ui.info_wdg->update_labels(pcity, ui.info_icon_label);
+  ui.info_wdg->update_labels(pcity);
   ui.info_icon_label->setCity(pcity);
   ui.info_icon_label->updateText();
 }

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -23,6 +23,7 @@
 #include <QVBoxLayout>
 #include <QWidgetAction>
 // utility
+#include "fc_types.h"
 #include "fcintl.h"
 #include "support.h"
 // common
@@ -969,8 +970,8 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
 void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
 {
   int illness = 0;
-  char buffer[512];
-  char buf[2 * m_labels.size()][512];
+  QString buffer;
+  QString buf[2 * m_labels.size()];
   int granaryturns;
 
   enum {
@@ -992,86 +993,70 @@ void city_info::update_labels(struct city *pcity, cityIconInfoLabel *ciil)
   };
 
   // fill the buffers with the necessary info
-  fc_snprintf(buf[FOOD], sizeof(buf[FOOD]), "%3d (%+4d)",
-              pcity->prod[O_FOOD], pcity->surplus[O_FOOD]);
-  fc_snprintf(buf[SHIELD], sizeof(buf[SHIELD]), "%3d (%+4d)",
-              pcity->prod[O_SHIELD] + pcity->waste[O_SHIELD],
-              pcity->surplus[O_SHIELD]);
-  fc_snprintf(buf[TRADE], sizeof(buf[TRADE]), "%3d (%+4d)",
-              pcity->surplus[O_TRADE] + pcity->waste[O_TRADE],
-              pcity->surplus[O_TRADE]);
-  fc_snprintf(buf[GOLD], sizeof(buf[GOLD]), "%3d (%+4d)",
-              pcity->prod[O_GOLD], pcity->surplus[O_GOLD]);
-  fc_snprintf(buf[LUXURY], sizeof(buf[LUXURY]), "%3d",
-              pcity->prod[O_LUXURY]);
-  fc_snprintf(buf[SCIENCE], sizeof(buf[SCIENCE]), "%3d",
-              pcity->prod[O_SCIENCE]);
-  fc_snprintf(buf[GRANARY], sizeof(buf[GRANARY]), "%4d/%-4d",
-              pcity->food_stock, city_granary_size(city_size_get(pcity)));
+  buf[FOOD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_FOOD],
+                                pcity->surplus[O_FOOD]);
+  buf[SHIELD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_SHIELD],
+                                  pcity->surplus[O_SHIELD]);
+  buf[TRADE] = QString::asprintf("%3d (%+4d)", pcity->prod[O_TRADE],
+                                 pcity->surplus[O_TRADE]);
+  buf[GOLD] = QString::asprintf("%3d (%+4d)", pcity->prod[O_GOLD],
+                                pcity->surplus[O_GOLD]);
+  buf[LUXURY] = QString::asprintf("%3d (%+4d)", pcity->prod[O_LUXURY],
+                                  pcity->surplus[O_LUXURY]);
+  buf[SCIENCE] = QString::asprintf("%3d (%+4d)", pcity->prod[O_SCIENCE],
+                                   pcity->surplus[O_SCIENCE]);
+  buf[GRANARY] = QString::asprintf("%4d/%-4d", pcity->food_stock,
+                                   city_granary_size(city_size_get(pcity)));
 
-  get_city_dialog_output_text(pcity, O_FOOD, buf[FOOD + 1],
-                              sizeof(buf[FOOD + 1]));
-  get_city_dialog_output_text(pcity, O_SHIELD, buf[SHIELD + 1],
-                              sizeof(buf[SHIELD + 1]));
-  get_city_dialog_output_text(pcity, O_TRADE, buf[TRADE + 1],
-                              sizeof(buf[TRADE + 1]));
-  get_city_dialog_output_text(pcity, O_GOLD, buf[GOLD + 1],
-                              sizeof(buf[GOLD + 1]));
-  get_city_dialog_output_text(pcity, O_SCIENCE, buf[SCIENCE + 1],
-                              sizeof(buf[SCIENCE + 1]));
-  get_city_dialog_output_text(pcity, O_LUXURY, buf[LUXURY + 1],
-                              sizeof(buf[LUXURY + 1]));
-  get_city_dialog_culture_text(pcity, buf[CULTURE + 1],
-                               sizeof(buf[CULTURE + 1]));
-  get_city_dialog_pollution_text(pcity, buf[POLLUTION + 1],
-                                 sizeof(buf[POLLUTION + 1]));
-  get_city_dialog_illness_text(pcity, buf[ILLNESS + 1],
-                               sizeof(buf[ILLNESS + 1]));
+  buf[FOOD + 1] = get_city_dialog_output_text(pcity, O_FOOD);
+  buf[SHIELD + 1] = get_city_dialog_output_text(pcity, O_SHIELD);
+  buf[TRADE + 1] = get_city_dialog_output_text(pcity, O_TRADE);
+  buf[GOLD + 1] = get_city_dialog_output_text(pcity, O_GOLD);
+  buf[SCIENCE + 1] = get_city_dialog_output_text(pcity, O_SCIENCE);
+  buf[LUXURY + 1] = get_city_dialog_output_text(pcity, O_LUXURY);
+  buf[CULTURE + 1] = get_city_dialog_culture_text(pcity);
+  buf[POLLUTION + 1] = get_city_dialog_pollution_text(pcity);
+  buf[ILLNESS + 1] = get_city_dialog_illness_text(pcity);
 
   granaryturns = city_turns_to_grow(pcity);
 
   if (granaryturns == 0) {
     // TRANS: city growth is blocked.  Keep short.
-    fc_snprintf(buf[GROWTH], sizeof(buf[GROWTH]), _("blocked"));
+    buf[GROWTH] = _("blocked");
   } else if (granaryturns == FC_INFINITY) {
     // TRANS: city is not growing.  Keep short.
-    fc_snprintf(buf[GROWTH], sizeof(buf[GROWTH]), _("never"));
+    buf[GROWTH] = _("never");
   } else {
     /* A negative value means we'll have famine in that many turns.
        But that's handled down below. */
     // TRANS: city growth turns.  Keep short.
-    fc_snprintf(buf[GROWTH], sizeof(buf[GROWTH]),
-                PL_("%d turn", "%d turns", abs(granaryturns)),
-                abs(granaryturns));
+    buf[GROWTH] = QString::asprintf(
+        PL_("%d turn", "%d turns", abs(granaryturns)), abs(granaryturns));
   }
 
-  fc_snprintf(buf[CORRUPTION], sizeof(buf[CORRUPTION]), "%4d",
-              pcity->waste[O_TRADE]);
-  fc_snprintf(buf[WASTE], sizeof(buf[WASTE]), "%4d", pcity->waste[O_SHIELD]);
-  fc_snprintf(buf[CULTURE], sizeof(buf[CULTURE]), "%4d",
-              pcity->client.culture);
-  fc_snprintf(buf[POLLUTION], sizeof(buf[POLLUTION]), "%4d",
-              pcity->pollution);
+  buf[CORRUPTION] = QString::asprintf("%4d", pcity->waste[O_TRADE]);
+  buf[WASTE] = QString::asprintf("%4d", pcity->waste[O_SHIELD]);
+  buf[CULTURE] = QString::asprintf("%4d", pcity->client.culture);
+  buf[POLLUTION] = QString::asprintf("%4d", pcity->pollution);
 
   if (!game.info.illness_on) {
-    fc_snprintf(buf[ILLNESS], sizeof(buf[ILLNESS]), " -.-");
+    buf[ILLNESS] = QStringLiteral(" -.-");
   } else {
     illness = city_illness_calc(pcity, nullptr, nullptr, nullptr, nullptr);
     // illness is in tenth of percent
-    fc_snprintf(buf[ILLNESS], sizeof(buf[ILLNESS]), "%4.1f%%",
-                static_cast<float>(illness) / 10.0);
+    buf[ILLNESS] =
+        QString::asprintf("%4.1f%%", static_cast<float>(illness) / 10.0);
   }
   if (pcity->steal) {
-    fc_snprintf(buf[STEAL], sizeof(buf[STEAL]), _("%d times"), pcity->steal);
+    buf[STEAL] = QString::asprintf(_("%d times"), pcity->steal);
   } else {
-    fc_snprintf(buf[STEAL], sizeof(buf[STEAL]), _("Not stolen"));
+    buf[STEAL] = QString::asprintf(_("Not stolen"));
   }
 
-  get_city_dialog_airlift_value(pcity, buf[AIRLIFT], sizeof(buf[AIRLIFT]));
-  get_city_dialog_airlift_text(pcity, buf[AIRLIFT + 1],
-                               sizeof(buf[AIRLIFT + 1]));
+  buf[AIRLIFT] = get_city_dialog_airlift_value(pcity);
+  buf[AIRLIFT + 1] = get_city_dialog_airlift_text(pcity);
 
-  get_city_dialog_output_text(pcity, O_FOOD, buffer, sizeof(buffer));
+  buffer = get_city_dialog_output_text(pcity, O_FOOD);
 
   for (int i = 0; i < m_labels.size(); i++) {
     int j = 2 * i;

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -65,7 +65,6 @@ public:
   bool oneliner;
 };
 
-#define NUM_INFO_FIELDS 15
 /****************************************************************************
   Custom progressbar with animated progress and right click event
 ****************************************************************************/
@@ -318,7 +317,7 @@ public:
   void update_labels(struct city *ci_city, cityIconInfoLabel *);
 
 private:
-  QLabel *qlt[NUM_INFO_FIELDS];
+  std::vector<QLabel *> m_labels;
 };
 
 class governor_sliders : public QGroupBox {

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -280,7 +280,6 @@ public:
   cityIconInfoLabel(QWidget *parent = 0);
   void setCity(struct city *pcity);
   void updateText();
-  void updateTooltip(int, const QString &);
 
 private:
   void initLayout();
@@ -314,10 +313,12 @@ class city_info : public QWidget {
 
 public:
   city_info(QWidget *parent = 0);
-  void update_labels(struct city *ci_city, cityIconInfoLabel *);
+  void update_labels(struct city *ci_city);
 
 private:
-  std::vector<QLabel *> m_labels;
+  QLabel *m_food, *m_production, *m_trade, *m_gold, *m_luxury, *m_science,
+      *m_granary, *m_growth, *m_corruption, *m_waste, *m_culture,
+      *m_pollution, *m_plague, *m_stolen, *m_airlift;
 };
 
 class governor_sliders : public QGroupBox {

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -316,8 +316,8 @@ public:
   void update_labels(struct city *ci_city);
 
 private:
-  QLabel *m_food, *m_production, *m_trade, *m_gold, *m_luxury, *m_science,
-      *m_granary, *m_growth, *m_corruption, *m_waste, *m_culture,
+  QLabel *m_size, *m_food, *m_production, *m_trade, *m_gold, *m_luxury,
+      *m_science, *m_granary, *m_growth, *m_corruption, *m_waste, *m_culture,
       *m_pollution, *m_plague, *m_stolen, *m_airlift;
 };
 

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -166,6 +166,15 @@ void get_city_dialog_production(struct city *pcity, char *buffer,
   }
 }
 
+namespace {
+/**
+ * Embeds the content in an HTML preformatted element
+ */
+QString html_pre(const QString &content)
+{
+  return QStringLiteral("<pre>") + content + QStringLiteral("</pre>");
+}
+
 /**
    Helper structure to accumulate a breakdown of the constributions
    to some numeric city property. Contributions are returned in order,
@@ -198,7 +207,7 @@ struct city_sum {
    (the first item is the numeric value and must have a 'f' conversion
    spec; the second is the description).
  */
-static struct city_sum *city_sum_new(const char *format)
+struct city_sum *city_sum_new(const char *format)
 {
   struct city_sum *sum = new city_sum();
 
@@ -214,10 +223,10 @@ static struct city_sum *city_sum_new(const char *format)
    If 'posdesc'/'negdesc' and other properties match an existing entry,
    'value' is added to the existing entry, else a new one is appended.
  */
-static void city_sum_add_real(struct city_sum *sum, double value,
-                              bool suppress_if_zero, const QString &auxfmt,
-                              double aux, const QString &posdesc,
-                              const QString &negdesc)
+void city_sum_add_real(struct city_sum *sum, double value,
+                       bool suppress_if_zero, const QString &auxfmt,
+                       double aux, const QString &posdesc,
+                       const QString &negdesc)
 {
   size_t i;
 
@@ -256,7 +265,7 @@ static void city_sum_add_real(struct city_sum *sum, double value,
     - Allows control over whether the item will be discarded if its
       net value is zero (suppress_if_zero).
  */
-static void fc__attribute((__format__(__printf__, 6, 8)))
+void fc__attribute((__format__(__printf__, 6, 8)))
     fc__attribute((__format__(__printf__, 7, 8)))
         fc__attribute((nonnull(1, 6, 7)))
             city_sum_add_full(struct city_sum *sum, double value,
@@ -286,7 +295,7 @@ static void fc__attribute((__format__(__printf__, 6, 8)))
     - not suppressed if net value is zero (compare city_sum_add_nonzero())
     - no auxiliary number
  */
-static void fc__attribute((__format__(__printf__, 3, 4)))
+void fc__attribute((__format__(__printf__, 3, 4)))
     fc__attribute((nonnull(1, 3)))
         city_sum_add(struct city_sum *sum, double value, const char *descfmt,
                      ...)
@@ -309,7 +318,7 @@ static void fc__attribute((__format__(__printf__, 3, 4)))
     - suppressed if net value is zero (compare city_sum_add())
     - no auxiliary number
  */
-static void fc__attribute((__format__(__printf__, 3, 4)))
+void fc__attribute((__format__(__printf__, 3, 4)))
     fc__attribute((nonnull(1, 3)))
         city_sum_add_if_nonzero(struct city_sum *sum, double value,
                                 const char *descfmt, ...)
@@ -328,7 +337,7 @@ static void fc__attribute((__format__(__printf__, 3, 4)))
 /**
    Return the net total accumulated in the sum so far.
  */
-static double city_sum_total(struct city_sum *sum)
+double city_sum_total(struct city_sum *sum)
 {
   size_t i;
   double total = 0;
@@ -345,7 +354,7 @@ static double city_sum_total(struct city_sum *sum)
       0: val1 == val2 (approximately)
      +1: val1 >  val2
  */
-static inline int city_sum_compare(double val1, double val2)
+inline int city_sum_compare(double val1, double val2)
 {
   /* Fudgey epsilon -- probably the numbers we're dealing with have at
    * most 1% or 0.1% real difference */
@@ -362,7 +371,7 @@ static inline int city_sum_compare(double val1, double val2)
    account_for_unknown is optional, as not every sum wants it (consider
    pollution's clipping).
  */
-static QString fc__attribute((__format__(__printf__, 3, 4)))
+QString fc__attribute((__format__(__printf__, 3, 4)))
     fc__attribute((nonnull(1, 3)))
         city_sum_print(struct city_sum *sum, bool account_for_unknown,
                        const char *totalfmt, ...)
@@ -411,8 +420,9 @@ static QString fc__attribute((__format__(__printf__, 3, 4)))
   va_end(args);
 
   delete sum;
-  return result;
+  return html_pre(result);
 }
+} // anonymous namespace
 
 /**
    Return text describing the production output.
@@ -816,7 +826,7 @@ QString get_city_dialog_size_text(const struct city *pcity)
   }
   specialist_type_iterate_end;
 
-  return text.trimmed();
+  return html_pre(text.trimmed());
 }
 
 /**

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -790,6 +790,36 @@ QString get_city_dialog_airlift_text(const struct city *pcity)
 }
 
 /**
+ * Return text describing the city's citizens.
+ */
+QString get_city_dialog_size_text(const struct city *pcity)
+{
+  auto text = QString();
+  // TRANS: Number of happy citizens
+  text += QString(_("Happy: %1\n"))
+              .arg(pcity->feel[CITIZEN_HAPPY][FEELING_FINAL]);
+  // TRANS: Number of content citizens
+  text += QString(_("Content: %1\n"))
+              .arg(pcity->feel[CITIZEN_CONTENT][FEELING_FINAL]);
+  // TRANS: Number of unhappy citizens
+  text += QString(_("Unhappy: %1\n"))
+              .arg(pcity->feel[CITIZEN_UNHAPPY][FEELING_FINAL]);
+  // TRANS: Number of angry citizens
+  text += QString(_("Angry: %1\n"))
+              .arg(pcity->feel[CITIZEN_ANGRY][FEELING_FINAL]);
+
+  specialist_type_iterate(sp)
+  {
+    text += QStringLiteral("%1: %2\n")
+                .arg(specialist_plural_translation(specialist_by_number(sp)))
+                .arg(pcity->specialists[sp]);
+  }
+  specialist_type_iterate_end;
+
+  return text.trimmed();
+}
+
+/**
  * Return time until next growth
  */
 QString get_city_dialog_growth_value(const struct city *pcity)

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -790,6 +790,25 @@ QString get_city_dialog_airlift_text(const struct city *pcity)
 }
 
 /**
+ * Return time until next growth
+ */
+QString get_city_dialog_growth_value(const struct city *pcity)
+{
+  auto granaryturns = city_turns_to_grow(pcity);
+  if (granaryturns == 0) {
+    // TRANS: city growth is blocked.  Keep short.
+    return _("blocked");
+  } else if (granaryturns == FC_INFINITY) {
+    // TRANS: city is not growing.  Keep short.
+    return _("never");
+  } else {
+    // TRANS: city growth turns.  Keep short.
+    return QString::asprintf(PL_("%d turn", "%d turns", abs(granaryturns)),
+                             abs(granaryturns));
+  }
+}
+
+/**
    Return airlift capacity.
  */
 QString get_city_dialog_airlift_value(const struct city *pcity)

--- a/client/citydlg_common.h
+++ b/client/citydlg_common.h
@@ -35,6 +35,7 @@ QString get_city_dialog_pollution_text(const struct city *pcity);
 QString get_city_dialog_culture_text(const struct city *pcity);
 QString get_city_dialog_illness_text(const struct city *pcity);
 QString get_city_dialog_airlift_text(const struct city *pcity);
+QString get_city_dialog_size_text(const struct city *pcity);
 
 QString get_city_dialog_growth_value(const struct city *pcity);
 QString get_city_dialog_airlift_value(const struct city *pcity);

--- a/client/citydlg_common.h
+++ b/client/citydlg_common.h
@@ -17,7 +17,8 @@
 #include "city.h"
 #include "fc_types.h"
 
-class QPixmap;
+#include <QString>
+
 struct worklist;
 
 int get_citydlg_canvas_width();
@@ -28,20 +29,14 @@ char *city_production_cost_str(const struct city *pcity);
 void get_city_dialog_production(struct city *pcity, char *buffer,
                                 size_t buffer_len);
 
-void get_city_dialog_output_text(const struct city *pcity,
-                                 Output_type_id otype, char *buffer,
-                                 size_t bufsz);
-void get_city_dialog_pollution_text(const struct city *pcity, char *buf,
-                                    size_t bufsz);
-void get_city_dialog_culture_text(const struct city *pcity, char *buf,
-                                  size_t bufsz);
-void get_city_dialog_illness_text(const struct city *pcity, char *buf,
-                                  size_t bufsz);
-void get_city_dialog_airlift_text(const struct city *pcity, char *buf,
-                                  size_t bufsz);
+QString get_city_dialog_output_text(const struct city *pcity,
+                                    Output_type_id otype);
+QString get_city_dialog_pollution_text(const struct city *pcity);
+QString get_city_dialog_culture_text(const struct city *pcity);
+QString get_city_dialog_illness_text(const struct city *pcity);
+QString get_city_dialog_airlift_text(const struct city *pcity);
 
-void get_city_dialog_airlift_value(const struct city *pcity, char *buf,
-                                   size_t bufsz);
+QString get_city_dialog_airlift_value(const struct city *pcity);
 
 int get_city_citizen_types(struct city *pcity, enum citizen_feeling index,
                            enum citizen_category *categories);

--- a/client/citydlg_common.h
+++ b/client/citydlg_common.h
@@ -36,6 +36,7 @@ QString get_city_dialog_culture_text(const struct city *pcity);
 QString get_city_dialog_illness_text(const struct city *pcity);
 QString get_city_dialog_airlift_text(const struct city *pcity);
 
+QString get_city_dialog_growth_value(const struct city *pcity);
 QString get_city_dialog_airlift_value(const struct city *pcity);
 
 int get_city_citizen_types(struct city *pcity, enum citizen_feeling index,


### PR DESCRIPTION
Closes #438.
The citizen types (happiness and entertainers) is shown in the tooltip.

The patch itself is rather small, but there's a lot of refactoring to make it less error-prone in the end.