### PR TITLE
Expand the city dialog text for military happiness

### DIFF
--- a/client/text.h
+++ b/client/text.h
@@ -48,6 +48,6 @@ QString text_happiness_buildings(const struct city *pcity);
 QString text_happiness_nationality(const struct city *pcity);
 QString text_happiness_cities(const struct city *pcity);
 QString text_happiness_luxuries(const struct city *pcity);
-const QString text_happiness_units(const struct city *pcity);
+QString text_happiness_units(const struct city *pcity);
 QString text_happiness_wonders(const struct city *pcity);
 int get_bulbs_per_turn(int *pours, bool *pteam, int *ptheirs);


### PR DESCRIPTION
Improve the description of martial law by listing the number of units applying
it and the total number of citizens made happier as a result.
Greatly expand the description of military unhappiness by explaining the three
effects that come into play and providing numbers similiar to the above.

Should help with #269.

## Example text

Up to 2 military units in the city may impose martial law. Each of them makes 2 unhappy citizens content.

1 military unit in this city imposes the martial law. <b>1 citizen</b> is made happier as a result.

Military units in the field may cause unhappiness. The unhappiness caused by military units is reduced by 3 with respect to its normal value.

This city supports 3 agressive military units, resulting in <b>1 additional unhappy citizen.</b>