### PR TITLE
Initialize city_dialog::pcity

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1472,6 +1472,7 @@ void city_dialog::hideEvent(QHideEvent *event)
       unit_focus_update();
     }
     update_map_canvas_visible();
+    pcity = nullptr;
   }
   queen()->mapview_wdg->show_all_fcwidgets();
 }

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -359,7 +359,7 @@ public:
   void setup_ui(struct city *qcity);
   void refresh();
   void cma_check_agent();
-  struct city *pcity;
+  struct city *pcity = nullptr;
   bool dont_focus{false};
 
 private:


### PR DESCRIPTION
I encountered a class of crashes where city_dialog::pcity was garbage. Make
sure that it's always nullptr while the city screen is hidden.

## Testing

Zoom in and out many times while also constantly switching player. `master` crashes occasionally, this patch prevents the crash.