### PR TITLE
Implement map centering with Qt animations and move map updates to the renderer

### DIFF
--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -434,7 +434,7 @@ void chat_widget::anchor_clicked(const QUrl &link)
     break;
   }
   if (ptile) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     link_mark_restore(type, id);
   }
 }

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -2325,7 +2325,7 @@ void city_dialog::get_city(bool next)
     other_pcity =
         city_list_get(client.conn.playing->cities, (i + k + size) % size);
   }
-  center_tile_mapcanvas(other_pcity->tile);
+  queen()->mapview_wdg->center_on_tile(other_pcity->tile);
   pcity = other_pcity;
   refresh();
 }
@@ -2708,7 +2708,7 @@ void real_city_dialog_popup(struct city *pcity)
     top_bar_show_map();
     queen()->mapview_wdg->hide_all_fcwidgets();
   }
-  center_tile_mapcanvas(pcity->tile);
+  queen()->mapview_wdg->center_on_tile(pcity->tile);
 
   widget->setup_ui(pcity);
   widget->show();

--- a/client/cityrep.cpp
+++ b/client/cityrep.cpp
@@ -22,12 +22,12 @@
 #include "cityrep_g.h"
 #include "client_main.h"
 #include "governor.h"
-#include "mapview_common.h"
 // gui-qt
 #include "cityrep.h"
 #include "fc_client.h"
 #include "hudwidget.h"
 #include "icons.h"
+#include "mapview.h"
 #include "page_game.h"
 #include "qtg_cxxside.h"
 
@@ -413,7 +413,7 @@ void city_widget::city_view()
 
   Q_ASSERT(pcity != nullptr);
   if (gui_options.center_when_popup_city) {
-    center_tile_mapcanvas(pcity->tile);
+    queen()->mapview_wdg->center_on_tile(pcity->tile);
   }
   real_city_dialog_popup(pcity);
 }
@@ -455,7 +455,7 @@ void city_widget::center()
   }
   pcity = selected_cities[0];
   Q_ASSERT(pcity != nullptr);
-  center_tile_mapcanvas(pcity->tile);
+  queen()->mapview_wdg->center_on_tile(pcity->tile);
   queen()->game_tab_widget->setCurrentIndex(0);
 }
 

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -857,9 +857,7 @@ void set_client_state(enum client_states newstate)
     boot_help_texts(client_current_nation_set(), tileset_help(tileset));
 
     global_worklists_build();
-    can_slide = false;
     unit_focus_update();
-    can_slide = true;
     set_client_page(PAGE_GAME);
     // Find something sensible to display instead of the intro gfx.
     center_on_something();

--- a/client/climisc.cpp
+++ b/client/climisc.cpp
@@ -53,10 +53,12 @@
 #include "climap.h"
 #include "climisc.h"
 #include "control.h"
+#include "mapview.h"
 #include "mapview_common.h"
 #include "messagewin_common.h"
 #include "options.h"
 #include "packhand.h"
+#include "page_game.h"
 #include "tilespec.h"
 
 // gui-qt
@@ -399,26 +401,26 @@ void center_on_something()
     return;
   }
 
-  can_slide = false;
   if (get_num_units_in_focus() > 0) {
-    center_tile_mapcanvas(unit_tile(head_of_units_in_focus()));
+    queen()->mapview_wdg->center_on_tile(unit_tile(head_of_units_in_focus()),
+                                         false);
   } else if (client_has_player()
              && nullptr
                     != (pcity = player_primary_capital(client_player()))) {
     // Else focus on the capital.
-    center_tile_mapcanvas(pcity->tile);
+    queen()->mapview_wdg->center_on_tile(pcity->tile, false);
   } else if (nullptr != client.conn.playing
              && 0 < city_list_size(client.conn.playing->cities)) {
     // Just focus on any city.
     pcity = city_list_get(client.conn.playing->cities, 0);
     fc_assert_ret(pcity != nullptr);
-    center_tile_mapcanvas(pcity->tile);
+    queen()->mapview_wdg->center_on_tile(pcity->tile, false);
   } else if (nullptr != client.conn.playing
              && 0 < unit_list_size(client.conn.playing->units)) {
     // Just focus on any unit.
     punit = unit_list_get(client.conn.playing->units, 0);
     fc_assert_ret(punit != nullptr);
-    center_tile_mapcanvas(unit_tile(punit));
+    queen()->mapview_wdg->center_on_tile(unit_tile(punit), false);
   } else {
     struct tile *ctile =
         native_pos_to_tile(&(wld.map), wld.map.xsize / 2, wld.map.ysize / 2);
@@ -437,9 +439,8 @@ void center_on_something()
     }
     iterate_outward_end;
 
