### PR TITLE
Port unit wait time patches

### DIFF
--- a/common/city.cpp
+++ b/common/city.cpp
@@ -3353,6 +3353,9 @@ struct city *create_city_virtual(struct player *pplayer, struct tile *ptile,
   if (is_server()) {
     pcity->server.mgr_score_calc_turn = -1; // -1 = never
 
+    pcity->server.prod_change_timestamp = time(NULL);
+    pcity->server.prod_change_turn = game.info.turn;
+
     CALL_FUNC_EACH_AI(city_alloc, pcity);
   } else {
     pcity->client.info_units_supported =

--- a/common/city.h
+++ b/common/city.h
@@ -415,6 +415,10 @@ struct city {
       void *ais[FREECIV_AI_MOD_LAST];
 
       struct vision *vision;
+
+      /* when city production was changed by player */
+      time_t prod_change_timestamp;
+      int prod_change_turn;
     } server;
 
     struct {

--- a/common/fc_types.h
+++ b/common/fc_types.h
@@ -764,6 +764,17 @@ BV_DEFINE(bv_startpos_nations, MAX_NUM_STARTPOS_NATIONS);
 #include "specenum_gen.h"
 
 // Used in the network protocol.
+#define SPECENUM_NAME unitwaittime_style
+#define SPECENUM_BITWISE
+// Unit wait time only prevents moving.
+#define SPECENUM_ZERO UWT_CLASSICAL
+#define SPECENUM_ZERONAME "Classical"
+// Wait time applies to activities such as building roads and fortresses.
+#define SPECENUM_VALUE0 UWT_ACTIVITIES
+#define SPECENUM_VALUE0NAME "Activities"
+#include "specenum_gen.h"
+
+// Used in the network protocol.
 #define SPECENUM_NAME gameloss_style
 #define SPECENUM_BITWISE
 // Like classical Freeciv. No special effects.

--- a/common/game.cpp
+++ b/common/game.cpp
@@ -405,6 +405,7 @@ static void game_defaults(bool keep_ruleset_value)
     game.server.timeoutintinc = GAME_DEFAULT_TIMEOUTINTINC;
     game.server.turnblock = GAME_DEFAULT_TURNBLOCK;
     game.server.unitwaittime = GAME_DEFAULT_UNITWAITTIME;
+    game.server.unitwaittime_extended = GAME_DEFAULT_UNITWAITTIME_EXTENDED;
     game.server.plr_colors = nullptr;
   } else {
     // Client side takes care of itself in client_main()

--- a/common/game.h
+++ b/common/game.h
@@ -184,6 +184,7 @@ struct civ_game {
       int techpenalty;
       bool turnblock;
       int unitwaittime; // minimal time between two movements of a unit
+      unsigned unitwaittime_style;
       int upgrade_veteran_loss;
       bool vision_reveal_tiles;
 
@@ -574,6 +575,8 @@ extern struct world wld;
 #define GAME_MIN_UNITWAITTIME 0
 #define GAME_MAX_UNITWAITTIME GAME_MAX_TIMEOUT
 #define GAME_DEFAULT_UNITWAITTIME 0
+
+#define GAME_DEFAULT_UNITWAITTIME_STYLE UWT_CLASSICAL
 
 #define GAME_DEFAULT_PHASE_MODE 0
 

--- a/common/game.h
+++ b/common/game.h
@@ -184,6 +184,8 @@ struct civ_game {
       int techpenalty;
       bool turnblock;
       int unitwaittime; // minimal time between two movements of a unit
+      bool unitwaittime_extended; // UWT applies to built and captured/bribed
+                                  // units.
       unsigned unitwaittime_style;
       int upgrade_veteran_loss;
       bool vision_reveal_tiles;
@@ -575,6 +577,7 @@ extern struct world wld;
 #define GAME_MIN_UNITWAITTIME 0
 #define GAME_MAX_UNITWAITTIME GAME_MAX_TIMEOUT
 #define GAME_DEFAULT_UNITWAITTIME 0
+#define GAME_DEFAULT_UNITWAITTIME_EXTENDED false
 
 #define GAME_DEFAULT_UNITWAITTIME_STYLE UWT_CLASSICAL
 

--- a/common/unit.h
+++ b/common/unit.h
@@ -116,6 +116,21 @@ struct unit_order {
 struct unit;
 struct unit_list;
 
+struct unit_wait {
+  int id;
+  time_t wake_up;
+  enum unit_activity activity;
+  int activity_count;
+};
+
+// 'struct unit_wait_list' and related functions.
+#define SPECLIST_TAG unit_wait
+#define SPECLIST_TYPE struct unit_wait
+#include "speclist.h"
+#define unit_wait_list_link_iterate(unit_wait_list, plink)                  \
+  TYPED_LIST_LINK_ITERATE(struct unit_wait_list_link, unit_wait_list, plink)
+#define unit_wait_list_link_iterate_end LIST_LINK_ITERATE_END
+
 struct unit {
   const struct unit_type *utype; // Cannot be nullptr.
   struct tile *tile;
@@ -223,6 +238,7 @@ struct unit {
       int ord_city;
 
       struct vision *vision;
+      struct unit_wait_list_link *wait;
       struct unit_move_data *moving;
 
       // The unit is in the process of dying.

--- a/server/cityhand.cpp
+++ b/server/cityhand.cpp
@@ -343,6 +343,9 @@ void really_handle_city_buy(struct player *pplayer, struct city *pcity)
   }
   city_refresh(pcity);
 
+  /* Update action timestamp inherited by the bought unit */
+  city_did_prod_change(pcity);
+
   if (VUT_UTYPE == pcity->production.kind) {
     notify_player(pplayer, pcity->tile, E_UNIT_BUY, ftc_server,
                   // TRANS: bought an unit.

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -1285,6 +1285,9 @@ bool transfer_city(struct player *ptaker, struct city *pcity,
       advisor_choose_build(ptaker, pcity);
     }
 
+    // Update action timestamp inherited by any units being produced
+    city_did_prod_change(pcity);
+
     // What wasn't obsolete for the old owner may be so now.
     remove_obsolete_buildings_city(pcity, true);
 
@@ -3009,6 +3012,9 @@ void change_build_target(struct player *pplayer, struct city *pcity,
   // Change build target.
   pcity->production = *target;
 
+  // Update action timestamp inherited by any units being produced
+  city_did_prod_change(pcity);
+
   // What's the name of the target?
   name = city_production_name_translation(pcity);
 
@@ -3048,6 +3054,16 @@ void change_build_target(struct player *pplayer, struct city *pcity,
                   _("The %s have started building The %s in %s."),
                   nation_plural_for_player(pplayer), name, city_link(pcity));
   }
+}
+
+/**
+ * City did something to change production. Used to set action
+ * timestamps for new units.
+ */
+void city_did_prod_change(struct city *pcity)
+{
+  pcity->server.prod_change_timestamp = time(nullptr);
+  pcity->server.prod_change_turn = game.info.turn;
 }
 
 /**

--- a/server/citytools.h
+++ b/server/citytools.h
@@ -113,3 +113,5 @@ void clear_worker_tasks(struct city *pcity);
 void package_and_send_worker_tasks(struct city *pcity);
 
 int city_production_buy_gold_cost(const struct city *pcity);
+
+void city_did_prod_change(struct city *pcity);

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -2482,6 +2482,13 @@ static struct unit *city_create_unit(struct city *pcity,
            pcity->rally_point.length * sizeof(struct unit_order));
   }
 
+  /* Initialize the new unit's action timestamp from when the city
+     production was changed or the unit bought */
+  if (game.server.unitwaittime_extended) {
+    punit->action_timestamp = pcity->server.prod_change_timestamp;
+    punit->action_turn = pcity->server.prod_change_turn;
+  }
+
   /* This might destroy pcity and/or punit: */
   script_server_signal_emit("unit_built", punit, pcity);
 

--- a/server/diplomats.cpp
+++ b/server/diplomats.cpp
@@ -660,6 +660,11 @@ bool diplomat_bribe(struct player *pplayer, struct unit *pdiplomat,
     return true;
   }
 
+  if (game.server.unitwaittime_extended) {
+    /* Counts as an action even if the move to be tried doesn't succeed */
+    unit_did_action(pdiplomat);
+  }
+
   /* Try to move the briber onto the victim's square unless the victim has
    * been bounced because it couldn't share tile with a unit or city. */
   if (!bounce

--- a/server/sernet.h
+++ b/server/sernet.h
@@ -30,6 +30,7 @@ void close_connections_and_socket();
 void really_close_connections();
 void init_connections();
 int server_make_connection(QTcpSocket *new_sock, const QString &client_addr);
+void finish_unit_waits();
 void connection_ping(struct connection *pconn);
 void handle_conn_pong(struct connection *pconn);
 void handle_client_heartbeat(struct connection *pconn);

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "server.h"
+#include "unittools.h"
 
 // Qt
 #include <QCoreApplication>
@@ -1071,6 +1072,8 @@ void server::pulse()
     }
   }
   conn_list_iterate_end
+
+  finish_unit_waits();
 
   call_ai_refresh();
   script_server_signal_emit("pulse");

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -2774,6 +2774,18 @@ static struct setting settings[] = {
         nullptr, nullptr, unitwaittime_name,
         GAME_DEFAULT_UNITWAITTIME_STYLE),
 
+    GEN_BOOL(
+        "unitwaittime_extended", game.server.unitwaittime_extended,
+        SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, ALLOW_NONE,
+        ALLOW_BASIC,
+        N_("Unitwaittime also applies to newly-built and captured/bribed "
+           "units."),
+        N_("If set, newly-built units are subject to unitwaittime so that "
+           "the moment the city production was last touched counts as their "
+           "last \"action\". Also, getting captured/bribed counts as action "
+           "for the victim. "),
+        nullptr, nullptr, GAME_DEFAULT_UNITWAITTIME_EXTENDED),
+
     /* This setting points to the "stored" value; changing it won't have an
        effect until the next synchronization point (i.e., the start of the
        next turn). */

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -565,6 +565,18 @@ static const struct sset_val_name *bool_name(int enable)
   return nullptr;
 }
 
+/**
+ * Unitwaittime style names accessor.
+ */
+static const struct sset_val_name *unitwaittime_name(int bit)
+{
+  switch (1 << bit) {
+    NAME_CASE(UWT_ACTIVITIES, "ACTIVITIES",
+              N_("Wait time applies to activity completion at turn change"));
+  }
+  return NULL;
+}
+
 #undef NAME_CASE
 
 /****************************************************************************
@@ -2743,6 +2755,24 @@ static struct setting settings[] = {
                "limited to a maximum value of 2/3 'timeout'."),
             nullptr, unitwaittime_callback, nullptr, GAME_MIN_UNITWAITTIME,
             GAME_MAX_UNITWAITTIME, GAME_DEFAULT_UNITWAITTIME),
+
+    GEN_BITWISE(
+        "unitwaittime_style", game.server.unitwaittime_style,
+        SSET_RULES_FLEXIBLE, SSET_INTERNAL, SSET_VITAL, ALLOW_NONE,
+        ALLOW_BASIC, N_("Unitwaittime style"),
+        /* TRANS: The strings between double quotes are also translated
+         * separately (they must match!). The strings between single
+         * quotes are setting names and shouldn't be translated. The
+         * strings between parentheses and in uppercase must stay as
+         * untranslated. */
+        N_("This setting affects unitwaittime:\n"
+           "- \"Activities\" (ACTIVITIES): Units moved less than "
+           "'unitwaittime' seconds from turn change will not complete "
+           "activities such as pillaging and building roads during "
+           "turn change, but during the next turn when their wait "
+           "expires."),
+        nullptr, nullptr, unitwaittime_name,
+        GAME_DEFAULT_UNITWAITTIME_STYLE),
 
     /* This setting points to the "stored" value; changing it won't have an
        effect until the next synchronization point (i.e., the start of the

--- a/server/srv_main.h
+++ b/server/srv_main.h
@@ -84,6 +84,8 @@ extern struct civserver {
   unsigned short identity_number;
 
   char game_identifier[MAX_LEN_GAME_IDENTIFIER];
+
+  struct unit_wait_list *unit_waits;
 } server;
 
 void init_game_seed();

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2200,6 +2200,11 @@ struct unit *unit_change_owner(struct unit *punit, struct player *pplayer,
   gained_unit->paradropped = punit->paradropped;
   gained_unit->server.birth_turn = punit->server.birth_turn;
 
+  if (game.server.unitwaittime_extended) {
+    // Counts as an action for unitwaittime
+    unit_did_action(gained_unit);
+  }
+
   send_unit_info(nullptr, gained_unit);
 
   // update unit upkeep in the homecity of the victim

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -88,6 +88,7 @@ void execute_unit_orders(struct player *pplayer);
 void finalize_unit_phase_beginning(struct player *pplayer);
 
 // various
+void finish_unit_wait(struct unit *punit, int activity_count);
 void place_partisans(struct tile *pcenter, struct player *powner, int count,
                      int sq_radius);
 bool teleport_unit_to_city(struct unit *punit, struct city *pcity,


### PR DESCRIPTION
This ports two of the LT patches mentioned in #1150:

* Add the option for unitwaittime to apply to unit activities
* Expand unitwaittime to affect newly-built units and captured/bribed units

I don't think we should port the other two.

The port itself is untested, but the original patches have been used in production.

Closes #1150.