### PR TITLE
Set a baseline palette for all themes except System

### DIFF
--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -138,13 +138,14 @@ void gui_load_theme(const QString &directory, const QString &theme_name)
   load_chat_colors(settings);
   current_theme = theme_name;
   QPixmapCache::clear();
+  if (theme_name != QStringLiteral("System")) {
+    // Need to do this *before* changing the stylesheet.
+    // FIXME How to reset to the system palette?
+    QApplication::setPalette(load_palette(settings));
+  }
   current_app()->setStyleSheet(*stylestring);
   if (king()) {
     queen()->reloadSidebarIcons();
-  }
-  if (theme_name != QStringLiteral("System")) {
-    // FIXME How to reset to the system palette?
-    QApplication::setPalette(load_palette(settings));
   }
 }
 

--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -142,7 +142,7 @@ void gui_load_theme(const QString &directory, const QString &theme_name)
   if (king()) {
     queen()->reloadSidebarIcons();
   }
-  if (theme_name != QStringLiteral("system")) {
+  if (theme_name != QStringLiteral("System")) {
     // FIXME How to reset to the system palette?
     QApplication::setPalette(load_palette(settings));
   }

--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -201,6 +201,12 @@ QStringList get_useable_themes_in_directory(QString &directory)
   name = QString(directory);
 
   for (auto const &str : qAsConst(sl)) {
+#ifdef Q_OS_WIN
+    // "System" creates endless problems on Windows, see #1287 #756
+    if (str == QStringLiteral("System")) {
+      continue;
+    }
+#endif
     f.setFileName(name + "/" + str + "/resource.qss");
     if (!f.exists()) {
       continue;

--- a/data/themes/gui-qt/Classic/theme.conf
+++ b/data/themes/gui-qt/Classic/theme.conf
@@ -1,11 +1,5 @@
-
-[general_colors]
-Link = #5CAAE5
-ButtonText = #7C4A03
-Foreground = #7C4A03
-WindowText = #7C4A03
-
 ; Breeze Light colors
+[general_colors]
 Button = #EFF0F1
 Light = #FFFFFF
 Midlight = #F6F7F7
@@ -13,18 +7,18 @@ Dark = #888E93
 Mid = #C4C8CC
 Text = #232627
 BrightText = #FFFFFF
-;ButtonText = #232627
+ButtonText = #232627
 Base = #FCFCFC
 Window = #EFF0F1
 Shadow = #474A4C
 Highlight = #3DAEE9
 HighlightedText = #FCFCFC
-;Link = #2980B9
+Link = #2980B9
 LinkVisited = #7F8C8D
 AlternateBase = #EFF0F1
 ToolTipBase = #232627
 ToolTipText = #FCFCFC
 PlaceholderText = #232627
-;Foreground = #232627
-;WindowText = #232627
+Foreground = #232627
+WindowText = #232627
 Background = #EFF0F1

--- a/data/themes/gui-qt/Necrophos/theme.conf
+++ b/data/themes/gui-qt/Necrophos/theme.conf
@@ -1,11 +1,5 @@
-
-[general_colors]
-Link = #5CAAE5
-ButtonText = #7C4A03
-Foreground = #7C4A03
-WindowText = #7C4A03
-
 ; Breeze Light colors
+[general_colors]
 Button = #EFF0F1
 Light = #FFFFFF
 Midlight = #F6F7F7
@@ -13,18 +7,18 @@ Dark = #888E93
 Mid = #C4C8CC
 Text = #232627
 BrightText = #FFFFFF
-;ButtonText = #232627
+ButtonText = #232627
 Base = #FCFCFC
 Window = #EFF0F1
 Shadow = #474A4C
 Highlight = #3DAEE9
 HighlightedText = #FCFCFC
-;Link = #2980B9
+Link = #2980B9
 LinkVisited = #7F8C8D
 AlternateBase = #EFF0F1
 ToolTipBase = #232627
 ToolTipText = #FCFCFC
 PlaceholderText = #232627
-;Foreground = #232627
-;WindowText = #232627
+Foreground = #232627
+WindowText = #232627
 Background = #EFF0F1

--- a/data/themes/gui-qt/NightStalker/theme.conf
+++ b/data/themes/gui-qt/NightStalker/theme.conf
@@ -1,0 +1,24 @@
+; Breeze Dark colors
+[general_colors]
+WindowText = #fcfcfc
+Button = #31363b
+Light = #40464c
+Midlight = #363b40
+Dark = #191b1d
+Mid = #25292c
+Text = #fcfcfc
+BrightText = #ffffff
+ButtonText = #fcfcfc
+Base = #1b1e20
+Window = #2a2e32
+Shadow = #121415
+Highlight = #3daee9
+HighlightedText = #fcfcfc
+Link = #1d99f3
+LinkVisited = #9b59b6
+AlternateBase = #232629
+ToolTipBase = #31363b
+ToolTipText = #fcfcfc
+PlaceholderText = #fcfcfc
+Foreground = #fcfcfc
+Background = #2a2e32

--- a/data/themes/gui-qt/System/resource.qss
+++ b/data/themes/gui-qt/System/resource.qss
@@ -6,12 +6,6 @@
   text-align: right;
 }
 
-*[doomchat="true"] {
-  background-color: white;
-  color: black;
-  border: 1px solid #c3b48e;
-}
-
 *[unit_wait_table="true"] {
   background-color: rgba(0,0,0,175);
   color: white;
@@ -24,7 +18,7 @@ chat_widget QTextBrowser
   color: rgb( 240, 240, 240);
 }
 
-chat_widget QLineEdit
+pageGame chat_widget QLineEdit
 {
   background-color: black;
   border: 1px solid #13395f;
@@ -34,14 +28,14 @@ chat_widget QLineEdit
 info_tile, notify_dialog {
   color: #e8ff00;
   border: 1px solid #e8ff00;
-  background-color: rgba(0, 0, 0,175);
+  background-color: rgba(0, 0, 0, 175);
 }
 
-message_widget, chat_widget {
+message_widget, chat_widget, hud_units {
   background-color: rgba(0,0,0,175);
 }
 
-message_widget *, chat_widget * {
+message_widget *, chat_widget *, hud_units * {
   color: white;
 }
 
@@ -117,58 +111,4 @@ research_color {
   selection-background-color: #6779c5 /*box*/;
   color: #96b62e /*lines*/;
   alternate-background-color: white /* box edge */;
-}
-
-QMenuBar {
-  color: black;
-}
-
-QMenu {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0 rgba(84, 85, 86, 225), stop:1 rgba(55, 55, 54, 255));
-  border:none;
-}
-
-QMenu::item {
-  color: #FFFFFF;
-  padding: 3px 20px 3px 25px;
-  border: 2px solid transparent;
-}
-
-QMenu::item:disabled {
-  color: #999999;
-}
-
-QMenu::item:selected {
-  color: #3399FF;
-  background-color: rgba(55, 55, 54, 255);
-  border: 2px solid grey;
-  border-radius: 9px;
-}
-
-QStatusBar QLabel {
- color: black;
-}
-
-page_main QLabel {
- color: black;
-}
-
-page_pregame QLabel {
- color: black;
-}
-
-page_load QLabel {
- color: black;
-}
-
-page_load QCheckBox {
-  color: black;
-}
-
-page_network QLabel {
- color: black;
-}
-
-page_scenario QLabel {
- color: black;
 }

--- a/data/themes/gui-qt/TheLastLaserMaster/theme.conf
+++ b/data/themes/gui-qt/TheLastLaserMaster/theme.conf
@@ -1,0 +1,24 @@
+; Breeze Dark colors
+[general_colors]
+WindowText = #fcfcfc
+Button = #31363b
+Light = #40464c
+Midlight = #363b40
+Dark = #191b1d
+Mid = #25292c
+Text = #fcfcfc
+BrightText = #ffffff
+ButtonText = #fcfcfc
+Base = #1b1e20
+Window = #2a2e32
+Shadow = #121415
+Highlight = #3daee9
+HighlightedText = #fcfcfc
+Link = #1d99f3
+LinkVisited = #9b59b6
+AlternateBase = #232629
+ToolTipBase = #31363b
+ToolTipText = #fcfcfc
+PlaceholderText = #fcfcfc
+Foreground = #fcfcfc
+Background = #2a2e32


### PR DESCRIPTION
In order to achieve consistency in what is displayed regardless of the system
theme, the system color scheme needs to be overriden. Previously only 3 colors
were changed (and for a single theme), which was causing readbility issues when
the system color scheme didn't match the theme.

Always fill the system QPalette with dark colors for dark themes and light
colors for light themes. Use the Breeze Light and Breeze Dark palettes as
references.

There are still some issues when changing the theme on the fly, much like #762.
It looks fine after restarting the game.