### PR TITLE
Use hue replacement anywhere a unit sprite is needed

### DIFF
--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -801,8 +801,8 @@ QRect polished_citybar_painter::paint(QPainter &painter,
     const QPixmap *xsprite = nullptr;
     const auto &target = pcity->production;
     if (can_see_inside && (VUT_UTYPE == target.kind)) {
-      xsprite =
-          get_unittype_sprite(t, target.value.utype, direction8_invalid());
+      xsprite = get_unittype_sprite(t, target.value.utype,
+                                    direction8_invalid(), owner_color);
     } else if (can_see_inside && (target.kind == VUT_IMPROVEMENT)) {
       xsprite = get_building_sprite(t, target.value.building);
     }

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -23,6 +23,7 @@
 #include <QVBoxLayout>
 #include <QWidgetAction>
 // utility
+#include "colors_common.h"
 #include "fc_types.h"
 #include "fcintl.h"
 #include "support.h"
@@ -400,8 +401,9 @@ void progress_bar::set_pixmap(struct universal *target)
   QRect crop;
 
   if (VUT_UTYPE == target->kind) {
+    auto color = get_player_color(tileset, client_player());
     sprite = get_unittype_sprite(get_tileset(), target->value.utype,
-                                 direction8_invalid());
+                                 direction8_invalid(), color);
   } else {
     sprite = get_building_sprite(tileset, target->value.building);
   }
@@ -2456,8 +2458,9 @@ void city_dialog::update_improvements()
       str = utype_values_translation(target.value.utype);
       cost = utype_build_shield_cost(pcity, target.value.utype);
       tooltip = get_tooltip_unit(target.value.utype, true).trimmed();
+      auto color = get_player_color(get_tileset(), city_owner(pcity));
       sprite = get_unittype_sprite(get_tileset(), target.value.utype,
-                                   direction8_invalid());
+                                   direction8_invalid(), color);
     } else if (target.kind == VUT_IMPROVEMENT) {
       str = city_improvement_name_translation(pcity, target.value.building);
       sprite = get_building_sprite(tileset, target.value.building);
@@ -2882,8 +2885,9 @@ void city_production_delegate::paint(QPainter *painter,
       is_flying = true;
     }
 
+    auto color = get_player_color(get_tileset(), client_player());
     sprite = get_unittype_sprite(get_tileset(), target->value.utype,
-                                 direction8_invalid());
+                                 direction8_invalid(), color);
   } else {
     is_unit = false;
     name = improvement_name_translation(target->value.building);

--- a/client/economyreport.cpp
+++ b/client/economyreport.cpp
@@ -10,6 +10,8 @@
 
 #include "economyreport.h"
 // client
+#include "client_main.h"
+#include "colors_common.h"
 #include "sprite.h"
 // gui-qt
 #include "fc_client.h"
@@ -120,7 +122,9 @@ void eco_report::update_report()
     struct unit_type *putype = pentry->type;
     cid id;
 
-    auto sprite = get_unittype_sprite(tileset, putype, direction8_invalid());
+    auto color = get_player_color(tileset, client_player());
+    auto sprite =
+        get_unittype_sprite(tileset, putype, direction8_invalid(), color);
     id = cid_encode_unit(putype);
 
     ui.eco_widget->insertRow(i + max_row);

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -19,6 +19,7 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 // utility
+#include "colors_common.h"
 #include "fcintl.h"
 // common
 #include "government.h"
@@ -289,7 +290,9 @@ void help_dialog::make_tree()
       case HELP_UNIT:
         f_type = unit_type_by_translated_name(s);
         if (f_type) {
-          spite = get_unittype_sprite(tileset, f_type, direction8_invalid());
+          auto color = get_player_color(tileset, client_player());
+          spite = get_unittype_sprite(tileset, f_type, direction8_invalid(),
+                                      color);
         }
         break;
 
@@ -853,8 +856,9 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
     max_utype = uclass_max_values(utype->uclass);
 
     // Unit icon
+    auto color = get_player_color(tileset, client_player());
     add_info_pixmap(
-        get_unittype_sprite(tileset, utype, direction8_invalid()));
+        get_unittype_sprite(tileset, utype, direction8_invalid(), color));
 
     add_info_progress(_("Attack:"), utype->attack_strength, 0,
                       max_utype->attack_strength);

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -19,6 +19,7 @@
 #include <QRadioButton>
 #include <QVBoxLayout>
 // common
+#include "colors_common.h"
 #include "movement.h"
 #include "nation.h"
 #include "research.h"
@@ -1202,8 +1203,9 @@ void hud_unit_loader::show_me()
   setRowCount(transports.count());
   setColumnCount(max_size + 1);
   for (i = 0; i < transports.count(); i++) {
+    auto color = get_player_color(tileset, unit_owner(transports.at(i)));
     auto sprite = get_unittype_sprite(tileset, transports.at(i)->utype,
-                                      direction8_invalid());
+                                      direction8_invalid(), color);
     QString str = utype_rule_name(transports.at(i)->utype);
     // TRANS: MP - just movement points
     str += " ("
