### PR TITLE
Remove comments headers with too many stars

### DIFF
--- a/ai/default/aiair.cpp
+++ b/ai/default/aiair.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/ai/default/aidata.cpp
+++ b/ai/default/aidata.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "game.h"

--- a/ai/default/aidiplomat.cpp
+++ b/ai/default/aidiplomat.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "bitvector.h"

--- a/ai/default/aiferry.cpp
+++ b/ai/default/aiferry.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/ai/default/aiguard.cpp
+++ b/ai/default/aiguard.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/ai/default/aihand.cpp
+++ b/ai/default/aihand.cpp
@@ -58,7 +58,7 @@
 
 #include "aihand.h"
 
-/*****************************************************************************
+/**
   A man builds a city
   With banks and cathedrals
   A man melts the sand so he can
@@ -70,7 +70,7 @@
   And these are the days when our work has come assunder
   And these are the days when we look for something other
   /U2 Lemon.
-*****************************************************************************/
+ */
 
 #define LOGLEVEL_TAX LOG_DEBUG
 
@@ -149,9 +149,9 @@ void dai_calc_data(const struct player *pplayer, int *trade, int *expenses,
   }
 }
 
-/*****************************************************************************
+/**
   Additional data needed for the AI rates calculation
-*****************************************************************************/
+ */
 enum { AI_RATE_SCI = 0, AI_RATE_TAX, AI_RATE_LUX, AI_RATE_COUNT };
 
 enum celebration {

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "bitvector.h"

--- a/ai/default/ailog.cpp
+++ b/ai/default/ailog.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "map.h"

--- a/ai/default/aiparatrooper.cpp
+++ b/ai/default/aiparatrooper.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <QHash>
 

--- a/ai/default/daiactions.cpp
+++ b/ai/default/daiactions.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "city.h"

--- a/ai/default/daidiplomacy.cpp
+++ b/ai/default/daidiplomacy.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #endif

--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "city.h"

--- a/client/attribute.cpp
+++ b/client/attribute.cpp
@@ -8,7 +8,7 @@
          `%%%%%%%'       or (at your option) any later version. You should
             have received  a copy of the GNU  General Public License along
                  with Freeciv21. If not, see https://www.gnu.org/licenses/.
-                 ********************************************************/
+ */
 
 #include <QHash>
 

--- a/client/audio.cpp
+++ b/client/audio.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>

--- a/client/audio_none.cpp
+++ b/client/audio_none.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "support.h"
 

--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
    //           Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors.
  _oo\ This file is  part of Freeciv21. Freeciv21 is free software: you can
 (__/ \  _  _   redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
     \_______/  \  your option) any later version. You should have received
      [[] [[] a copy of the GNU General Public License along with Freeciv21.
      [[] [[]                     If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "chatline.h"
 // Qt

--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv and Freeciv21 contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cmath>
 #include <vector>

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "citydlg.h"
 // Qt

--- a/client/cityrep.cpp
+++ b/client/cityrep.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QApplication>

--- a/client/cityrepdata.cpp
+++ b/client/cityrepdata.cpp
@@ -883,7 +883,7 @@ void init_city_report_game_data()
             == ARRAY_SIZE(base_city_report_specs) + specialist_count() + 1);
 }
 
-/************************************************************************
+/**
   The following several functions allow intelligent sorting city report
   fields by column.  This doesn't necessarily do the right thing, but
   it's better than sorting alphabetically.
@@ -894,7 +894,7 @@ void init_city_report_game_data()
   way, two character fields are compared alphabetically.  Arbitrarily, a
   numeric field is sorted before a character field (for "justification"
   note that numbers are before letters in the ASCII table).
-************************************************************************/
+ */
 
 /* A datum is one short string, or one number.
    A datum_vector represents a long string of alternating strings and

--- a/client/civstatus.cpp
+++ b/client/civstatus.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
                   Copyright (c) 2021 Freeciv21 contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 #include "civstatus.h"
 
 #include "canvas.h"

--- a/client/climap.cpp
+++ b/client/climap.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "map.h"

--- a/client/climisc.cpp
+++ b/client/climisc.cpp
@@ -11,10 +11,10 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/***********************************************************************
+/**
   This module contains various general - mostly highlevel - functions
   used throughout the client.
-***********************************************************************/
+ */
 
 #include <QBitArray>
 #include <algorithm>

--- a/client/colors.cpp
+++ b/client/colors.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <QPainter>
 // gui-qt

--- a/client/colors_common.cpp
+++ b/client/colors_common.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/client/connectdlg.cpp
+++ b/client/connectdlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "game.h"

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>
 #endif
@@ -97,7 +97,7 @@ void serverProcess::drop()
   }
 }
 
-/**************************************************************************
+/**
 The general chain of events:
 
 Two distinct paths are taken depending on the choice of mode:
@@ -120,7 +120,7 @@ then:
          not. if not, then we send another load command. if so, then we send
          a series of packet_generic_message packets with commands to start
          the game.
-**************************************************************************/
+ */
 
 /**
    Tests if the client has started the server.

--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "dialogs.h"
 // Qt

--- a/client/diplodlg.cpp
+++ b/client/diplodlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "diplodlg.h"
 // Qt

--- a/client/economyreport.cpp
+++ b/client/economyreport.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "economyreport.h"
 // client

--- a/client/editor.cpp
+++ b/client/editor.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <QRect>
 #include <QSet>

--- a/client/endgamereport.cpp
+++ b/client/endgamereport.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "endgamereport.h"
 // Qt

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "fc_client.h"
 // Qt
@@ -338,9 +338,9 @@ void fc_client::slot_disconnect()
   switch_page(PAGE_MAIN);
 }
 
-/****************************************************************************
+/**
   Deletes cursors
-****************************************************************************/
+ */
 void fc_client::delete_cursors()
 {
   int frame;

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "fonts.h"
 // Qt
@@ -90,7 +90,7 @@ void fcFont::initFonts()
   options_iterate_end;
 }
 
-/*****************************************************************************
+/**
    Increases/decreases all fonts sizes
  */
 void fcFont::setSizeAll(int new_size)

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -43,9 +43,9 @@ class PFPath;
 // Indexed by unit id
 static auto goto_finders = std::map<int, freeciv::path_finder>();
 
-/****************************************************************************
+/**
   Various stuff for the goto routes
-****************************************************************************/
+ */
 static struct tile *goto_destination = nullptr;
 
 /**

--- a/client/gotodlg.cpp
+++ b/client/gotodlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "gotodlg.h"
 // Qt

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Keep this first. In particular before any Qt include.
 #ifdef AUDIO_SDL

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QApplication>
@@ -158,9 +158,9 @@ help_dialog::help_dialog(QWidget *parent) : qfc_dialog(parent)
  */
 void help_dialog::update_fonts() { help_wdg->update_fonts(); }
 
-/****************************************************************************
+/**
   Hide event
-****************************************************************************/
+ */
 void help_dialog::hideEvent(QHideEvent *event)
 {
   Q_UNUSED(event)
@@ -168,9 +168,9 @@ void help_dialog::hideEvent(QHideEvent *event)
   king()->qt_settings.help_splitter1 = splitter->saveState();
 }
 
-/****************************************************************************
+/**
   Show event
-****************************************************************************/
+ */
 void help_dialog::showEvent(QShowEvent *event)
 {
   Q_UNUSED(event)
@@ -190,9 +190,9 @@ void help_dialog::showEvent(QShowEvent *event)
   }
 }
 
-/****************************************************************************
+/**
   Close event
-****************************************************************************/
+ */
 void help_dialog::closeEvent(QCloseEvent *event)
 {
   Q_UNUSED(event)
@@ -1217,7 +1217,7 @@ static void make_helppiclabel(QPixmap *spr, const QString &tooltip,
   label->setToolTip(tooltip);
 }
 
-/***************************************************************************
+/**
    Creates a terrain widget with title, terrain image, legend. An optional
    tooltip can be given to explain the legend.
  */

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "hudwidget.h"
 // Qt
@@ -1688,9 +1688,9 @@ hud_unit_combat::hud_unit_combat(int attacker_unit_id, int defender_unit_id,
   init_images();
 }
 
-/****************************************************************************
+/**
   Draws images of units to pixmaps for later use
-****************************************************************************/
+ */
 void hud_unit_combat::init_images(bool redraw)
 {
   QImage crdimg, acrimg, at, dt;
@@ -1752,9 +1752,9 @@ void hud_unit_combat::init_images(bool redraw)
   aimg = aimg.scaled(w, w, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 }
 
-/****************************************************************************
+/**
   Sets scale for images
-****************************************************************************/
+ */
 void hud_unit_combat::set_scale(float scale)
 {
   hud_scale = scale;
@@ -1898,9 +1898,9 @@ hud_battle_log::~hud_battle_log()
   delete mw;
 }
 
-/****************************************************************************
+/**
   Updates size when scale has changed
-****************************************************************************/
+ */
 void hud_battle_log::update_size()
 {
   int w = 3 * tileset_unit_height(tileset) / 2 * scale;
@@ -1922,9 +1922,9 @@ void hud_battle_log::update_size()
   startTimer(50);
 }
 
-/****************************************************************************
+/**
   Set scale
-****************************************************************************/
+ */
 void hud_battle_log::set_scale(float s)
 {
   scale = s;

--- a/client/icons.cpp
+++ b/client/icons.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "icons.h"
 // Qt

--- a/client/luaconsole.cpp
+++ b/client/luaconsole.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "luaconsole.h"
 // Qt

--- a/client/luaconsole_common.cpp
+++ b/client/luaconsole_common.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdarg>
 // utility

--- a/client/luascript/api_client_base.cpp
+++ b/client/luascript/api_client_base.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "featured_text.h"

--- a/client/luascript/script_client.cpp
+++ b/client/luascript/script_client.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdarg>
 #include <ctime>
@@ -40,14 +40,14 @@ extern "C" {
 
 #include "script_client.h"
 
-/*****************************************************************************
+/**
   Lua virtual machine state.
-*****************************************************************************/
+ */
 static struct fc_lua *main_fcl = nullptr;
 
-/*****************************************************************************
+/**
   Optional game script code (useful for scenarios).
-*****************************************************************************/
+ */
 static char *script_client_code = nullptr;
 
 static void script_client_vars_init();

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QApplication>

--- a/client/mapctrl_common.cpp
+++ b/client/mapctrl_common.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <memory>
 

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -2320,10 +2320,10 @@ void free_mapcanvas_and_overview()
   delete mapview.tmp_store;
 }
 
-/****************************************************************************
+/**
   Map link mark module: it makes link marks when a link is sent by chating,
   or restore a mark with clicking a link on the chatline.
-****************************************************************************/
+ */
 struct link_mark {
   enum text_link_type type; // The target type.
   int id;                   // The city or unit id, or tile index.

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "menu.h"
 
@@ -228,9 +228,9 @@ void gov_menu::change_gov(int target_gov)
   popup_revolution_dialog(government_by_number(target_gov));
 }
 
-/**************************************************************************
+/**
   Keeps track of all gov_menu instances.
-**************************************************************************/
+ */
 QSet<gov_menu *> gov_menu::instances = QSet<gov_menu *>();
 
 /**
@@ -458,9 +458,9 @@ void go_act_menu::start_go_act(int act_id, int sub_tgt_id)
   request_unit_goto(ORDER_PERFORM_ACTION, act_id, sub_tgt_id);
 }
 
-/**************************************************************************
+/**
   Store all goto and act menu items so they can be updated etc
-**************************************************************************/
+ */
 QSet<go_act_menu *> go_act_menu::instances;
 
 /**
@@ -1384,9 +1384,9 @@ void mr_menu::update_airlift_menu()
   unit_type_iterate_end;
 }
 
-/****************************************************************************
+/**
   Updates "build path" menu
-****************************************************************************/
+ */
 void mr_menu::update_roads_menu()
 {
   QAction *act;
@@ -1433,9 +1433,9 @@ void mr_menu::update_roads_menu()
   }
 }
 
-/****************************************************************************
+/**
   Updates "build bases" menu
-****************************************************************************/
+ */
 void mr_menu::update_bases_menu()
 {
   QAction *act;
@@ -2517,7 +2517,7 @@ void mr_menu::slot_city_names() { key_city_names_toggle(); }
  */
 void mr_menu::slot_city_outlines() { key_city_outlines_toggle(); }
 
-/**************************************************************************
+/**
    Action "Citybar changed"
  */
 void mr_menu::slot_set_citybar()
@@ -2734,9 +2734,9 @@ void mr_menu::slot_help(const QString &topic)
   popup_help_dialog_typed(Q_(topic.toStdString().c_str()), HELP_ANY);
 }
 
-/****************************************************************
+/**
   Actions "BUILD_PATH_*"
-*****************************************************************/
+ */
 void mr_menu::slot_build_path(int id)
 {
   for (const auto punit : get_units_in_focus()) {
@@ -2752,9 +2752,9 @@ void mr_menu::slot_build_path(int id)
   }
 }
 
-/****************************************************************
+/**
   Actions "BUILD_BASE_*"
-*****************************************************************/
+ */
 void mr_menu::slot_build_base(int id)
 {
   for (const auto punit : get_units_in_focus()) {

--- a/client/messageoptions.cpp
+++ b/client/messageoptions.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "messageoptions.h"
 // Qt

--- a/client/messagewin.cpp
+++ b/client/messagewin.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "messagewin.h"
 

--- a/client/messagewin_common.cpp
+++ b/client/messagewin_common.cpp
@@ -8,7 +8,7 @@
          `%%%%%%%'       or (at your option) any later version. You should
             have received  a copy of the GNU  General Public License along
                  with Freeciv21. If not, see https://www.gnu.org/licenses/.
-                 ********************************************************/
+ */
 
 #include <cstring>
 

--- a/client/minimap.cpp
+++ b/client/minimap.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "minimap.h"
 

--- a/client/music.cpp
+++ b/client/music.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "connection.h"

--- a/client/notifyreport.cpp
+++ b/client/notifyreport.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "notifyreport.h"
 // Qt

--- a/client/optiondlg.cpp
+++ b/client/optiondlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QApplication>

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -207,9 +207,9 @@ static bool options_fully_initialized = false;
 static const QVector<QString> *
 get_mapimg_format_list(const struct option *poption);
 
-/****************************************************************************
+/**
   Option set structure.
-****************************************************************************/
+ */
 struct option_set {
   struct option *(*option_by_number)(int);
   struct option *(*option_first)();
@@ -327,9 +327,9 @@ struct option_color_vtable {
   bool (*set)(struct option *, struct ft_color);
 };
 
-/****************************************************************************
+/**
   The base class for options.
-****************************************************************************/
+ */
 struct option {
   // A link to the option set.
   const struct option_set *poptset;
@@ -958,9 +958,9 @@ bool option_color_set(struct option *poption, struct ft_color color)
   return false;
 }
 
-/****************************************************************************
+/**
   Client option set.
-****************************************************************************/
+ */
 static struct option *client_optset_option_by_number(int id);
 static struct option *client_optset_option_first();
 static int client_optset_category_number();
@@ -980,9 +980,9 @@ struct copt_val_name {
                         * users. */
 };
 
-/****************************************************************************
+/**
   Virtuals tables for the client options.
-****************************************************************************/
+ */
 static int client_option_number(const struct option *poption);
 static const char *client_option_name(const struct option *poption);
 static const char *client_option_description(const struct option *poption);
@@ -1066,9 +1066,9 @@ enum client_option_category {
   COC_MAX
 };
 
-/****************************************************************************
+/**
   Derived class client option, inherinting of base class option.
-****************************************************************************/
+ */
 struct client_option {
   struct option base_option; // Base structure, must be the first!
 
@@ -1373,9 +1373,9 @@ struct client_option {
     }                                                                       \
   }
 
-/****************************************************************************
+/**
   Enumerator name accessors.
-****************************************************************************/
+ */
 
 // Some changed callbacks.
 static void reqtree_show_icons_callback(struct option *poption);
@@ -2485,18 +2485,18 @@ static void client_option_save(struct option *poption,
   }
 }
 
-/****************************************************************************
+/**
   Server options variables.
-****************************************************************************/
+ */
 static char **server_options_categories = nullptr;
 static struct server_option *server_options = nullptr;
 
 static int server_options_categories_num = 0;
 static int server_options_num = 0;
 
-/****************************************************************************
+/**
   Server option set.
-****************************************************************************/
+ */
 static struct option *server_optset_option_by_number(int id);
 static struct option *server_optset_option_first();
 static int server_optset_category_number();
@@ -2509,9 +2509,9 @@ static struct option_set server_optset_static = {
     .category_name = server_optset_category_name};
 const struct option_set *server_optset = &server_optset_static;
 
-/****************************************************************************
+/**
   Virtuals tables for the client options.
-****************************************************************************/
+ */
 static int server_option_number(const struct option *poption);
 static const char *server_option_name(const struct option *poption);
 static const char *server_option_description(const struct option *poption);
@@ -2588,9 +2588,9 @@ static const struct option_bitwise_vtable server_option_bitwise_vtable = {
     .values = server_option_bitwise_pretty,
     .set = server_option_bitwise_set};
 
-/****************************************************************************
+/**
   Derived class server option, inheriting from base class option.
-****************************************************************************/
+ */
 struct server_option {
   struct option base_option; // Base structure, must be the first!
 
@@ -2781,9 +2781,9 @@ void handle_server_setting_const(
   psoption->category = packet->category;
 }
 
-/****************************************************************************
+/**
   Common part of handle_server_setting_*() functions. See below.
-****************************************************************************/
+ */
 #define handle_server_setting_common(psoption, packet)                      \
   psoption->is_changeable = packet->is_changeable;                          \
   psoption->setdef = packet->setdef;                                        \
@@ -4748,9 +4748,9 @@ static void manual_turn_done_callback(struct option *poption)
   }
 }
 
