### PR TITLE
Optimize Doxygen docs some

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ build.ninja
 .vs
 # Project file
 *.kdev4
+
+# In case someone runs Doxygen
+/doc/doxygen

--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -16,12 +16,8 @@ namespace freeciv {
  * @class renderer
  * @brief Renders the map on widgets
  *
- * This class is used to draw the map. It can handle zoom via the @ref scale
- * property.
- *
- * @property scale By how much the map is scaled before being drawn (a scale
- * of 2 means that everything is 2x bigger)
- * @property origin The position of the top left corner of the view.
+ * This class is used to draw the map. The position of the mapview is given
+ * by @ref origin and zoom is set via the @ref scale property.
  */
 
 /**
@@ -45,7 +41,8 @@ void renderer::set_origin(const QPointF &origin)
 }
 
 /**
- * Changes the scale of the rendering (zooms in or out).
+ * Changes the scale of the rendering (zooms in or out). A scale of 2 means
+ * that everything is 2x bigger.
  */
 void renderer::set_scale(double scale)
 {
@@ -71,9 +68,9 @@ void renderer::set_viewport_size(const QSize &size)
 }
 
 /**
- * Renders the specified region of the visible portion of the map on @c
+ * Renders the specified @c region of the visible portion of the map on @c
  * painter.
- * @see @ref render(QPainter&, const QRect&)
+ * @overload
  */
 void renderer::render(QPainter &painter, const QRegion &region) const
 {
@@ -85,8 +82,8 @@ void renderer::render(QPainter &painter, const QRegion &region) const
 /**
  * Renders the specified area of the visible portion of the map on @c
  * painter. This is meant to be used directly from @c paintEvent, so the
- * position of
- * @c area is relative to the @ref viewport.
+ * position of @c area is relative to the viewport.
+ * @overload
  */
 void renderer::render(QPainter &painter, const QRect &area) const
 {

--- a/doc/freeciv.doxygen
+++ b/doc/freeciv.doxygen
@@ -177,7 +177,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -242,7 +242,7 @@ TCL_SUBST              =
 # members will be omitted, etc.
 # The default value is: NO.
 
-OPTIMIZE_OUTPUT_FOR_C  = YES
+OPTIMIZE_OUTPUT_FOR_C  = NO
 
 # Set the OPTIMIZE_OUTPUT_JAVA tag to YES if your project consists of Java or
 # Python sources only. Doxygen will then generate output that is more tailored
@@ -309,7 +309,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.


### PR DESCRIPTION
This PR:

* Turns Doxygen to use C++ mode as we're writing more and more C++ code as opposed to C.
* Adds the files produced by Doxygen to `.gitignore`
* Improves the documentation of the newly introduced `renderer` class

To run Doxygen, use `doxygen doc/freeciv.doxygen`.
