### PR TITLE
Add commands to control the timeout

### DIFF
--- a/server/commands.cpp
+++ b/server/commands.cpp
@@ -423,6 +423,32 @@ static struct command commands[] = {
      N_("If there is none, become the game organizer with increased "
         "permissions."),
      nullptr, nullptr, CMD_ECHO_ADMINS, VCF_NONE, 50},
+    {"timeoutshow", ALLOW_INFO, SYN_ORIG_("timeoutshow"),
+     N_("Show timeout settings and timers."),
+     N_("Shows information about the timeout for the current turn, for "
+        "instance how much time is left."),
+     nullptr, CMD_ECHO_ALL, VCF_NONE, 0},
+    {"timeoutset", ALLOW_CTRL,
+     // TRANS: translate text between <> only
+     N_("timeoutset <time>"),
+     N_("Changes the timeout for the current turn."),
+     // TRANS: don't translate the format
+     N_("This command changes the remaining time for the current turn. "
+        "Passing a value of 0 ends the turn immediately.\n"
+        "The time is specified as hours, minutes, and seconds using the "
+        "format hh:mm:ss (minutest and hours and are "
+        "optional)."),
+     nullptr, CMD_ECHO_ALL, VCF_NONE, 50},
+    {"timeoutadd", ALLOW_CTRL,
+     // TRANS: translate text between <> only
+     N_("timeoutadd <time>"), N_("Adds more time to the current turn."),
+     // TRANS: don't translate the format
+     N_("This increases the timeout for the current turn, giving players "
+        "more time to finish their actions.\n"
+        "The time is specified as hours, minutes, and seconds using the "
+        "format hh:mm:ss (minutest and hours and are "
+        "optional)."),
+     nullptr, CMD_ECHO_ALL, VCF_NONE, 50},
     {"timeoutincrease", ALLOW_CTRL,
      // TRANS: translate text between <> only
      N_("timeoutincrease <turn> <turninc> <value> <valuemult>"),

--- a/server/commands.cpp
+++ b/server/commands.cpp
@@ -447,7 +447,7 @@ static struct command commands[] = {
         "more time to finish their actions.\n"
         "The time is specified as hours, minutes, and seconds using the "
         "format hh:mm:ss (minutest and hours and are "
-        "optional)."),
+        "optional). Negative values are allowed."),
      nullptr, CMD_ECHO_ALL, VCF_NONE, 50},
     {"timeoutincrease", ALLOW_CTRL,
      // TRANS: translate text between <> only

--- a/server/commands.h
+++ b/server/commands.h
@@ -71,7 +71,10 @@ enum command_id {
 #endif
   CMD_CMDLEVEL,
   CMD_FIRSTLEVEL,
-  CMD_TIMEOUT,
+  CMD_TIMEOUT_SHOW, // not really harmful, info level
+  CMD_TIMEOUT_SET,
+  CMD_TIMEOUT_ADD,
+  CMD_TIMEOUT_INCREASE,
   CMD_CANCELVOTE,
   CMD_IGNORE,
   CMD_UNIGNORE,


### PR DESCRIPTION
Add three new timeout-related server commands:

- timeoutshow displays the current timeout
- timeoutadd adds time to the current turn
- timeoutset sets the remaining time for the current turn

They are named timeoutsomething for three reasons:

- timeoutincrease already exists
- it's easier to find them if they're together in /help commands
- sub-commands like "timeout show" are not feasible with the current
  implementation

This is heavily inspired from an earlier patch used by LT with 2.6,
41cc12b401fe4a9db8d22b78039561710fff59e3. The syntax is however more flexible,
allowing for hours or minutes to be passed directly without doing any
calculation.

Closes #1151.