-/****************************************************************************
+/**
   Callback for changing music volume
-****************************************************************************/
+ */
 static void sound_volume_callback(struct option *poption)
 {
   Q_UNUSED(poption)

--- a/client/overview_common.cpp
+++ b/client/overview_common.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <cmath> // floor
 

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
   /\ ___ /\                 Copyright (c) 1996-2020 Freeciv21 and Freeciv
  (  o   o  )                 contributors. This file is part of Freeciv21.
   \  >#<  /           Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
   ///  ///   --                     You should have received a copy of the
                           GNU General Public License along with Freeciv21.
                                   If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "page_load.h"
 // Qt

--- a/client/page_main.cpp
+++ b/client/page_main.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "page_main.h"
 // utility

--- a/client/page_network.cpp
+++ b/client/page_network.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
              .--~~,__        Copyright (c) 1996-2020 Freeciv21 and Freeciv
 :-....,-------`~~'._.'       contributors. This file is part of Freeciv21.
  `-,,,  ,_      ;'~U'  Freeciv21 is free software: you can redistribute it
@@ -8,7 +8,7 @@
        the License, or (at your option) any later version. You should have
    received a copy of the GNU General Public License along with Freeciv21.
                                 If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 #include "page_network.h"
 
 #include <QTimer>

--- a/client/page_pregame.cpp
+++ b/client/page_pregame.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
              ____             Copyright (c) 1996-2020 Freeciv21 and Freeciv
             /    \__          contributors. This file is part of Freeciv21.
 |\         /    @   \   Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
  /  /__________\  \                 You should have received a copy of the
  L_JJ           \__JJ      GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "page_pregame.h"
 // Qt

--- a/client/page_scenario.cpp
+++ b/client/page_scenario.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
   /\ ___ /\                 Copyright (c) 1996-2020 Freeciv21 and Freeciv
  (  o   o  )                 contributors. This file is part of Freeciv21.
   \  >#<  /           Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
   ///  ///   --                     You should have received a copy of the
                           GNU General Public License along with Freeciv21.
                                   If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "page_scenario.h"
 // Qt

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "plrdlg.h"
 // Qt

--- a/client/pregameoptions.cpp
+++ b/client/pregameoptions.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
              ____             Copyright (c) 1996-2020 Freeciv21 and Freeciv
             /    \__          contributors. This file is part of Freeciv21.
 |\         /    @   \   Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
  /  /__________\  \                 You should have received a copy of the
  L_JJ           \__JJ      GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include "fcintl.h"

--- a/client/ratesdlg.cpp
+++ b/client/ratesdlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "ratesdlg.h"
 // Qt

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"
@@ -55,9 +55,9 @@
  * +-------->
  */
 
-/****************************************************************************
+/**
   Edge types for coloring the edges by type in the tree
-****************************************************************************/
+ */
 enum reqtree_edge_type {
   REQTREE_EDGE = 0, // Normal, "unvisited"
   REQTREE_READY_EDGE,

--- a/client/sciencedlg.cpp
+++ b/client/sciencedlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QComboBox>

--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>
@@ -74,10 +74,10 @@ fcUdpScan::fcUdpScan(QObject *parent) : QUdpSocket(parent)
       this, &fcUdpScan::sockError);
 }
 
