### PR TITLE
Expand the city dialog text for nationality

### DIFF
--- a/client/text.cpp
+++ b/client/text.cpp
@@ -1326,7 +1326,6 @@ QString text_happiness_buildings(const struct city *pcity)
 {
   if (const auto effects = get_effects(EFT_MAKE_CONTENT);
       effect_list_size(effects) == 0) {
-    effect_list_destroy(effects);
     return QString(); // Disabled in the ruleset.
   }
 
@@ -1396,7 +1395,6 @@ QString text_happiness_nationality(const struct city *pcity)
   if (auto effects = get_effects(EFT_ENEMY_CITIZEN_UNHAPPY_PCT);
       !game.info.citizen_nationality || effect_list_size(effects) == 0) {
     // Disabled in the ruleset
-    effect_list_destroy(effects);
     return QString();
   }
 

--- a/client/text.h
+++ b/client/text.h
@@ -45,7 +45,7 @@ const QString act_sel_action_tool_tip(const struct action *paction,
                                       const struct act_prob prob);
 
 QString text_happiness_buildings(const struct city *pcity);
-const QString text_happiness_nationality(const struct city *pcity);
+QString text_happiness_nationality(const struct city *pcity);
 QString text_happiness_cities(const struct city *pcity);
 QString text_happiness_luxuries(const struct city *pcity);
 const QString text_happiness_units(const struct city *pcity);


### PR DESCRIPTION
Follow-up of #1206, #1208, and #1209 for citizen nationality.

Explain the rules and give the result of the calculation. The rule sentence is
not fully correct but it's easier to understand than the actual mechanism.
Hopefully helps with #269.

## Example texts

All examples are with nationality enabled.

### Example 1

The presence of enemy citizens can create additional unhappiness. However, it is not the case in this city.

### Example 2

For every 2 citizens of an enemy nation, one citizen becomes unhappy.

There is **no enemy citizen** in this city.

### Example 3

For every 2 citizens of an enemy nation, one citizen becomes unhappy.

There are 5 enemy citizens in this city, resulting in **2 additional unhappy.**