### PR TITLE
Expand the text for empire size unhappiness

### DIFF
--- a/client/text.h
+++ b/client/text.h
@@ -46,7 +46,7 @@ const QString act_sel_action_tool_tip(const struct action *paction,
 
 QString text_happiness_buildings(const struct city *pcity);
 const QString text_happiness_nationality(const struct city *pcity);
-const QString text_happiness_cities(const struct city *pcity);
+QString text_happiness_cities(const struct city *pcity);
 const QString text_happiness_luxuries(const struct city *pcity);
 const QString text_happiness_units(const struct city *pcity);
 QString text_happiness_wonders(const struct city *pcity);

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -2055,7 +2055,7 @@ int city_granary_size(int city_size)
    A positive number is a number of content citizens. A negative number is
    a number of angry citizens (a city never starts with both).
  */
-static int player_base_citizen_happiness(const struct player *pplayer)
+int player_base_citizen_happiness(const struct player *pplayer)
 {
   int cities = city_list_size(pplayer->cities);
   int content = get_player_bonus(pplayer, EFT_CITY_UNHAPPY_SIZE);
@@ -2069,7 +2069,7 @@ static int player_base_citizen_happiness(const struct player *pplayer)
 
   if (cities > basis) {
     content--;
-    if (step != 0) {
+    if (step > 0) {
       /* the first penalty is at (basis + 1) cities;
          the next is at (basis + step + 1), _not_ (basis + step) */
       content -= (cities - basis - 1) / step;

--- a/common/city.h
+++ b/common/city.h
@@ -532,6 +532,7 @@ void city_size_set(struct city *pcity, citizens size);
 
 citizens city_specialists(const struct city *pcity);
 
+int player_base_citizen_happiness(const struct player *pplayer);
 citizens player_content_citizens(const struct player *pplayer);
 citizens player_angry_citizens(const struct player *pplayer);
 


### PR DESCRIPTION
Improve the city dialog tooltip text that explains how many citizens are
unhappy because of the number of cities. Write two paragraphs: the first
describing the rules for the current player, and the second the status of the
city at hand. The total number of citizens that can be made content without
improvements is also shown; see #269.

## Example texts

### classic, size 14, communism

All cities start with 4 content citizens. Once you have more than 12 cities, a citizen becomes unhappy.

You have 36 cities, resulting in a maximum of 3 content citizens. In this city of size 14, **3 citizens are content.**

### classic, size 2, communism

All cities start with 4 content citizens. Once you have more than 12 cities, a citizen becomes unhappy.

You have 36 cities, resulting in a maximum of 3 content citizens. In this city of size 2, **all citizens are content.**

### Aviation, size 4, monarchy

All cities start with 4 content citizens. Once you have more than 10 cities, a citizen becomes unhappy. Afterwards, for every 9 additional cities, a content citizen becomes unhappy. If there are no more content citizens, an unhappy citizen becomes angry instead.

You have 11 cities, resulting in a maximum of 3 content citizens. In this city of size 4, **3 citizens are content.** With 9 more cities, a content citizen would become unhappy.

### Aviation, size 2, monarchy

All cities start with 4 content citizens. Once you have more than 10 cities, a citizen becomes unhappy. Afterwards, for every 9 additional cities, a content citizen becomes unhappy. If there are no more content citizens, an unhappy citizen becomes angry instead.

You have 11 cities, resulting in a maximum of 3 content citizens. In this city of size 2, **all citizens are content.** With 18 more cities, a content citizen would become unhappy.