### PR TITLE
Expand the city dialog text for luxury spendings

### DIFF
--- a/client/text.h
+++ b/client/text.h
@@ -47,7 +47,7 @@ const QString act_sel_action_tool_tip(const struct action *paction,
 QString text_happiness_buildings(const struct city *pcity);
 const QString text_happiness_nationality(const struct city *pcity);
 QString text_happiness_cities(const struct city *pcity);
-const QString text_happiness_luxuries(const struct city *pcity);
+QString text_happiness_luxuries(const struct city *pcity);
 const QString text_happiness_units(const struct city *pcity);
 QString text_happiness_wonders(const struct city *pcity);
 int get_bulbs_per_turn(int *pours, bool *pteam, int *ptheirs);


### PR DESCRIPTION
Same as (and on top of) #1206 for luxury. The rules are much simpler and so the code also is.

Improve the city dialog tooltip text that explains how many citizens are
made happier by luxury. This provides a lot more information than the previous
"Luxury: %d total", which will hopefully help towards https://github.com/longturn/freeciv21/issues/269.

## Example texts

### Sad, sad city

For each 2 luxury produced in a city, a citizen becomes happier. This city generates no luxury.

### Normal sad city

For each 2 luxury produced in a city, a citizen becomes happier. This city generates a total of 1 luxury, not enough to have an effect.

### Getting happier

For each 2 luxury produced in a city, a citizen becomes happier. This city generates a total of 5 luxury.

2 citizens are made happier using 4 luxury. 1 luxury is not used.

### Happiest

For each 2 luxury produced in a city, a citizen becomes happier. This city generates a total of 8 luxury.

All available luxury is used to make 3 citizens happier.