-    center_tile_mapcanvas(ctile);
+    queen()->mapview_wdg->center_on_tile(ctile, false);
   }
-  can_slide = true;
 }
 
 /**

--- a/client/control.cpp
+++ b/client/control.cpp
@@ -52,6 +52,8 @@
 
 // gui-qt
 #include "chatline.h"
+#include "mapview.h"
+#include "page_game.h"
 #include "qtg_cxxside.h"
 
 struct client_disband_unit_data {
@@ -420,7 +422,7 @@ void auto_center_on_focus_unit()
 
   if (ptile && gui_options.auto_center_on_unit
       && !tile_visible_and_not_on_border_mapcanvas(ptile)) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
   }
 }
 
@@ -664,7 +666,7 @@ void unit_focus_advance()
       /* Autocenter on Wakeup, regardless of the local option
        * "auto_center_on_unit". */
       if (!tile_visible_and_not_on_border_mapcanvas(unit_tile(candidate))) {
-        center_tile_mapcanvas(unit_tile(candidate));
+        queen()->mapview_wdg->center_on_tile(unit_tile(candidate));
       }
     }
   }
@@ -2307,7 +2309,7 @@ void request_center_focus_unit()
   struct tile *ptile = find_a_focus_unit_tile_to_center_on();
 
   if (ptile) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
   }
 }
 
