### PR TITLE
Fix a double free of the attributes block

### DIFF
--- a/common/player.cpp
+++ b/common/player.cpp
@@ -578,11 +578,6 @@ static void player_defaults(struct player *pplayer)
     pplayer->wonder_build_turn[i] = -1;
   }
 
-  pplayer->attribute_block.data = nullptr;
-  pplayer->attribute_block.length = 0;
-  pplayer->attribute_block_buffer.data = nullptr;
-  pplayer->attribute_block_buffer.length = 0;
-
   pplayer->rgb = nullptr;
 
   memset(pplayer->multipliers, 0, sizeof(pplayer->multipliers));
@@ -629,11 +624,8 @@ void player_clear(struct player *pplayer, bool full)
   pplayer->savegame_ai_type_name = nullptr;
 
   // Clears the attribute blocks.
-  delete[] pplayer->attribute_block.data;
-  pplayer->attribute_block.length = 0;
-
-  delete[] pplayer->attribute_block_buffer.data;
-  pplayer->attribute_block_buffer.length = 0;
+  pplayer->attribute_block.clear();
+  pplayer->attribute_block_buffer.clear();
 
   // Clears units and cities.
   unit_list_iterate(pplayer->units, punit)

--- a/common/player.h
+++ b/common/player.h
@@ -283,8 +283,8 @@ struct player {
 
   int wonder_build_turn[B_LAST]; /* turn numbers when wonders were built */
 
-  struct attribute_block_s attribute_block;
-  struct attribute_block_s attribute_block_buffer;
+  QByteArray attribute_block;
+  QByteArray attribute_block_buffer;
 
   QBitArray *tile_known;
 


### PR DESCRIPTION
I had no idea where the double free came from, so I just refactored to avoid
explicit delete[] altogether.

Closes #1224.

**Testing**

The attributes block is used to store governor information. Check that governors can still be operated correctly; that they are saved and reloaded; that both old and new saves can still be loaded.