### PR TITLE
Fix crash when non-player changes ai_manual_turn_done

### DIFF
--- a/client/options.cpp
+++ b/client/options.cpp
@@ -4741,8 +4741,10 @@ static void manual_turn_done_callback(struct option *poption)
 {
   Q_UNUSED(poption)
   update_turn_done_button_state();
-  if (!gui_options.ai_manual_turn_done && is_ai(client.conn.playing)) {
-    if (can_end_turn()) {
+
+  if (!gui_options.ai_manual_turn_done) {
+    const player *pplayer = client_player();
+    if (pplayer != nullptr && is_ai(pplayer) && can_end_turn()) {
       user_ended_turn();
     }
   }


### PR DESCRIPTION
This could happen in pre-game, or for global observer.

See osdn #45310

Ported from: https://github.com/freeciv/freeciv/commit/a8570f3b61cbead146a87820fdeb57862b22dca1