@@ -1214,8 +1216,9 @@ void hud_unit_loader::show_me()
     j = 1;
     unit_list_iterate(transports.at(i)->transporting, tunit)
     {
-      sprite =
-          get_unittype_sprite(tileset, tunit->utype, direction8_invalid());
+      color = get_player_color(tileset, unit_owner(tunit));
+      sprite = get_unittype_sprite(tileset, tunit->utype,
+                                   direction8_invalid(), color);
       new_item = new QTableWidgetItem(QIcon(*sprite), QLatin1String(""));
       setItem(i, j, new_item);
       j++;
@@ -1680,6 +1683,8 @@ hud_unit_combat::hud_unit_combat(int attacker_unit_id, int defender_unit_id,
   def_veteran = make_def_veteran;
   att_hp_loss = attacker->hp - att_hp;
   def_hp_loss = defender->hp - def_hp;
+  attacker_color = get_player_color(tileset, unit_owner(attacker));
+  defender_color = get_player_color(tileset, unit_owner(attacker));
   if (defender_hp <= 0) {
     center_tile = attacker->tile;
   } else {
@@ -1709,8 +1714,8 @@ void hud_unit_combat::init_images(bool redraw)
     if (!redraw) {
       put_unit(defender, &defender_pixmap, 0, 0);
     } else {
-      defender_pixmap =
-          *get_unittype_sprite(tileset, type_defender, direction8_invalid());
+      defender_pixmap = *get_unittype_sprite(
+          tileset, type_defender, direction8_invalid(), defender_color);
     }
     dimg = defender_pixmap.toImage();
     dr = zealous_crop_rect(dimg);
@@ -1733,8 +1738,8 @@ void hud_unit_combat::init_images(bool redraw)
     if (!redraw) {
       put_unit(attacker, &attacker_pixmap, 0, 0);
     } else {
-      attacker_pixmap =
-          *get_unittype_sprite(tileset, type_attacker, direction8_invalid());
+      attacker_pixmap = *get_unittype_sprite(
+          tileset, type_attacker, direction8_invalid(), attacker_color);
     }
     aimg = attacker_pixmap.toImage();
     ar = zealous_crop_rect(aimg);

--- a/client/hudwidget.h
+++ b/client/hudwidget.h
@@ -322,6 +322,7 @@ private:
   struct unit *defender = nullptr;
   const struct unit_type *type_attacker = nullptr;
   const struct unit_type *type_defender = nullptr;
+  QColor attacker_color, defender_color;
   struct tile *center_tile = nullptr;
   bool focus = false;
   float fading = 0.0f;

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -10,6 +10,7 @@
 **************************************************************************/
 
 // utility
+#include "colors_common.h"
 #include "log.h"
 
 // common
@@ -133,7 +134,8 @@ static void node_rectangle_minimum_size(struct tree_node *node, int *width,
         if (advance_number(unit->require_advance) != node->tech) {
           continue;
         }
-        sprite = get_unittype_sprite(tileset, unit, direction8_invalid());
+        sprite = get_unittype_sprite(tileset, unit, direction8_invalid(),
+                                     QColor());
         max_icon_height = std::max(max_icon_height, sprite->height());
         icons_width_sum += sprite->width() + 2;
       }
@@ -1045,8 +1047,9 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
             if (advance_number(unit->require_advance) != node->tech) {
               continue;
             }
-            sprite =
-                get_unittype_sprite(tileset, unit, direction8_invalid());
+            auto color = get_player_color(tileset, client_player());
+            sprite = get_unittype_sprite(tileset, unit, direction8_invalid(),
+                                         color);
             rttp = new req_tooltip_help();
             rttp->rect =
                 QRect(icon_startx,

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -235,7 +235,7 @@ const QPixmap *get_government_sprite(const struct tileset *t,
 const QPixmap *get_unittype_sprite(const struct tileset *t,
                                    const struct unit_type *punittype,
                                    enum direction8 facing,
-                                   const QColor &replace = QColor());
+                                   const QColor &replace);
 const QPixmap *get_sample_city_sprite(const struct tileset *t,
                                       int style_idx);
 const QPixmap *get_tax_sprite(const struct tileset *t, Output_type_id otype);

--- a/client/unitreport.cpp
+++ b/client/unitreport.cpp
@@ -16,6 +16,7 @@
 #include <QPainter>
 #include <QScrollArea>
 // common
+#include "colors_common.h"
 #include "movement.h"
 #include "text.h"
 // client
@@ -265,7 +266,9 @@ unittype_item::~unittype_item() = default;
  */
 void unittype_item::init_img()
 {
-  auto sp = get_unittype_sprite(get_tileset(), utype, direction8_invalid());
+  auto color = get_player_color(get_tileset(), client_player());
+  auto sp =
+      get_unittype_sprite(get_tileset(), utype, direction8_invalid(), color);
   label_pix.setPixmap(*sp);
 }
 


### PR DESCRIPTION
The use of client_player() triggers hundreds of assertions when loading a large
game as a global observer; we'll need to fix that.

Closes #1269.