### PR TITLE
Fix horizontal edges not showing in iso-hex grids

### DIFF
--- a/client/editor.cpp
+++ b/client/editor.cpp
@@ -754,8 +754,7 @@ static void editor_end_selection_rectangle(int canvas_x, int canvas_y)
                           mapview.gui_y0 + editor->selrect_y,
                           editor->selrect_width, editor->selrect_height);
   for (auto it = freeciv::gui_rect_iterator(tileset, rect); it.next();) {
-    if (it.current_item() != freeciv::gui_rect_iterator::item_type::tile
-        || !it.tile()) {
+    if (!it.has_tile()) {
       continue;
     }
     if (editor->selection_mode == SELECTION_MODE_NEW

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -1194,21 +1194,16 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
     for (auto it = freeciv::gui_rect_iterator(tileset, rect); it.next();) {
       const int cx = it.x() - mapview.gui_x0, cy = it.y() - mapview.gui_y0;
 
-      switch (it.current_item()) {
-      case freeciv::gui_rect_iterator::item_type::corner:
+      if (it.has_corner()) {
         put_one_element(mapview.store, layer, nullptr, nullptr, &it.corner(),
                         nullptr, cx, cy);
-        break;
-      case freeciv::gui_rect_iterator::item_type::edge:
+      }
+      if (it.has_edge()) {
         put_one_element(mapview.store, layer, nullptr, &it.edge(), nullptr,
                         nullptr, cx, cy);
-        break;
-      case freeciv::gui_rect_iterator::item_type::tile:
-        // Unseen tiles are null
-        if (it.tile()) {
-          put_one_tile(mapview.store, layer, it.tile(), cx, cy);
-        }
-        break;
+      }
+      if (it.has_tile()) {
+        put_one_tile(mapview.store, layer, it.tile(), cx, cy);
       }
     }
   }
@@ -1227,8 +1222,7 @@ void update_map_canvas(int canvas_x, int canvas_y, int width, int height)
             height + 2 * GOTO_WIDTH);
   for (auto it = freeciv::gui_rect_iterator(tileset, goto_rect);
        it.next();) {
-    if (it.current_item() != freeciv::gui_rect_iterator::item_type::tile
-        || !it.tile()) {
+    if (!it.has_tile()) {
       continue;
     }
     adjc_dir_base_iterate(&(wld.map), it.tile(), dir)
@@ -1382,8 +1376,7 @@ void show_city_descriptions(int canvas_base_x, int canvas_base_y,
     const int canvas_x = it.x() - mapview.gui_x0;
     const int canvas_y = it.y() - mapview.gui_y0;
 
-    if (it.current_item() == freeciv::gui_rect_iterator::item_type::tile
-        && it.tile() && tile_city(it.tile())) {
+    if (it.has_tile() && tile_city(it.tile())) {
       int width = 0, height = 0;
       struct city *pcity = tile_city(it.tile());
 
@@ -1427,8 +1420,7 @@ void show_tile_labels(int canvas_base_x, int canvas_base_y, int width_base,
     const int canvas_x = it.x() - mapview.gui_x0;
     const int canvas_y = it.y() - mapview.gui_y0;
 
-    if (it.current_item() == freeciv::gui_rect_iterator::item_type::tile
-        && it.tile() && it.tile()->label != nullptr) {
+    if (it.has_tile() && it.tile()->label != nullptr) {
       int width = 0, height = 0;
 
       show_tile_label(mapview.store, canvas_x, canvas_y, it.tile(), &width,

--- a/client/mapview_geometry.cpp
+++ b/client/mapview_geometry.cpp
@@ -40,8 +40,97 @@ namespace freeciv {
  * One can also retrieve the canvas position of the current item using the
  * @ref x and @ref y functions.
  *
- * @todo Recover the picture of the grid formerly at
- *       http://article.gmane.org/gmane.games.freeciv.devel/50449.
+ * The order of iteration depends on the map topology. The basic idea is to
+ * operate on a rectangular grid, which works pretty nicely when the topology
+ * is neither isometric nor hexagonal:
+ * ~~~
+ *    |     |     |
+ * t  e  t  e  t  e  t
+ *    |     |     |
+ * e--c--e--c--e--c--e--
+ *    |     |     |
+ * t  e  t  e  t  e  t
+ *    |     |     |
+ * e--c--e--c--e--c--e--
+ *    |     |     |
+ * t  e  t  e  t  e  t
+ *    |     |     |
+ * ~~~
+ *
+ * In the diagram above, "t" stands for @ref tile, "e" for @ref edge, and "c"
+ * for @ref corner. Iteration takes place from left to right and from top to
+ * bottom, i.e. in reading order.
+ *
+ * Things get more complicated for isometric grids, as some points on the
+ * grid don't correspond to anything and need to be skipped. They are
+ * represented with dots in the diagram below:
+ * ~~~
+ * t . c . t . c . t
+ *    / \     / \
+ * . e . e . e . e .
+ *  /     \ /     \
+ * c . t . c . t . c
+ *  \     / \     /
+ * . e . e . e . e .
+ *    \ /     \ /
+ * t . c . t . c . t
+ *    / \     / \
+ * . e . e . e . e .
+ *  /     \ /     \
+ * c . t . c . t . c
+ *  \     / \     /
+ * . e . e . e . e .
+ *    \ /     \ /
+ * t . c . t . c . t
+ * ~~~
+ *
+ * For hexagonal grids, some points are corners and edges at the same time:
+ * ~~~
+ *   . --ce- .   t   . --ce- .
+ *    /     \         /     \
+ *   e   .   e   .   e   .   e
+ *  /         \     /         \
+ * - .   t   . --ce- .   t   . -
+ *  \         /     \         /
+ *   e   .   e   .   e   .   e
+ *    \     /         \     /
+ *   . --ce- .   t   . --ce- .
+ *    /     \         /     \
+ *   e   .   e   .   e   .   e
+ *  /         \     /         \
+ * - .   t   . --ce- .   t   . -
+ *  \         /     \         /
+ *   e   .   e   .   e   .   e
+ *    \     /         \     /
+ *   . --ce-  .  t   . --ce- .
+ * ~~~
+ *
+ *
+ * ~~~
+ * t . c . t . c . t
+ *    / \     / \
+ * . e . e . e . e .
+ *  /     \ /     \
+ * |       |       |
+ * ce. t . ce. t . ce
+ * |       |       |
+ *  \     / \     /
+ * . e . e . e . e .
+ *    \ /     \ /
+ *     |       |
+ * t . ce. t . ce. t
+ *     |       |
+ *    / \     / \
+ * . e . e . e . e .
+ *  /     \ /     \
+ * |       |       |
+ * ce. t . ce. t . ce
+ * |       |       |
+ *  \     / \     /
+ * . e . e . e . e .
+ *    \ /     \ /
+ * t . c . t . c . t
+ * ~~~
  */
 
 /**

--- a/client/mapview_geometry.h
+++ b/client/mapview_geometry.h
@@ -18,31 +18,24 @@ namespace freeciv {
 
 class gui_rect_iterator {
 public:
-  /// The type of item currently being iterated over.
-  enum class item_type {
-    corner, ///< The meeting point of up to four tiles.
-    edge,   ///< The edge between two tiles.
-    tile,   ///< The center of a tile.
-  };
-
   gui_rect_iterator(const struct tileset *t, const QRect &rect);
 
-  /**
-   * Retrieves the current corner. Only valid if @ref current_item is
-   * @ref item_type::corner "corner".
-   */
+  /// Checks whether the current iteration point has a corner.
+  bool has_corner() const { return m_has_corner; }
+
+  /// Checks whether the current iteration point has an edge.
+  bool has_edge() const { return m_has_edge; }
+
+  /// Checks whether the current iteration point has a non-null tile.
+  bool has_tile() const { return m_has_tile; }
+
+  /// Retrieves the current corner. Only valid if @ref has_corner is @c true.
   const tile_corner &corner() const { return m_corner; }
 
-  /**
-   * Retrieves the current edge. Only valid if @ref current_item is
-   * @ref item_type::edge "edge".
-   */
+  /// Retrieves the current edge. Only valid if @ref has_edge is @c true.
   const tile_edge &edge() const { return m_edge; }
 
-  /**
-   * Retrieves the current tile. Only valid if @ref current_item is
-   * @ref item_type::tile "tile".
-   */
+  /// Retrieves the current tile. Only valid if @ref has_tile is @c true.
   const ::tile *tile() const { return m_tile; }
 
   /// Retrieves the x position of the current item.
@@ -53,9 +46,6 @@ public:
 
   bool next();
 
-  /// Retrieves the type of the current item.
-  item_type current_item() { return m_type; }
-
 private:
   bool m_isometric;
   int m_index, m_count;
@@ -63,10 +53,10 @@ private:
   int m_x0, m_y0, m_x1, m_y1;
   int m_xi, m_yi;
 
-  item_type m_type = item_type::tile; // Just set it to *something* initially
   tile_corner m_corner;
   tile_edge m_edge;
   ::tile *m_tile = nullptr;
+  bool m_has_corner = false, m_has_edge = false, m_has_tile = false;
 };
 
 } // namespace freeciv


### PR DESCRIPTION
In the initial implementation of gui_rect_iterator, it was assumed that each
iteration point corresponds to a single type of object in the geometry. This
was without counting on the laziness of Freeciv's hex implementation, which
simply collapsed one of the vertical edges into a corner. In hex mode, some
iteration points need to be corners and edges at the same time.

This PR also adds more documentation to the code.

Closes https://github.com/longturn/freeciv21/issues/1253.