@@ -2375,7 +2377,7 @@ void do_move_unit(struct unit *punit, struct unit *target_unit)
            && punit->ssa_controller != SSA_NONE)
           || (punit->ssa_controller == SSA_NONE))
       && !tile_visible_and_not_on_border_mapcanvas(dst_tile)) {
-    center_tile_mapcanvas(dst_tile);
+    queen()->mapview_wdg->center_on_tile(dst_tile);
   }
 
   if (hover_state != HOVER_NONE && in_focus) {
@@ -2799,7 +2801,7 @@ void key_center_capital()
 
   if (capital) {
     // Center on the tile, and pop up the crosshair overlay.
-    center_tile_mapcanvas(capital->tile);
+    queen()->mapview_wdg->center_on_tile(capital->tile);
     put_cross_overlay_tile(capital->tile);
   } else {
     create_event(nullptr, E_BAD_COMMAND, ftc_client,

--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -903,7 +903,7 @@ notify_goto::notify_goto(const char *headline, const char *lines,
  */
 void notify_goto::goto_tile()
 {
-  center_tile_mapcanvas(gtile);
+  queen()->mapview_wdg->center_on_tile(gtile);
   close();
 }
 

--- a/client/gotodlg.cpp
+++ b/client/gotodlg.cpp
@@ -25,6 +25,7 @@
 #include "client_main.h"
 #include "control.h"
 #include "goto.h"
+#include "mapview.h"
 #include "mapview_common.h"
 #include "text.h"
 // gui-qt
@@ -145,7 +146,7 @@ void goto_dialog::item_selected(const QItemSelection &sl,
   item = goto_tab->item(i, 0);
   city_id = item->data(Qt::UserRole).toInt();
   dest = game_city_by_number(city_id);
-  center_tile_mapcanvas(city_tile(dest));
+  queen()->mapview_wdg->center_on_tile(city_tile(dest));
   can_airlift = false;
   for (const auto punit : get_units_in_focus()) {
     if (unit_can_airlift_to(punit, dest)) {
@@ -304,7 +305,7 @@ void goto_dialog::go_to_city()
  */
 void goto_dialog::close_dlg()
 {
-  center_tile_mapcanvas(original_tile);
+  queen()->mapview_wdg->center_on_tile(original_tile);
   hide();
 }
 

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -827,7 +827,7 @@ hud_action::hud_action(QWidget *parent, const QIcon &icon,
  */
 void hud_action::paintEvent(QPaintEvent *event)
 {
-  QRect rx, ry, rz;
+  QRect rx, rz;
   QPainter p;
 
   rx = QRect(0, 0, width(), height());
@@ -1853,7 +1853,7 @@ void hud_unit_combat::paintEvent(QPaintEvent *event)
  */
 void hud_unit_combat::mousePressEvent(QMouseEvent *e)
 {
-  center_tile_mapcanvas(center_tile);
+  queen()->mapview_wdg->center_on_tile(center_tile);
 }
 
 /**

--- a/client/mapctrl_common.cpp
+++ b/client/mapctrl_common.cpp
@@ -322,7 +322,7 @@ void recenter_button_pressed(int canvas_x, int canvas_y)
   struct tile *ptile = canvas_pos_to_nearest_tile(canvas_x, canvas_y);
 
   if (can_client_change_view() && ptile) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
   }
 }
 

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -138,6 +138,9 @@ map_view::map_view()
           std::make_unique<QPropertyAnimation>(m_renderer, "origin")),
       m_scale_animation(std::make_unique<QPropertyAnimation>(this, "scale"))
 {
+  connect(m_renderer, &freeciv::renderer::repaint_needed, this,
+          qOverload<const QRegion &>(&map_view::update));
+
   menu_click = false;
   cursor = -1;
   QTimer *timer = new QTimer(this);

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -257,7 +257,7 @@ double map_view::scale() const { return m_renderer->scale(); }
 void map_view::set_scale(double scale)
 {
   m_scale_animation->stop();
-  m_scale_animation->setDuration(100);
+  m_scale_animation->setDuration(gui_options.smooth_center_slide_msec);
   m_scale_animation->setEndValue(scale);
   m_scale_animation->setCurrentTime(0);
   m_scale_animation->start();

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -198,7 +198,7 @@ void map_view::show_all_fcwidgets()
 /**
  * Centers the view on a tile.
  */
-void map_view::center_on_tile(tile *tile)
+void map_view::center_on_tile(tile *tile, bool animate)
 {
   int tile_x, tile_y;
   index_to_map_pos(&tile_x, &tile_y, tile_index(tile));
@@ -211,20 +211,24 @@ void map_view::center_on_tile(tile *tile)
   gui_y -= (mapview.height - tileset_tile_height(tileset)) / 2;
 
   m_origin_animation->stop();
-  m_origin_animation->setDuration(gui_options.smooth_center_slide_msec);
-  m_origin_animation->setCurrentTime(0);
+  if (animate) {
+    m_origin_animation->setDuration(gui_options.smooth_center_slide_msec);
+    m_origin_animation->setCurrentTime(0);
 
-  const auto start = QPointF(mapview.gui_x0, mapview.gui_y0);
-  m_origin_animation->setStartValue(start);
+    const auto start = QPointF(mapview.gui_x0, mapview.gui_y0);
+    m_origin_animation->setStartValue(start);
 
-  // To wrap correctly, we first find the direction in which the animation
-  // should go and then choose the end point for Qt's linear interpolation.
-  float diff_x, diff_y;
-  gui_distance_vector(tileset, &diff_x, &diff_y, mapview.gui_x0,
-                      mapview.gui_y0, gui_x, gui_y);
-  m_origin_animation->setEndValue(start + QPointF(diff_x, diff_y));
+    // To wrap correctly, we first find the direction in which the animation
+    // should go and then choose the end point for Qt's linear interpolation.
+    float diff_x, diff_y;
+    gui_distance_vector(tileset, &diff_x, &diff_y, mapview.gui_x0,
+                        mapview.gui_y0, gui_x, gui_y);
+    m_origin_animation->setEndValue(start + QPointF(diff_x, diff_y));
 
-  m_origin_animation->start();
+    m_origin_animation->start();
+  } else {
+    m_renderer->set_origin(QPointF(gui_x, gui_y));
+  }
 }
 
 /**

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -73,7 +73,7 @@ signals:
   void scale_changed(double scale) const;
 
 public slots:
-  void center_on_tile(tile *tile);
+  void center_on_tile(tile *tile, bool animate = true);
 
   void zoom_in();
   void zoom_reset();

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -73,6 +73,8 @@ signals:
   void scale_changed(double scale) const;
 
 public slots:
+  void center_on_tile(tile *tile);
+
   void zoom_in();
   void zoom_reset();
   void zoom_out();
@@ -103,6 +105,7 @@ private:
   int cursor;
   freeciv::renderer *m_renderer;
   double m_scale = 1;
+  std::unique_ptr<QPropertyAnimation> m_origin_animation;
   std::unique_ptr<QPropertyAnimation> m_scale_animation;
   QPointer<freeciv::tileset_debugger> m_debugger = nullptr;
   std::vector<QPointer<fcwidget>> m_hidden_fcwidgets;

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -167,8 +167,8 @@ void map_to_gui_vector(const struct tileset *t, float *gui_dx, float *gui_dy,
    GUI coordinates are comparable to canvas coordinates but extend in all
    directions.  gui(0,0) == map(0,0).
  */
-static void map_to_gui_pos(const struct tileset *t, float *gui_x,
-                           float *gui_y, int map_x, int map_y)
+void map_to_gui_pos(const struct tileset *t, float *gui_x, float *gui_y,
+                    int map_x, int map_y)
 {
   /* Since the GUI origin is the same as the map origin we can just do a
    * vector conversion. */
@@ -401,9 +401,9 @@ static void normalize_gui_pos(const struct tileset *t, float *gui_x,
    Find the vector with minimum "real" distance between two GUI positions.
    This corresponds to map_to_distance_vector but works for GUI coordinates.
  */
-static void gui_distance_vector(const struct tileset *t, float *gui_dx,
-                                float *gui_dy, float gui_x0, float gui_y0,
-                                float gui_x1, float gui_y1)
+void gui_distance_vector(const struct tileset *t, float *gui_dx,
+                         float *gui_dy, float gui_x0, float gui_y0,
+                         float gui_x1, float gui_y1)
 {
   int map_x0, map_y0, map_x1, map_y1;
   float gui_x0_base, gui_y0_base, gui_x1_base, gui_y1_base;

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -978,7 +978,7 @@ void put_nuke_mushroom_pixmaps(struct tile *ptile)
    * we update everything to the store, but don't write this to screen.
    * Then add the nuke graphic to the store.  Finally flush everything to
    * the screen and wait 1 second. */
-  unqueue_mapview_updates(false);
+  unqueue_mapview_updates();
 
   QPainter p(mapview.store);
   p.drawPixmap(canvas_x, canvas_y, *mysprite);
@@ -1508,7 +1508,7 @@ void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
   punit0->hp = MAX(punit0->hp, hp0);
   punit1->hp = MAX(punit1->hp, hp1);
 
-  unqueue_mapview_updates(true);
+  unqueue_mapview_updates();
 
   const struct sprite_vector *anim = get_unit_explode_animation(tileset);
   const int num_tiles_explode_unit = sprite_vector_size(anim);
@@ -1524,14 +1524,14 @@ void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
       refresh_unit_mapcanvas(punit1, unit_tile(punit1), false);
     }
 
-    unqueue_mapview_updates(true);
+    unqueue_mapview_updates();
     anim_delay(gui_options.smooth_combat_step_msec);
   }
 
   if (num_tiles_explode_unit > 0
       && tile_to_canvas_pos(&canvas_x, &canvas_y, unit_tile(losing_unit))) {
     refresh_unit_mapcanvas(losing_unit, unit_tile(losing_unit), false);
-    unqueue_mapview_updates(false);
+    unqueue_mapview_updates();
     QPainter p(mapview.tmp_store);
     p.drawPixmap(canvas_x, canvas_y, *mapview.store, canvas_x, canvas_y,
                  tileset_tile_width(tileset), tileset_tile_height(tileset));
@@ -1612,8 +1612,8 @@ void move_unit_map_canvas(struct unit *punit, struct tile *src_tile, int dx,
           (tileset_unit_height(tileset) - tileset_full_tile_height(tileset));
     }
 
-    // Bring the backing store up to date, but don't flush.
-    unqueue_mapview_updates(false);
+    // Bring the backing store up to date.
+    unqueue_mapview_updates();
 
     tuw = tileset_unit_width(tileset);
     tuh = tileset_unit_height(tileset);
@@ -1907,10 +1907,8 @@ std::map<freeciv::map_updates_handler::update_type, QRectF> update_rects()
 /**
    See comment in update_map_canvas_visible().
  */
-void unqueue_mapview_updates(bool write_to_screen)
+void unqueue_mapview_updates()
 {
-  Q_UNUSED(write_to_screen);
-
   // Emit the repaint_needed signal of all updates handlers.
   // Emitting a signal is simply done by calling its function.
   freeciv::map_updates_handler::invoke(
@@ -2302,7 +2300,7 @@ void map_canvas_resized(int width, int height)
       /* Do not draw to the screen here as that could cause problems
        * when we are only initially setting up the view and some widgets
        * are not yet ready. */
-      unqueue_mapview_updates(false);
+      unqueue_mapview_updates();
     }
   }
   flush_dirty_overview();

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -229,9 +229,15 @@ void refresh_city_mapcanvas(struct city *pcity, struct tile *ptile,
 void unqueue_mapview_updates(bool write_to_screen);
 void map_to_gui_vector(const struct tileset *t, float *gui_dx, float *gui_dy,
                        int map_dx, int map_dy);
+void map_to_gui_pos(const struct tileset *t, float *gui_x, float *gui_y,
+                    int map_x, int map_y);
 bool tile_to_canvas_pos(float *canvas_x, float *canvas_y, const tile *ptile);
 struct tile *canvas_pos_to_tile(float canvas_x, float canvas_y);
 struct tile *canvas_pos_to_nearest_tile(float canvas_x, float canvas_y);
+
+void gui_distance_vector(const struct tileset *t, float *gui_dx,
+                         float *gui_dy, float gui_x0, float gui_y0,
+                         float gui_x1, float gui_y1);
 
 void get_mapview_scroll_window(float *xmin, float *ymin, float *xmax,
                                float *ymax, int *xsize, int *ysize);
@@ -239,7 +245,7 @@ void get_mapview_scroll_pos(int *scroll_x, int *scroll_y);
 
 void set_mapview_origin(float gui_x0, float gui_y0);
 struct tile *get_center_tile_mapcanvas();
-void center_tile_mapcanvas(struct tile *ptile);
+[[deprecated]] void center_tile_mapcanvas(struct tile *ptile);
 
 bool tile_visible_mapcanvas(struct tile *ptile);
 bool tile_visible_and_not_on_border_mapcanvas(struct tile *ptile);

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -245,7 +245,6 @@ void get_mapview_scroll_pos(int *scroll_x, int *scroll_y);
 
 void set_mapview_origin(float gui_x0, float gui_y0);
 struct tile *get_center_tile_mapcanvas();
-[[deprecated]] void center_tile_mapcanvas(struct tile *ptile);
 
 bool tile_visible_mapcanvas(struct tile *ptile);
 bool tile_visible_and_not_on_border_mapcanvas(struct tile *ptile);

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -222,7 +222,7 @@ void refresh_city_mapcanvas(struct city *pcity, struct tile *ptile,
                             bool full_refresh);
 
 std::map<freeciv::map_updates_handler::update_type, QRectF> update_rects();
-void unqueue_mapview_updates(bool write_to_screen);
+void unqueue_mapview_updates();
 void map_to_gui_vector(const struct tileset *t, float *gui_dx, float *gui_dy,
                        int map_dx, int map_dy);
 void map_to_gui_pos(const struct tileset *t, float *gui_x, float *gui_y,

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -42,10 +42,6 @@ void mapdeco_clear_gotoroutes();
 
 extern struct view mapview;
 
-/* HACK: Callers can set this to FALSE to disable sliding.  It should be
- * reenabled afterwards. */
-extern bool can_slide;
-
 #define GOTO_WIDTH 2
 
 /*

--- a/client/mapview_common.h
+++ b/client/mapview_common.h
@@ -25,7 +25,6 @@ struct view {
   int store_width, store_height;
   bool can_do_cached_drawing; // TRUE if cached drawing is possible.
   QPixmap *store, *tmp_store;
-  std::unique_ptr<freeciv::map_updates_handler> updates;
 };
 
 void mapdeco_init();
@@ -226,6 +225,7 @@ void refresh_unit_mapcanvas(struct unit *punit, struct tile *ptile,
 void refresh_city_mapcanvas(struct city *pcity, struct tile *ptile,
                             bool full_refresh);
 
+std::map<freeciv::map_updates_handler::update_type, QRectF> update_rects();
 void unqueue_mapview_updates(bool write_to_screen);
 void map_to_gui_vector(const struct tileset *t, float *gui_dx, float *gui_dy,
                        int map_dx, int map_dy);

--- a/client/messagewin_common.cpp
+++ b/client/messagewin_common.cpp
@@ -23,8 +23,10 @@
 
 // client
 #include "client_main.h"
+#include "mapview.h"
 #include "messagewin_common.h"
 #include "options.h"
+#include "page_game.h"
 #include "update_queue.h"
 
 // gui-qt
@@ -177,7 +179,7 @@ void meswin_popup_city(int message_index)
     struct city *pcity = tile_city(ptile);
 
     if (gui_options.center_when_popup_city) {
-      center_tile_mapcanvas(ptile);
+      queen()->mapview_wdg->center_on_tile(ptile);
     }
 
     if (pcity && can_player_see_units_in_city(client.conn.playing, pcity)) {
@@ -201,6 +203,6 @@ void meswin_goto(int message_index)
   fc_assert_ret(0 <= message_index && message_index < messages_total);
 
   if (messages[message_index]->location_ok) {
-    center_tile_mapcanvas(messages[message_index]->tile);
+    queen()->mapview_wdg->center_on_tile(messages[message_index]->tile);
   }
 }

--- a/client/minimap.cpp
+++ b/client/minimap.cpp
@@ -271,7 +271,7 @@ void minimap_view::mousePressEvent(QMouseEvent *event)
     overview_to_map_pos(&x, &y, fx, fy);
     auto *ptile = map_pos_to_tile(&(wld.map), x, y);
     fc_assert_ret(ptile);
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     update_image();
   }
   event->setAccepted(true);

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -84,11 +84,13 @@
 #include "editor.h"
 #include "goto.h" // client_goto_init()
 #include "governor.h"
+#include "mapview.h"
 #include "mapview_common.h"
 #include "messagewin_common.h"
 #include "music.h"
 #include "options.h"
 #include "overview_common.h"
+#include "page_game.h"
 #include "plrdlg_common.h"
 #include "tilespec.h"
 #include "update_queue.h"
@@ -503,9 +505,9 @@ void handle_unit_combat_info(const struct packet_unit_combat_info *packet)
       show_combat = true;
     } else if (gui_options.auto_center_on_combat) {
       if (unit_owner(punit0) == client.conn.playing) {
-        center_tile_mapcanvas(unit_tile(punit0));
+        queen()->mapview_wdg->center_on_tile(unit_tile(punit0));
       } else {
-        center_tile_mapcanvas(unit_tile(punit1));
+        queen()->mapview_wdg->center_on_tile(unit_tile(punit1));
       }
       show_combat = true;
     }

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -346,7 +346,7 @@ void center_next_enemy_city()
         }
         if ((last_center_enemy_city == 0) || center_next) {
           last_center_enemy_city = pcity->id;
-          center_tile_mapcanvas(pcity->tile);
+          queen()->mapview_wdg->center_on_tile(pcity->tile);
           return;
         }
         if (pcity->id == last_center_enemy_city) {
@@ -359,7 +359,7 @@ void center_next_enemy_city()
   players_iterate_end;
 
   if (ptile != nullptr) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     last_center_enemy_city = first_id;
   }
 }
@@ -386,7 +386,7 @@ void center_next_player_city()
         }
         if ((last_center_player_city == 0) || center_next) {
           last_center_player_city = pcity->id;
-          center_tile_mapcanvas(pcity->tile);
+          queen()->mapview_wdg->center_on_tile(pcity->tile);
           return;
         }
         if (pcity->id == last_center_player_city) {
@@ -399,7 +399,7 @@ void center_next_player_city()
   players_iterate_end;
 
   if (ptile != nullptr) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     last_center_player_city = first_id;
   }
 }
@@ -429,7 +429,7 @@ void center_next_player_capital()
       }
       if ((last_center_player_city == 0) || center_next) {
         last_center_player_city = capital->id;
-        center_tile_mapcanvas(capital->tile);
+        queen()->mapview_wdg->center_on_tile(capital->tile);
         put_cross_overlay_tile(capital->tile);
         return;
       }
@@ -441,7 +441,7 @@ void center_next_player_capital()
   players_iterate_end;
 
   if (ptile != nullptr) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     put_cross_overlay_tile(ptile);
     last_center_player_city = first_id;
   }
@@ -469,7 +469,7 @@ void cycle_enemy_units()
         }
         if ((last_center_enemy == 0) || center_next) {
           last_center_enemy = punit->id;
-          center_tile_mapcanvas(punit->tile);
+          queen()->mapview_wdg->center_on_tile(punit->tile);
           return;
         }
         if (punit->id == last_center_enemy) {
@@ -482,7 +482,7 @@ void cycle_enemy_units()
   players_iterate_end;
 
   if (ptile != nullptr) {
-    center_tile_mapcanvas(ptile);
+    queen()->mapview_wdg->center_on_tile(ptile);
     last_center_enemy = first_id;
   }
 }

--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -6,6 +6,7 @@
 
 #include "renderer.h"
 
+#include "map_updates_handler.h"
 #include "mapview_common.h"
 #include "mapview_g.h"
 
@@ -26,7 +27,12 @@ namespace freeciv {
 /**
  * Constructor.
  */
-renderer::renderer(QObject *parent) : QObject(parent) {}
+renderer::renderer(QObject *parent)
+    : QObject(parent), m_updates(new map_updates_handler(this))
+{
+  connect(m_updates, &map_updates_handler::repaint_needed, this,
+          &renderer::unqueue_updates, Qt::QueuedConnection);
+}
 
 /**
  * Changes the origin of the canvas (the point at the top left of the view).
@@ -35,7 +41,7 @@ void renderer::set_origin(const QPointF &origin)
 {
   m_origin = origin;
   set_mapview_origin(origin.x(), origin.y());
-  flush_dirty(); // Request (or rather, force) a new frame
+  emit repaint_needed(QRect(QPoint(), m_viewport_size));
 }
 
 /**
@@ -92,6 +98,55 @@ void renderer::render(QPainter &painter, const QRect &area) const
       QRectF(area.left() / scale(), area.top() / scale(),
              area.width() / scale(), area.height() / scale());
   painter.drawPixmap(area, *mapview.store, mapview_rect);
+}
+
+/**
+ * Processes all pending map updates and writes them to the map buffer.
+ */
+void renderer::unqueue_updates()
+{
+  const auto rects = update_rects();
+
+  /* This code "pops" the lists of tile updates off of the static array and
+   * stores them locally.  This allows further updates to be queued within
+   * the function itself (namely, within update_map_canvas). */
+  const auto updates = m_updates->list();
+  const auto full = m_updates->full();
+
+  m_updates->clear();
+
+  if (!map_is_empty()) {
+    if (full) {
+      update_map_canvas(0, 0, mapview.store_width, mapview.store_height);
+      emit repaint_needed(QRect(0, 0, mapview.store_width * scale(),
+                                mapview.store_height * scale()));
+    } else {
+      QRectF to_update;
+
+      for (const auto [tile, upd_types] : updates) {
+        for (const auto [type, rect] : rects) {
+          if (upd_types & type) {
+            float xl, yt;
+            (void) tile_to_canvas_pos(&xl, &yt, tile);
+            to_update |= rect.translated(xl, yt);
+          }
+        }
+      }
+
+      if (to_update.intersects(
+              QRectF(0, 0, mapview.width, mapview.height))) {
+        const auto aligned = to_update.toAlignedRect();
+        update_map_canvas(aligned.x(), aligned.y(), aligned.width(),
+                          aligned.height());
+
+        const auto scaled_aligned =
+            QRectF(aligned.x() * scale(), aligned.y() * scale(),
+                   aligned.width() * scale(), aligned.height() * scale())
+                .toAlignedRect();
+        emit repaint_needed(scaled_aligned);
+      }
+    }
+  }
 }
 
 } // namespace freeciv

--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -34,10 +34,8 @@ renderer::renderer(QObject *parent) : QObject(parent) {}
 void renderer::set_origin(const QPointF &origin)
 {
   m_origin = origin;
-  can_slide = false; // The renderer doesn't do any sliding by itself.
   set_mapview_origin(origin.x(), origin.y());
   flush_dirty(); // Request (or rather, force) a new frame
-  can_slide = true;
 }
 
 /**

--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -7,6 +7,7 @@
 #include "renderer.h"
 
 #include "mapview_common.h"
+#include "mapview_g.h"
 
 namespace freeciv {
 
@@ -19,12 +20,25 @@ namespace freeciv {
  *
  * @property scale By how much the map is scaled before being drawn (a scale
  * of 2 means that everything is 2x bigger)
+ * @property origin The position of the top left corner of the view.
  */
 
 /**
  * Constructor.
  */
 renderer::renderer(QObject *parent) : QObject(parent) {}
+
+/**
+ * Changes the origin of the canvas (the point at the top left of the view).
+ */
+void renderer::set_origin(const QPointF &origin)
+{
+  m_origin = origin;
+  can_slide = false; // The renderer doesn't do any sliding by itself.
+  set_mapview_origin(origin.x(), origin.y());
+  flush_dirty(); // Request (or rather, force) a new frame
+  can_slide = true;
+}
 
 /**
  * Changes the scale of the rendering (zooms in or out).

--- a/client/renderer.h
+++ b/client/renderer.h
@@ -15,6 +15,8 @@
 
 namespace freeciv {
 
+class map_updates_handler;
+
 class renderer : public QObject {
   Q_OBJECT
   Q_PROPERTY(QPointF origin READ origin WRITE set_origin);
@@ -39,10 +41,17 @@ public:
   void render(QPainter &painter, const QRegion &region) const;
   void render(QPainter &painter, const QRect &area) const;
 
+signals:
+  void repaint_needed(const QRegion &where);
+
+private slots:
+  void unqueue_updates();
+
 private:
   QPointF m_origin;
   double m_scale = 1.0;
   QSize m_viewport_size;
+  map_updates_handler *m_updates;
 };
 
 } // namespace freeciv

--- a/client/renderer.h
+++ b/client/renderer.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 #include <QPainter>
+#include <QPointF>
 #include <QRect>
 #include <QRegion>
 #include <QSize>
@@ -16,11 +17,16 @@ namespace freeciv {
 
 class renderer : public QObject {
   Q_OBJECT
+  Q_PROPERTY(QPointF origin READ origin WRITE set_origin);
   Q_PROPERTY(double scale READ scale WRITE set_scale);
 
 public:
   explicit renderer(QObject *parent = nullptr);
   virtual ~renderer() = default;
+
+  /// The origin of the view (the point at the top left corner)
+  QPointF origin() const { return m_origin; }
+  void set_origin(const QPointF &origin);
 
   /// The scale (zoom) at which rendering is performed
   double scale() const { return m_scale; }
@@ -34,6 +40,7 @@ public:
   void render(QPainter &painter, const QRect &area) const;
 
 private:
+  QPointF m_origin;
   double m_scale = 1.0;
   QSize m_viewport_size;
 };

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -77,7 +77,9 @@
 #include "layer_special.h"
 #include "layer_terrain.h"
 #include "layer_units.h"
+#include "mapview.h"
 #include "options.h" // for fill_xxx
+#include "page_game.h"
 #include "tilespec.h"
 
 // gui-qt
@@ -1101,12 +1103,10 @@ bool tilespec_reread(const QString &name, bool game_fully_initialized)
    */
   generate_citydlg_dimensions();
   tileset_changed();
-  can_slide = false;
-  center_tile_mapcanvas(center_tile);
   /* update_map_canvas_visible forces a full redraw.  Otherwise with fast
    * drawing we might not get one.  Of course this is slower. */
   update_map_canvas_visible();
-  can_slide = true;
+  queen()->mapview_wdg->center_on_tile(center_tile, false);
 
   return new_tileset_in_use;
 }

--- a/client/unitreport.cpp
+++ b/client/unitreport.cpp
@@ -106,7 +106,7 @@ void units_waiting::clicked(int x, int y)
 
   if (punit) {
     unit_focus_set(punit);
-    center_tile_mapcanvas(punit->tile);
+    queen()->mapview_wdg->center_on_tile(punit->tile);
   }
 }
 


### PR DESCRIPTION
There are two main changes in this PR:

* When centering the map on a new tile, a "busy" loop was started within the mapview code. Rewrite this loop with `QPropertyAnimation`, but keep the old code around because not all calls have been ported yet.
* Move the handling of map updates to the renderer class. This way, when there is an update the renderer gets notified directly and decides on its own when to update the cached maps.