### PR TITLE
Don't use the capital for the tooltip of the city top bar button

### DIFF
--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -313,8 +313,8 @@ void pageGame::updateSidebarTooltips()
                 building_total + unit_total);
     sw_economy->setToolTip(buf);
     if (player_primary_capital(client_player())) {
-      sw_cities->setToolTip(
-          text_happiness_cities(player_primary_capital(client_player())));
+      auto cities = city_list_size(client_player()->cities);
+      sw_cities->setToolTip(QString(_("Cities: %1 total")).arg(cities));
     }
   } else {
     sw_science->hide();

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -293,10 +293,10 @@ void pageGame::updateSidebarTooltips()
 
   if (client.conn.playing && !client_is_global_observer()
       && C_S_RUNNING == client_state()) {
-    sw_science->setTooltip(science_dialog_text());
+    sw_science->setToolTip(science_dialog_text());
     str = QString(nation_plural_for_player(client_player()));
     str = str + '\n' + get_info_label_text(false);
-    sw_map->setTooltip(str);
+    sw_map->setToolTip(str);
     str = QString(_("Tax: %1% Science: %2% Luxury: %3%\n"))
               .arg(client.conn.playing->economic.tax)
               .arg(client.conn.playing->economic.luxury)
@@ -311,14 +311,14 @@ void pageGame::updateSidebarTooltips()
                             &tax);
     fc_snprintf(buf, sizeof(buf), _("Income: %d    Total Costs: %d"), tax,
                 building_total + unit_total);
-    sw_economy->setTooltip(buf);
+    sw_economy->setToolTip(buf);
     if (player_primary_capital(client_player())) {
-      sw_cities->setTooltip(
+      sw_cities->setToolTip(
           text_happiness_cities(player_primary_capital(client_player())));
     }
   } else {
     sw_science->hide();
-    sw_map->setTooltip(QLatin1String(""));
+    sw_map->setToolTip(QLatin1String(""));
     sw_economy->hide();
   }
   sw_indicators->setToolTip(get_info_label_text_popup());

--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -223,14 +223,6 @@ top_bar_widget::~top_bar_widget() { delete timer; }
 void top_bar_widget::setCustomLabels(const QString &l) { setText(l); }
 
 /**
-   Sets tooltip for sidewidget
- */
-void top_bar_widget::setTooltip(const QString &tooltip)
-{
-  setToolTip(tooltip);
-}
-
-/**
  * Paint event for top bar widget
  */
 void top_bar_widget::paintEvent(QPaintEvent *event)

--- a/client/top_bar.h
+++ b/client/top_bar.h
@@ -76,7 +76,6 @@ public:
   void setLabel(const QString &str);
   void setLeftClick(pfcn func);
   void setRightClick(pfcn func);
-  void setTooltip(const QString &tooltip);
   void setWheelDown(pfcn func);
   void setWheelUp(pfcn func);
 


### PR DESCRIPTION
The tooltip of the "Cities" button in the top bar was showing the number of
cities by querying the help text for the player's capital. Now that we have
better help texts, this string is more specific about the capital and breaks in
the context of the top bar.

Change back the tooltip to what it was before, i.e. a simple city counter.