-/**************************************************************************
+/**
   returns fcUdpScan instance, use it to initizalize fcUdpScan
   or for calling methods
-**************************************************************************/
+ */
 fcUdpScan *fcUdpScan::i()
 {
   if (!m_instance) {
@@ -86,9 +86,9 @@ fcUdpScan *fcUdpScan::i()
   return m_instance;
 }
 
-/**************************************************************************
+/**
   Pass errors to main scan
-**************************************************************************/
+ */
 void fcUdpScan::sockError(QAbstractSocket::SocketError socketError)
 {
   Q_UNUSED(socketError)
@@ -100,9 +100,9 @@ void fcUdpScan::sockError(QAbstractSocket::SocketError socketError)
   fcudp_scan->error_func(fcudp_scan, errstr);
 }
 
-/**************************************************************************
+/**
   deletes fcUdpScan
-**************************************************************************/
+ */
 void fcUdpScan::drop()
 {
   delete m_instance;

--- a/client/shortcuts.cpp
+++ b/client/shortcuts.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "shortcuts.h"
 // Qt

--- a/client/spaceshipdlg.cpp
+++ b/client/spaceshipdlg.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QGridLayout>

--- a/client/sprite.cpp
+++ b/client/sprite.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QImageReader>

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #endif

--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QApplication>

--- a/client/themes_common.cpp
+++ b/client/themes_common.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 #ifdef HAVE_CONFIG_H
 #endif
 
@@ -26,7 +26,9 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 #include "qtg_cxxside.h"
 
 Q_GLOBAL_STATIC(QVector<QString>, themes_list)
-/***************************************************************************
+
+/**
+  \file
   A theme is a portion of client data, which for following reasons should
   be separated from a tileset:
   - Theme is not only graphic related
@@ -38,7 +40,7 @@ Q_GLOBAL_STATIC(QVector<QString>, themes_list)
   Theme is stored in a directory called like the theme. The directory
 contains some data files. Each gui defines its own format in the
   get_useable_themes_in_directory() function.
-****************************************************************************/
+ */
 
 // A directory containing a list of usable themes
 struct theme_directory {

--- a/client/tileset_debugger.cpp
+++ b/client/tileset_debugger.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 2021 Freeciv21 contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "tileset_debugger.h"
 

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -11,11 +11,11 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/***********************************************************************
+/**
   Functions for handling the tilespec files which describe
   the files and contents of tilesets.
   original author: David Pfitzner <dwp@mso.anu.edu.au>
-***********************************************************************/
+ */
 
 #include <QHash>
 #include <QImageReader>

--- a/client/tooltips.cpp
+++ b/client/tooltips.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QAbstractItemView>
@@ -71,9 +71,9 @@ bool fc_tooltip::eventFilter(QObject *obj, QEvent *ev)
   return false;
 }
 
-/**************************************************************************
+/**
   'text' is assumed to have already been HTML-escaped if necessary
-**************************************************************************/
+ */
 QString bold(const QString &text) { return QString("<b>" + text + "</b>"); }
 
 /**

--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QAction>

--- a/client/tradecalculation.cpp
+++ b/client/tradecalculation.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 #include "tradecalculation.h"
 
 #include <random>

--- a/client/unitreport.cpp
+++ b/client/unitreport.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "unitreport.h"
 // Qt

--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
   /\ ___ /\        Copyright (c) 1996-2020 ＦＲＥＥＣＩＶ ２１ and Freeciv
  (  o   o  )                 contributors. This file is part of Freeciv21.
   \  >#<  /           Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
   ///  ///   --                     You should have received a copy of the
                           GNU General Public License along with Freeciv21.
                                   If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "unitselect.h"
 

--- a/client/voteinfo_bar.cpp
+++ b/client/voteinfo_bar.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include "voteinfo_bar.h"
 // Qt

--- a/client/widgetdecorations.cpp
+++ b/client/widgetdecorations.cpp
@@ -20,9 +20,9 @@
 #include "fc_client.h"
 #include "icons.h"
 
-/****************************************************************************
+/**
   Scale widget allowing scaling other widgets, shown in right top corner
-****************************************************************************/
+ */
 scale_widget::scale_widget(QRubberBand::Shape s, QWidget *p)
     : QRubberBand(s, p)
 {
@@ -40,9 +40,9 @@ scale_widget::scale_widget(QRubberBand::Shape s, QWidget *p)
   setAttribute(Qt::WA_TransparentForMouseEvents, false);
 }
 
-/****************************************************************************
+/**
   Draws 2 icons for resizing
-****************************************************************************/
+ */
 void scale_widget::paintEvent(QPaintEvent *event)
 {
   QRubberBand::paintEvent(event);
@@ -53,9 +53,9 @@ void scale_widget::paintEvent(QPaintEvent *event)
   p.end();
 }
 
-/****************************************************************************
+/**
   Mouse press event for scale widget
-****************************************************************************/
+ */
 void scale_widget::mousePressEvent(QMouseEvent *event)
 {
   if (event->button() == Qt::LeftButton) {

--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <cmath> // ceil, floor
 #include <cstdarg>

--- a/common/ai.cpp
+++ b/common/ai.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>

--- a/common/aicore/aiactions.cpp
+++ b/common/aicore/aiactions.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "unittype.h"

--- a/common/aicore/aisupport.cpp
+++ b/common/aicore/aisupport.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #endif

--- a/common/aicore/caravan.cpp
+++ b/common/aicore/caravan.cpp
@@ -181,9 +181,9 @@ static double windfall_benefit(const struct unit *caravan,
   }
 }
 
-/****************************************************************************
-  Compute the change in the per-turn trade.
-****************************************************************************/
+/*
+ * Compute the change in the per-turn trade.
+ */
 
 /**
    How much does the city benefit from the new trade route?
@@ -470,9 +470,9 @@ static bool get_discounted_reward(const struct unit *caravan,
   return true;
 }
 
-/****************************************************************************
+/**
   Functions to compute the benefit of moving the caravan to dest.
-****************************************************************************/
+ */
 
 /**
    Find the best destination for the caravan, ignoring transit time.

--- a/common/aicore/citymap.cpp
+++ b/common/aicore/citymap.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/common/aicore/cm.cpp
+++ b/common/aicore/cm.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdlib>
 #include <cstring>
@@ -28,7 +28,9 @@
 
 #include "cm.h"
 
-/*
+/**
+ * \file
+ *
  * Terms used
  * ==========
  *
@@ -60,9 +62,9 @@
  * - computing the weighting for tiles.  Ditto.
  */
 
-/*****************************************************************************
+/*
   Defines, structs, globals, forward declarations
-*****************************************************************************/
+ */
 
 Q_LOGGING_CATEGORY(cm_category, "freeciv.cm")
 
@@ -114,7 +116,7 @@ struct cm_fitness {
 struct cm_tile_type;
 struct cm_tile;
 
-/*
+/**
  * A tile.  Has a pointer to the type, and the x/y coords.
  * Used mostly just for converting to cm_result.
  */
@@ -145,7 +147,7 @@ struct cm_tile {
   VECTOR_ITERATE_END;                                                       \
   }
 
-/*
+/**
  * A tile type.
  * Holds the production (a hill produces 1/0/0);
  * Holds a list of which tiles match this (all the hills and tundra);
@@ -169,7 +171,7 @@ struct cm_tile_type {
   int lattice_depth; // depth = sum(#tiles) over all better types
 };
 
-/*
+/**
  * A partial solution.
  * Has the count of workers assigned to each lattice position, and
  * a count of idle workers yet unassigned.
@@ -183,7 +185,7 @@ struct partial_solution {
   int idle;               // number of idle workers
 };
 
-/*
+/**
  * State of the search.
  * This holds all the information needed to do the search, all in one
  * struct, in order to clean up the function calls.
@@ -331,9 +333,9 @@ std::unique_ptr<cm_result> cm_result_new(struct city *pcity)
   return result;
 }
 
-/****************************************************************************
+/*
   Functions of tile-types.
-****************************************************************************/
+ */
 
 /**
    Set all production to zero and initialize the vectors for this tile type.
@@ -517,9 +519,9 @@ static const struct cm_tile *tile_get(const struct cm_tile_type *ptype,
   return &ptype->tiles.p[j];
 }
 
-/****************************************************************************
+/*
   Functions on the cm_fitness struct.
-****************************************************************************/
+ */
 
 /**
    Return TRUE iff fitness A is strictly better than fitness B.
@@ -580,12 +582,12 @@ compute_fitness(const int surplus[], bool disorder, bool happy,
   return fitness;
 }
 
-/****************************************************************************
+/*
   Handle struct partial_solution.
   - perform a deep copy
   - convert to city
   - convert to cm_result
-****************************************************************************/
+ */
 
 /**
    Allocate and initialize an empty solution.
@@ -631,9 +633,9 @@ static void copy_partial_solution(struct partial_solution *dst,
   dst->idle = src->idle;
 }
 
-/****************************************************************************
+/**
   Evaluating a completed solution.
-****************************************************************************/
+ */
 
 /**
    Apply the solution to state->workers_map.
@@ -782,9 +784,9 @@ static void convert_solution_to_result(struct cm_state *state,
   result->found_a_valid = fitness.sufficient;
 }
 
-/****************************************************************************
+/**
   Compare functions to allow sorting lattice vectors.
-****************************************************************************/
+ */
 
 /**
    All the sorting in this code needs to respect the partial order
@@ -887,9 +889,9 @@ static int compare_tile_type_by_stat(const void *va, const void *vb)
   return compare_tile_type_by_lattice_order(*a, *b);
 }
 
-/****************************************************************************
+/**
   Compute the tile-type lattice.
-****************************************************************************/
+ */
 
 /**
    Compute the production of tile [x,y] and stuff it into the tile type.
@@ -1220,11 +1222,11 @@ static void init_tile_lattice(struct city *pcity,
   print_lattice(LOG_LATTICE, lattice);
 }
 
-/****************************************************************************
+/**
 
                Handling the choice stack for the bb algorithm.
 
-****************************************************************************/
+ */
 
 /**
    Return TRUE iff the stack is empty.

--- a/common/aicore/path_finding.cpp
+++ b/common/aicore/path_finding.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 // utility
 #include "bitvector.h"
 #include "genhash.h"

--- a/common/aicore/pf_tools.cpp
+++ b/common/aicore/pf_tools.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstring>
 

--- a/common/base.cpp
+++ b/common/base.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "extras.h"

--- a/common/borders.cpp
+++ b/common/borders.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/calendar.cpp
+++ b/common/calendar.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "game.h"

--- a/common/citizens.cpp
+++ b/common/citizens.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -866,9 +866,9 @@ int combat_bonus_against(const struct combat_bonus_list *list,
   return value;
 }
 
-/*******************************************************************/ /**
+/**
   Returns if the attack is going to be a tired attack
- ***********************************************************************/
+ */
 bool is_tired_attack(int moves_left)
 {
   return game.info.tired_attack && moves_left < SINGLE_MOVE;

--- a/common/culture.cpp
+++ b/common/culture.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "city.h"

--- a/common/disaster.cpp
+++ b/common/disaster.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 #include <cstring>
 
 // utility
@@ -31,7 +31,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 
 static bool initialized = false;
 
-/**************************************************************************
+/**
   The code creates a ruleset cache on ruleset load. This constant cache
   is used to speed up effects queries.  After the cache is created it is
   not modified again (though it may later be freed).
@@ -87,12 +87,12 @@ static bool initialized = false;
   No matter which sources caches are present, we should always know where
   to look for a source and so the lookups will always be fast even as the
   number of possible sources increases.
-**************************************************************************/
+ */
 
-/**************************************************************************
+/**
   Ruleset cache. The cache is created during ruleset loading and the data
   is organized to enable fast queries.
-**************************************************************************/
+ */
 static struct {
   // A single list containing every effect.
   struct effect_list *tracker;

--- a/common/extras.cpp
+++ b/common/extras.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/fc_interface.cpp
+++ b/common/fc_interface.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "shared.h"

--- a/common/featured_text.cpp
+++ b/common/featured_text.cpp
@@ -1132,11 +1132,11 @@ const char *unit_tile_link(const struct unit *punit)
   return buf;
 }
 
-/**********************************************************************/ /**
+/**
    Get a text of a unit's vet level.
    N.B.: The returned string is static, so every call to this function
    overwrites the previous.
- **************************************************************************/
+ */
 const char *unit_veteran_level_string(const struct unit *punit)
 {
   static char buf[MAX_LEN_LINK];
@@ -1152,11 +1152,11 @@ const char *unit_veteran_level_string(const struct unit *punit)
   return buf;
 }
 
-/**********************************************************************/ /**
+/**
    Get string of when unit gets upgraded to new veteran level.
    N.B.: The returned string is static, so every call to this function
    overwrites the previous.
- **************************************************************************/
+ */
 const char *unit_achieved_rank_string(const struct unit *punit)
 {
   static char buf[MAX_LEN_LINK];
@@ -1169,11 +1169,11 @@ const char *unit_achieved_rank_string(const struct unit *punit)
   return buf;
 }
 
-/**********************************************************************/ /**
+/**
    Get string of unit's attack would be a tired attack or not.
    N.B.: The returned string is static, so every call to this function
    overwrites the previous.
- **************************************************************************/
+ */
 const char *unit_tired_attack_string(const struct unit *punit)
 {
   static char buf[MAX_LEN_LINK];
@@ -1188,13 +1188,13 @@ const char *unit_tired_attack_string(const struct unit *punit)
   return buf;
 }
 
-/**********************************************************************/ /**
+/**
    Get string of unit's firepower text, i.e. "FP:2 "
    If firepower is equal to one, then an empty string is returned
    so as to shorten the text output.
    N.B.: The returned string is static, so every call to this function
    overwrites the previous.
- **************************************************************************/
+ */
 const char *unit_firepower_if_not_one(int firepower)
 {
   static char buf[MAX_LEN_LINK];

--- a/common/government.cpp
+++ b/common/government.cpp
@@ -175,9 +175,9 @@ bool can_change_to_government(struct player *pplayer,
                          &gov->reqs, RPT_CERTAIN);
 }
 
-/**************************************************************************
+/**
   Ruler titles.
-**************************************************************************/
+ */
 struct ruler_title {
   const struct nation_type *pnation;
   struct name_translation male;

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -11,10 +11,10 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/***********************************************************************
+/**
  This module is for generic handling of help data, independent
  of gui considerations.
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>
@@ -1096,12 +1096,12 @@ void boot_help_texts(const nation_set *nations_to_show,
   qDebug("Booted help texts ok");
 }
 
-/****************************************************************************
+/**
   The following few functions are essentially wrappers for the
   help_nodes help_list.  This allows us to avoid exporting the
   help_list, and instead only access it through a controlled
   interface.
-****************************************************************************/
+ */
 
 /**
    Find help item by name and type.
@@ -1155,7 +1155,7 @@ get_help_item_spec(const char *name, enum help_page_type htype, int *pos)
   return pitem;
 }
 
-/****************************************************************************
+/**
   FIXME:
   Also, in principle these could be auto-generated once, inserted
   into pitem->text, and then don't need to keep re-generating them.
@@ -1164,7 +1164,7 @@ get_help_item_spec(const char *name, enum help_page_type htype, int *pos)
   re-boot helptexts anyway).  Eg, genuinely dynamic information
   which could be useful would be if help system said which wonders
   have been built (or are being built and by who/where?)
-****************************************************************************/
+ */
 
 /**
    Write dynamic text for buildings (including wonders).  This includes

--- a/common/idex.cpp
+++ b/common/idex.cpp
@@ -11,7 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/***********************************************************************
+/**
    idex = ident index: a lookup table for quick mapping of unit and city
    id values to unit and city pointers.
 
@@ -23,7 +23,7 @@
 
    Note id values should probably be unsigned int: here leave as plain int
    so can use pointers to pcity->id etc.
-***********************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/common/improvement.cpp
+++ b/common/improvement.cpp
@@ -23,13 +23,13 @@
 
 #include "improvement.h"
 
-/**************************************************************************
+/**
 All the city improvements:
 Use improvement_by_number(id) to access the array.
 The improvement_types array is now setup in:
    server/ruleset.c (for the server)
    client/packhand.c (for the client)
-**************************************************************************/
+ */
 static struct impr_type improvement_types[B_LAST];
 
 /**

--- a/common/mapimg.cpp
+++ b/common/mapimg.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <cstdarg>
 

--- a/common/metaknowledge.cpp
+++ b/common/metaknowledge.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "diptreaty.h"

--- a/common/movement.cpp
+++ b/common/movement.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <QBitArray>
 

--- a/common/multipliers.cpp
+++ b/common/multipliers.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/nation.cpp
+++ b/common/nation.cpp
@@ -11,9 +11,9 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/**********************************************************************
+/**
    Functions for handling the nations.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"
@@ -41,9 +41,9 @@ static struct nation_set nation_sets[MAX_NUM_NATION_SETS];
 static int num_nation_groups;
 static struct nation_group nation_groups[MAX_NUM_NATION_GROUPS];
 
-/****************************************************************************
+/**
   Runs action if the nation is not valid.
-****************************************************************************/
+ */
 #ifdef FREECIV_DEBUG
 #define NATION_CHECK(pnation, action)                                       \
   fc_assert_action(nation_check(pnation), action)
@@ -191,9 +191,9 @@ enum barbarian_type nation_barbarian_type(const struct nation_type *nation)
   return nation->barb_type;
 }
 
-/****************************************************************************
+/**
   Nation leader.
-****************************************************************************/
+ */
 struct nation_leader {
   char *name;
   bool is_male;
@@ -282,7 +282,7 @@ const char *nation_legend_translation(const struct nation_type *pnation,
   return DG_(pnation->translation_domain, legend);
 }
 
-/****************************************************************************
+/**
   Nation default cities. The nation_city structure holds information about
   a default choice for the city name. The 'name' field is, of course, just
   the name for the city. The 'river' and 'terrain' fields are entries
@@ -293,7 +293,7 @@ const char *nation_legend_translation(const struct nation_type *pnation,
 
   This is controlled through the nation's ruleset like this:
     cities = "Washington (ocean, river, swamp)", "New York (!mountains)"
-****************************************************************************/
+ */
 struct nation_city {
   char *name;
   enum nation_city_preference river;
@@ -751,9 +751,9 @@ struct nation_set *nation_set_by_setting_value(const char *setting)
   return pset;
 }
 
-/****************************************************************************
+/**
   Nation set iterator.
-****************************************************************************/
+ */
 struct nation_set_iter {
   struct iterator vtable;
   struct nation_set *p, *end;
@@ -974,9 +974,9 @@ bool nation_is_in_group(const struct nation_type *pnation,
   return false;
 }
 
-/****************************************************************************
+/**
   Nation group iterator.
-****************************************************************************/
+ */
 struct nation_group_iter {
   struct iterator vtable;
   struct nation_group *p, *end;

--- a/common/networking/connection.cpp
+++ b/common/networking/connection.cpp
@@ -33,14 +33,14 @@ static void default_conn_close_callback(struct connection *pconn);
  */
 const char blank_addr_str[] = "---.---.---.---";
 
-/****************************************************************************
+/**
   This callback is used when an error occurs trying to write to the
   connection. The effect of the callback should be to close the connection.
   This is here so that the server and client can take appropriate
   (different) actions: server lost a client, client lost connection to
   server. Never attempt to call this function directly, call
   connection_close() instead.
-****************************************************************************/
+ */
 static conn_close_fn_t conn_close_callback = default_conn_close_callback;
 
 /**
@@ -701,9 +701,9 @@ enum cmdlevel conn_get_access(const struct connection *pconn)
   return pconn->access_level;
 }
 
-/**************************************************************************
+/**
   Connection patterns.
-**************************************************************************/
+ */
 struct conn_pattern {
   enum conn_pattern_type type;
   char *wildcard;

--- a/common/player.cpp
+++ b/common/player.cpp
@@ -1521,10 +1521,10 @@ const char *diplrel_name_translation(int value)
   }
 }
 
-/**************************************************************************
+/**
   Return the Casus Belli range when offender performs paction to tgt_plr
   at tgt_tile and the outcome is outcome.
-**************************************************************************/
+ */
 enum casus_belli_range casus_belli_range_for(const struct player *offender,
                                              const struct player *tgt_plr,
                                              const enum effect_type outcome,

--- a/common/reqtext.cpp
+++ b/common/reqtext.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "astring.h"

--- a/common/requirements.cpp
+++ b/common/requirements.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 // utility
 #include "fcintl.h"
 #include "log.h"
@@ -33,9 +33,9 @@
 
 #include "requirements.h"
 
-/************************************************************************
+/**
   Container for req_item_found functions
-************************************************************************/
+ */
 typedef enum req_item_found (*universal_found)(const struct requirement *,
                                                const struct universal *);
 static universal_found universal_found_function[VUT_COUNT] = {nullptr};

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 // utility
 #include "fcintl.h"
 #include "iterator.h"

--- a/common/rgbcolor.cpp
+++ b/common/rgbcolor.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #include <cstdarg>
 

--- a/common/road.cpp
+++ b/common/road.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "extras.h"

--- a/common/scriptcore/api_common_intl.cpp
+++ b/common/scriptcore/api_common_intl.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/scriptcore/api_common_utilities.cpp
+++ b/common/scriptcore/api_common_utilities.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cmath>
 

--- a/common/scriptcore/api_game_effects.cpp
+++ b/common/scriptcore/api_game_effects.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/scriptcore/api_game_find.cpp
+++ b/common/scriptcore/api_game_find.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/scriptcore/api_game_methods.cpp
+++ b/common/scriptcore/api_game_methods.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "deprecations.h"

--- a/common/scriptcore/api_game_specenum.cpp
+++ b/common/scriptcore/api_game_specenum.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstring>
 

--- a/common/scriptcore/api_signal_base.cpp
+++ b/common/scriptcore/api_signal_base.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 /* common/scriptcore */
 #include "luascript.h"
 #include "luascript_signal.h"

--- a/common/scriptcore/luascript.cpp
+++ b/common/scriptcore/luascript.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdarg>
 #include <ctime>
@@ -42,17 +42,17 @@ extern "C" {
 
 #include "luascript.h"
 
-/*****************************************************************************
+/**
   Configuration for script execution time limits. Checkinterval is the
   number of executed lua instructions between checking. Disabled if 0.
-*****************************************************************************/
+ */
 #define LUASCRIPT_MAX_EXECUTION_TIME_SEC 5.0
 #define LUASCRIPT_CHECKINTERVAL 10000
 
 // The name used for the freeciv lua struct saved in the lua state.
 #define LUASCRIPT_GLOBAL_VAR_NAME "__fcl"
 
-/*****************************************************************************
+/**
   Unsafe Lua builtin symbols that we to remove access to.
 
   If Freeciv's Lua version changes, you have to check how the set of
@@ -66,7 +66,7 @@ extern "C" {
   In general, unsafe is all functionality that gives access to:
   * Reading files and running processes
   * Loading lua files or libraries
-*****************************************************************************/
+ */
 #define LUASCRIPT_SECURE_LUA_VERSION1 503
 #define LUASCRIPT_SECURE_LUA_VERSION2 504
 
@@ -82,10 +82,10 @@ static const char *luascript_unsafe_symbols_permissive[] = {
 #warning "This can be a big security hole!"
 #endif
 
-/*****************************************************************************
+/**
   Lua libraries to load (all default libraries, excluding operating system
   and library loading modules). See linit.c in Lua 5.1 for the default list.
-*****************************************************************************/
+ */
 #if LUA_VERSION_NUM == 503 || LUA_VERSION_NUM == 504
 static luaL_Reg luascript_lualibs_secure[] = {
     // Using default libraries excluding: package, io, os, and bit32
@@ -780,7 +780,7 @@ void luascript_vars_load(struct fc_lua *fcl, struct section_file *file,
 
 /* To avoid the complexity and overheads of creating such objects for
  * 4-bit enums, here is a helper function to return Direction objects. */
-/******
+/**
    Returns a pointer to a given value of enum direction8 (always the same
    address for the same value), or nullptr if the direction is invalid
    on the current map.

--- a/common/scriptcore/luascript_func.cpp
+++ b/common/scriptcore/luascript_func.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdarg>
 

--- a/common/scriptcore/luascript_signal.cpp
+++ b/common/scriptcore/luascript_signal.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,9 +6,9 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
-/*****************************************************************************
+/**
   Signals implementation.
 
   New signal types can be declared with script_signal_create. Each
@@ -32,7 +32,7 @@
     return false
 
   If the value is 'true' the current signal emission will be stopped.
-*****************************************************************************/
+ */
 // utility
 #include "deprecations.h"
 

--- a/common/server_settings.cpp
+++ b/common/server_settings.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "fc_interface.h"

--- a/common/specialist.cpp
+++ b/common/specialist.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/style.cpp
+++ b/common/style.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/team.cpp
+++ b/common/team.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>

--- a/common/terrain.cpp
+++ b/common/terrain.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/tile.cpp
+++ b/common/tile.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #endif

--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/common/unitlist.cpp
+++ b/common/unitlist.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/common/unittype.cpp
+++ b/common/unittype.cpp
@@ -1774,13 +1774,13 @@ bool can_player_build_unit_later(const struct player *p,
   return true;
 }
 
-/**************************************************************************
+/**
   The following functions use static variables so we can quickly look up
   which unit types have given flag or role.
   For these functions flags and roles are considered to be in the same
 "space", and any "role" argument can also be a "flag". Unit order is in terms
 of the order in the units ruleset.
-**************************************************************************/
+ */
 static bool first_init = true;
 static int n_with_role[MAX_UNIT_ROLES];
 static struct unit_type **with_role[MAX_UNIT_ROLES];

--- a/common/victory.cpp
+++ b/common/victory.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "game.h"

--- a/common/workertask.cpp
+++ b/common/workertask.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
  /\/\             part of Freeciv21. Freeciv21 is free software: you can
    \_\  _..._    redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                   or (at your option) any later version. You should have
 received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // common
 #include "workertask.h"

--- a/server/actiontools.cpp
+++ b/server/actiontools.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "rand.h"
@@ -505,12 +505,12 @@ void action_consequence_success(const struct action *paction,
                             EFT_CASUS_BELLI_SUCCESS);
 }
 
-/**************************************************************************
+/**
   Take care of any consequences (like casus belli) of successfully
   completing the given action.
 
   victim_player can be nullptr
-**************************************************************************/
+ */
 void action_consequence_complete(const struct action *paction,
                                  struct player *offender,
                                  struct player *victim_player,

--- a/server/advisors/advcity.cpp
+++ b/server/advisors/advcity.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "city.h"
@@ -18,11 +18,11 @@
 
 #include "advcity.h"
 
-/**************************************************************************
+/**
   This calculates the usefulness of pcity to us. Note that you can pass
   another player's adv_data structure here for evaluation by different
   priorities.
-**************************************************************************/
+ */
 int adv_eval_calc_city(struct city *pcity, struct adv_data *adv)
 {
   int i =

--- a/server/advisors/advdata.cpp
+++ b/server/advisors/advdata.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/server/advisors/autoexplorer.cpp
+++ b/server/advisors/autoexplorer.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cmath> // log
 

--- a/server/animals.cpp
+++ b/server/animals.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 \^~~~~\   )  (   /~~~~^/ *     _      Copyright (c) 1996-2020 Freeciv21 and
  ) *** \  {**}  / *** (  *  _ {o} _      Freeciv contributors. This file is
   ) *** \_ ^^ _/ *** (   * {o}{o}{o}   part of Freeciv21. Freeciv21 is free
@@ -9,7 +9,7 @@
     (at your option) any later version. You should have received  a copy of
                         the GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "ai.h"

--- a/server/auth.cpp
+++ b/server/auth.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/server/barbarian.cpp
+++ b/server/barbarian.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,13 +7,13 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
-/***********************************************************************
+/**
   Functions for creating barbarians in huts, land and sea
   Started by Jerzy Klek <jekl@altavista.net>
   with more ideas from Falk Hueffner
-***********************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/server/citizenshand.cpp
+++ b/server/citizenshand.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -268,10 +268,10 @@ void remove_obsolete_buildings(struct player *pplayer)
   city_list_iterate_end;
 }
 
-/**************************************************************************
+/**
   Rearrange workers according to a cm_result struct.  The caller must make
   sure that the result is valid.
-**************************************************************************/
+ */
 void apply_cmresult_to_city(struct city *pcity,
                             const std::unique_ptr<cm_result> &cmr)
 {
@@ -573,9 +573,9 @@ void send_city_turn_notifications(struct connection *pconn)
   }
 }
 
-/**************************************************************************
+/**
   Save city surplus values for use during city processing.
-**************************************************************************/
+ */
 void city_save_surpluses(struct city *pcity)
 {
   output_type_iterate(o) { pcity->saved_surplus[o] = pcity->surplus[o]; }
@@ -2286,10 +2286,10 @@ static bool city_distribute_surplus_shields(struct player *pplayer,
   return true;
 }
 
-/**************************************************************************
+/**
   Record the build turn of a wonder. Used in city processing to figure
   out which wonders are built on the same turn and not yet effective.
-**************************************************************************/
+ */
 static void wonder_set_build_turn(struct player *pplayer,
                                   const struct impr_type *pimprove)
 {
@@ -3244,7 +3244,7 @@ void nullify_prechange_production(struct city *pcity)
 
 /*  Handle the possibility of plague in city. Return TRUE if plague hit.
   city_populate() checks pcity->turn_plague later to prevent growth.
-**************************************************************************/
+ */
 static bool city_handle_plague_risk(struct city *pcity)
 {
   /* ------------------------------------------------------------------------

--- a/server/commands.cpp
+++ b/server/commands.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/server/edithand.cpp
+++ b/server/edithand.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
     Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
                          is part of Freeciv21. Freeciv21 is free software:
 |\_/|,,_____,~~`        you can redistribute it and/or modify it under the
@@ -8,7 +8,7 @@
                         You should have received a copy of the GNU General
                           Public License along with Freeciv21. If not, see
                                             https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <QSet>
 #include <climits> // USHRT_MAX

--- a/server/fcdb.cpp
+++ b/server/fcdb.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #endif

--- a/server/generator/fracture_map.cpp
+++ b/server/generator/fracture_map.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
              ____             Copyright (c) 1996-2020 Freeciv21 and Freeciv
             /    \__          contributors. This file is part of Freeciv21.
 |\         /    @   \   Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
  /  /__________\  \                 You should have received a copy of the
  L_JJ           \__JJ      GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 // utility
 #include "rand.h"
 

--- a/server/generator/height_map.cpp
+++ b/server/generator/height_map.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 // utility
 #include "rand.h"
 

--- a/server/generator/mapgen.cpp
+++ b/server/generator/mapgen.cpp
@@ -183,9 +183,9 @@ static int hmap_low_level = 0;
 
 typedef enum { MC_NONE, MC_LOW, MC_NLOW } miscellaneous_c;
 
-/**************************************************************************
+/**
   These functions test for conditions used in rand_map_pos_characteristic
-**************************************************************************/
+ */
 
 /**
    Checks if the given location satisfy some wetness condition
@@ -221,9 +221,9 @@ static bool test_miscellaneous(const struct tile *ptile, miscellaneous_c c)
   return false;
 }
 
-/**************************************************************************
+/**
   Passed as data to rand_map_pos_filtered() by rand_map_pos_characteristic()
-**************************************************************************/
+ */
 struct DataFilter {
   wetness_c wc;
   temperature_type tc;
@@ -2544,9 +2544,9 @@ static void river_types_init()
   extra_type_by_cause_iterate_end;
 }
 
-/****************************************************************************
+/**
   Fair island generator types.
-****************************************************************************/
+ */
 enum fair_tile_flag {
   FTF_NONE = 0,
   FTF_ASSIGNED = 1 << 0,

--- a/server/generator/mapgen_topology.cpp
+++ b/server/generator/mapgen_topology.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 #include <cmath> // sqrt
 
 // utility

--- a/server/generator/mapgen_utils.cpp
+++ b/server/generator/mapgen_utils.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 // utility
 #include "fcintl.h"
 #include "log.h"
@@ -21,10 +21,10 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 
 #include "mapgen_utils.h"
 
-/**************************************************************************
+/**
  Map that contains, according to circumstances, information on whether
  we have already placed terrain (special, hut) here.
-**************************************************************************/
+ */
 static bool *placed_map;
 
 /**

--- a/server/generator/startpos.cpp
+++ b/server/generator/startpos.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 \^~~~~\   )  (   /~~~~^/ *     _      Copyright (c) 1996-2020 Freeciv21 and
  ) *** \  {**}  / *** (  *  _ {o} _      Freeciv contributors. This file is
   ) *** \_ ^^ _/ *** (   * {o}{o}{o}   part of Freeciv21. Freeciv21 is free
@@ -9,7 +9,7 @@
     (at your option) any later version. You should have received  a copy of
                         the GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <QBitArray>
 #include <cmath> // sqrt, HUGE_VAL

--- a/server/generator/temperature_map.cpp
+++ b/server/generator/temperature_map.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 
 // utilities
 #include "log.h"

--- a/server/infrapts.cpp
+++ b/server/infrapts.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 \^~~~~\   )  (   /~~~~^/ *     _      Copyright (c) 1996-2020 Freeciv21 and
  ) *** \  {**}  / *** (  *  _ {o} _      Freeciv contributors. This file is
   ) *** \_ ^^ _/ *** (   * {o}{o}{o}   part of Freeciv21. Freeciv21 is free
@@ -9,7 +9,7 @@
     (at your option) any later version. You should have received  a copy of
                         the GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 // common
 #include "map.h"
 

--- a/server/notify.cpp
+++ b/server/notify.cpp
@@ -458,9 +458,9 @@ void notify_research_embassies(const struct research *presearch,
   event_cache_add_for_players(&genmsg, players);
 }
 
-/**************************************************************************
+/**
   Event cache datas.
-**************************************************************************/
+ */
 enum event_cache_target { ECT_ALL, ECT_PLAYERS, ECT_GLOBAL_OBSERVERS };
 
 // Events are saved in that structure.

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -510,9 +510,9 @@ void report_wonders_of_the_world(struct conn_list *dest)
             buffer);
 }
 
-/**************************************************************************
+/**
  Helper functions which return the value for the given player.
-**************************************************************************/
+ */
 
 /**
    Population of player

--- a/server/score.cpp
+++ b/server/score.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdio>
 #include <cstring>
@@ -38,10 +38,10 @@
 
 static int get_spaceship_score(const struct player *pplayer);
 
-/**************************************************************************
+/**
   Allocates, fills and returns a land area claim map.
   Call free_landarea_map(&cmap) to free allocated memory.
-**************************************************************************/
+ */
 
 #define USER_AREA_MULT 1000
 
@@ -51,9 +51,9 @@ struct claim_map {
   } player[MAX_NUM_PLAYER_SLOTS];
 };
 
-/**************************************************************************
+/**
   Land Area Debug...
-**************************************************************************/
+ */
 
 #define LAND_AREA_DEBUG 0
 

--- a/server/scripting/api_server_base.cpp
+++ b/server/scripting/api_server_base.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 /* common/scriptcore */
 #include "luascript.h"

--- a/server/scripting/api_server_edit.cpp
+++ b/server/scripting/api_server_edit.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/server/scripting/api_server_game_methods.cpp
+++ b/server/scripting/api_server_game_methods.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "fcintl.h"

--- a/server/scripting/api_server_luadata.cpp
+++ b/server/scripting/api_server_luadata.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // utility
 #include "registry_ini.h"

--- a/server/scripting/api_server_notify.cpp
+++ b/server/scripting/api_server_notify.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "featured_text.h"

--- a/server/scripting/script_fcdb.cpp
+++ b/server/scripting/script_fcdb.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QStandardPaths>

--- a/server/scripting/script_server.cpp
+++ b/server/scripting/script_server.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
@@ -6,7 +6,7 @@
  License,  or (at your option) any later version. You should have received
  a copy of the GNU General Public License along with Freeciv21. If not,
  see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <cstdarg>
 #include <ctime>

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>
@@ -187,7 +187,7 @@ int settings_list_cmp(const struct setting *const *pset1,
 
 static bool set_enum_value(struct setting *pset, int val);
 
-/****************************************************************************
+/*
   Enumerator name accessors.
 
   Important note about compatibility:
@@ -196,7 +196,7 @@ static bool set_enum_value(struct setting *pset, int val);
      branch before.
   2) Take care of modifiying the pretty name of an existant value: make sure
   to modify the help texts which are using it.
-****************************************************************************/
+ */
 
 #define NAME_CASE(_val, _support, _pretty)                                  \
   case _val: {                                                              \
@@ -567,9 +567,9 @@ static const struct sset_val_name *bool_name(int enable)
 
 #undef NAME_CASE
 
-/****************************************************************************
-  Help callback functions.
-****************************************************************************/
+/*
+ * Help callback functions.
+ */
 
 /**
    Help about phasemode setting
@@ -612,9 +612,9 @@ static const char *huts_help(const struct setting *pset)
   return pset->extra_help;
 }
 
-/****************************************************************************
-  Action callback functions.
-****************************************************************************/
+/*
+ * Action callback functions.
+ */
 
 /**
    (De)initialze the score log.
@@ -786,9 +786,9 @@ static void metamessage_action(const struct setting *pset)
   }
 }
 
-/****************************************************************************
-  Validation callback functions.
-****************************************************************************/
+/*
+ * Validation callback functions.
+ */
 
 /**
    Verify the selected savename definition.

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -6448,9 +6448,9 @@ static void cmd_reply_matches(enum command_id cmd, struct connection *caller,
   cmd_reply(cmd, caller, C_COMMENT, _("Possible matches: %s"), buf);
 }
 
-/**************************************************************************
+/**
   Additional 'help' arguments
-**************************************************************************/
+ */
 #define SPECENUM_NAME help_general_args
 #define SPECENUM_VALUE0 HELP_GENERAL_COMMANDS
 #define SPECENUM_VALUE0NAME "commands"
@@ -6459,12 +6459,12 @@ static void cmd_reply_matches(enum command_id cmd, struct connection *caller,
 #define SPECENUM_COUNT HELP_GENERAL_COUNT
 #include "specenum_gen.h"
 
-/**************************************************************************
+/*
   Unified indices for help arguments:
     CMD_NUM           -  Server commands
     HELP_GENERAL_NUM  -  General help arguments, above
     settings_number() -  Server options
-**************************************************************************/
+ */
 #define HELP_ARG_NUM (CMD_NUM + HELP_GENERAL_COUNT + settings_number())
 
 /**
@@ -6910,9 +6910,9 @@ static void show_colors(struct connection *caller)
   cmd_reply(CMD_LIST, caller, C_COMMENT, horiz_line);
 }
 
-/**************************************************************************
+/**
   '/list' arguments
-**************************************************************************/
+ */
 #define SPECENUM_NAME list_args
 #define SPECENUM_VALUE0 LIST_COLORS
 #define SPECENUM_VALUE0NAME "colors"
@@ -7392,9 +7392,9 @@ static int num_tokens(int start)
   return res;
 }
 
-/**************************************************************************
+/**
   Commands that may be followed by a player name
-**************************************************************************/
+ */
 static const int player_cmd[] = {
     CMD_AITOGGLE,     CMD_HANDICAPPED, CMD_NOVICE,      CMD_EASY,
     CMD_NORMAL,       CMD_HARD,        CMD_CHEATING,
@@ -7421,9 +7421,9 @@ static bool is_player(int start)
   return false;
 }
 
-/**************************************************************************
+/**
   Commands that may be followed by a connection name
-**************************************************************************/
+ */
 static const int connection_cmd[] = {CMD_CUT, CMD_KICK, -1};
 
 /**
@@ -7463,12 +7463,12 @@ static bool is_cmdlevel_arg1(int start)
       start, command_name_by_number(CMD_CMDLEVEL), false);
 }
 
-/**************************************************************************
+/**
   Commands that may be followed by a server option name
 
   CMD_SHOW is handled by option_level_cmd, which is for both option levels
   and server options
-**************************************************************************/
+ */
 static const int server_option_cmd[] = {CMD_EXPLAIN, CMD_SET, CMD_DEFAULT,
                                         -1};
 
@@ -7491,9 +7491,9 @@ static bool is_server_option(int start)
   return false;
 }
 
-/**************************************************************************
+/**
   Commands that may be followed by an option level or server option
-**************************************************************************/
+ */
 static const int option_level_cmd[] = {CMD_SHOW, -1};
 
 /**
@@ -7547,9 +7547,9 @@ static bool is_enum_option_value(int start, int *opt_p)
   return false;
 }
 
-/**************************************************************************
+/**
   Commands that may be followed by a filename
-**************************************************************************/
+ */
 static const int filename_cmd[] = {CMD_LOAD, CMD_SAVE, CMD_READ_SCRIPT,
                                    CMD_WRITE_SCRIPT, -1};
 

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*
 _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  \  |    This file is part of Freeciv21. Freeciv21 is free software: you
   \_|        can redistribute it and/or modify it under the terms of the
@@ -7,7 +7,7 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
  '/ \'           or (at your option) any later version. You should have
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+ */
 // utility
 #include "fcintl.h"
 #include "log.h"

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>

--- a/tools/ruledit/req_vec_fix.cpp
+++ b/tools/ruledit/req_vec_fix.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // Qt
 #include <QButtonGroup>

--- a/tools/ruleutil/rulesave.cpp
+++ b/tools/ruleutil/rulesave.cpp
@@ -724,9 +724,9 @@ static bool save_cities_ruleset(const char *filename, const char *name)
   return save_ruleset_file(sfile, filename);
 }
 
-/**************************************************************************
+/**
   Effect saving callback data structure.
-**************************************************************************/
+ */
 typedef struct {
   int idx;
   struct section_file *sfile;

--- a/tools/shared/tools_fc_interface.cpp
+++ b/tools/shared/tools_fc_interface.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
                    part of Freeciv21. Freeciv21 is free software: you can
     ^oo^      redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
    ()__()             option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 // common
 #include "fc_interface.h"

--- a/utility/distribute.cpp
+++ b/utility/distribute.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
  __    __          part of Freeciv21. Freeciv21 is free software: you can
 / \\..// \    redistribute it and/or modify it under the terms of the GNU
@@ -7,7 +7,7 @@
                       option) any later version. You should have received
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #include <vector>
 // utility

--- a/utility/fciconv.cpp
+++ b/utility/fciconv.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
              ____             Copyright (c) 1996-2020 Freeciv21 and Freeciv
             /    \__          contributors. This file is part of Freeciv21.
 |\         /    @   \   Freeciv21 is free software: you can redistribute it
@@ -9,7 +9,7 @@
  /  /__________\  \                 You should have received a copy of the
  L_JJ           \__JJ      GNU General Public License along with Freeciv21.
                                  If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>

--- a/utility/genhash.cpp
+++ b/utility/genhash.cpp
@@ -11,7 +11,8 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/****************************************************************************
+/**
+   \file
    A general-purpose generic hash table implementation.
 
    Based on implementation previous included in registry.c, but separated
@@ -53,7 +54,7 @@
    Implementation uses open hashing. Collision resolution is done by
    separate chaining with linked lists. Resize hash table when deemed
    necessary by making and populating a new table.
-****************************************************************************/
+ */
 
 #include <cstring>
 

--- a/utility/inputfile.cpp
+++ b/utility/inputfile.cpp
@@ -11,7 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/***********************************************************************
+/**
   A low-level object for reading a registry-format file.
   original author: David Pfitzner <dwp@mso.anu.edu.au>
 
@@ -61,7 +61,7 @@
           trailing double-quote.  Note this does _not_ translate
           escaped doublequotes etc back to normal.
 
-***********************************************************************/
+ */
 
 #include <cstdarg>
 // Qt

--- a/utility/rand.cpp
+++ b/utility/rand.cpp
@@ -11,10 +11,11 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/*************************************************************************
+/**
+   \file
    The following random number generator is a simple wrapper around the
    C++ standard library.
-*************************************************************************/
+ */
 
 // utility
 #include "log.h"

--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -11,15 +11,16 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-/**************************************************************************
+/**
+  \file
   the idea with this file is to create something similar to the ms-windows
   .ini files functions.
   however the interface is nice. ie:
   secfile_lookup_str(file, "player%d.unit%d.name", plrno, unitno);
-***************************************************************************/
 
-/**************************************************************************
-  Description of the file format:
+  Description of the file format
+  ==============================
+
   (This is based on a format by the original authors, with
   various incremental extensions. --dwp)
 
@@ -137,16 +138,16 @@
   Such multi-lines can occur for column headings, vectors, or
   table rows, again with some potential for strange errors...
 
-***************************************************************************/
+  Hashing registry lookups
+  ========================
 
-/**************************************************************************
-  Hashing registry lookups: (by dwp)
+  (by dwp)
   - Have a hash table direct to entries, bypassing sections division.
   - For convenience, store the key (the full section+entry name)
     in the hash table (some memory overhead).
   - The number of entries is fixed when the hash table is built.
   - Now uses hash.c
-**************************************************************************/
+ */
 // KArchive
 #include <KFilterDev>
 

--- a/utility/support.cpp
+++ b/utility/support.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
   /\ ___ /\        Copyright (c) 1996-2020 ＦＲＥＥＣＩＶ ２１ and Freeciv
  (  o   o  )                 contributors. This file is part of Freeciv21.
   \  >#<  /           Freeciv21 is free software: you can redistribute it
@@ -9,9 +9,10 @@
   ///  ///   --                     You should have received a copy of the
                           GNU General Public License along with Freeciv21.
                                   If not, see https://www.gnu.org/licenses/.
-**************************************************************************/
+ */
 
-/***********************************************************************
+/**
+  \file
   This module contains replacements for functions which are not
   available on all platforms.  Where the functions are available
   natively, these are (mostly) just wrappers.
@@ -35,7 +36,7 @@
   The main disadvantage is remembering to use these "fc" functions on
   systems which have the functions natively.
 
-***********************************************************************/
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <fc_config.h>
@@ -652,18 +653,6 @@ int fc_break_lines(char *str, size_t desired_len)
 
   return num_lines;
 }
-
-/****************************************************************************
-  Character function wrappers
-
-  These functions are wrappers for the libc character class functions,
-  without any locale-dependent behavior. The character functions work as
-  documented for ASCII. Bytes outside of the ASCII set will not be reported
-  to belong to any character class, and will be left unchanged by
-  transformations. This behavior is safe but not strictly correct
-  forsingle-byte 8-bit- or UTF-8 encoded text; in UTF-8, any byte that is
-  part of a multibyte sequence is non-ASCII.
-****************************************************************************/
 
 /**
    Set quick_exit() callback if possible.

--- a/utility/timing.cpp
+++ b/utility/timing.cpp
@@ -37,7 +37,7 @@ civtimer::civtimer(enum timer_timetype ttype, enum timer_use tuse)
 {
 }
 
-/***********************************************************************
+/**
    Allocate a new timer with specified "type" and "use".
  */
 civtimer *timer_new(enum timer_timetype type, enum timer_use use)
@@ -45,7 +45,7 @@ civtimer *timer_new(enum timer_timetype type, enum timer_use use)
   return timer_renew(nullptr, type, use);
 }
 
-/************************************************************************
+/**
    Allocate a new timer, or reuse t, with specified "type" and "use".
  */
 civtimer *timer_renew(civtimer *t, enum timer_timetype type,


### PR DESCRIPTION
As a rule, we keep our function header comments simple:
```
/**
 * Some comment
 */
```
The two stars are for Doxygen to recognize a docstring.

There were still parts of the code with older, longer headers with many stars:
```
/***************************
```
or
```
/**********************/ /**
```
The first variant confuses Doxygen, and the second is just ugly (tm). I used
sed and a few regexes to edit all comments using the old variants. In some
cases, the comments were describing the whole file; in such cases I added \file
for Doxygen to pick them up.