### PR TITLE
List small wonders in the client, but hide them by default

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -574,6 +574,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_STEALINGS_IGNORE:
   case EFT_MAPS_STOLEN_PCT:
   case EFT_UNIT_SHIELD_VALUE_PCT:
+  case EFT_WONDER_VISIBLE:
     break;
     // This has no effect for AI
   case EFT_VISIBLE_WALLS:

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -14,10 +14,14 @@
 #include <QPainter>
 #include <QSortFilterProxyModel>
 // utility
+#include "astring.h"
 #include "fcintl.h"
 // common
+#include "city.h"
 #include "colors_common.h"
+#include "game.h"
 #include "government.h"
+#include "improvement.h"
 #include "nation.h"
 #include "research.h"
 // client
@@ -632,6 +636,38 @@ void plr_widget::nation_selected(const QItemSelection &sl,
       tech_str = tech_str + QStringLiteral("<i>") + res.toHtmlEscaped() + ","
                  + QStringLiteral("</i>") + sp;
     }
+  }
+  // Wonder information
+  auto wonders = QStringList();
+  for (int i = 0; i < improvement_count(); ++i) {
+    if (pplayer->wonders[i] == WONDER_NOT_BUILT) {
+      continue;
+    }
+
+    const auto improve = improvement_by_number(i);
+    const auto name =
+        QString(improvement_name_translation(improve)).toHtmlEscaped();
+    if (pplayer->wonders[i] == WONDER_LOST) {
+      // TRANS: %1 is a wonder name
+      wonders += QString(_("%1 (lost)")).arg(name);
+    } else if (const auto city = game_city_by_number(pplayer->wonders[i])) {
+      // TRANS: %1 is a wonder name, %2 is a city name
+      wonders += QString(_("%1 (in %2)"))
+                     .arg(name)
+                     .arg(QString(city_name_get(city)).toHtmlEscaped());
+    } else {
+      wonders += name;
+    }
+  }
+  if (!tech_str.isEmpty()) {
+    tech_str += nl;
+  }
+  // TRANS: Followed by a list of wonders the player knows another player has
+  tech_str += QString(_("<b>Known Wonders: </b>"));
+  if (wonders.isEmpty()) {
+    tech_str += QString(Q_("?wonder:None"));
+  } else {
+    tech_str += strvec_to_and_list(wonders.toVector());
   }
   plr->update_report(false);
 }

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1215,6 +1215,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_BORDER_VISION:
   case EFT_STEALINGS_IGNORE:
   case EFT_CASUS_BELLI_COMPLETE:
+  case EFT_WONDER_VISIBLE:
   case EFT_COUNT:
     return QStringLiteral("%1").arg(value);
   }

--- a/common/effects.h
+++ b/common/effects.h
@@ -307,6 +307,8 @@
 #define SPECENUM_VALUE130NAME "Bombard_Limit_Pct"
 #define SPECENUM_VALUE131 EFT_TRADE_REVENUE_EXPONENT
 #define SPECENUM_VALUE131NAME "Trade_Revenue_Exponent"
+#define SPECENUM_VALUE132 EFT_WONDER_VISIBLE
+#define SPECENUM_VALUE132NAME "Wonder_Visible"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/common/game.cpp
+++ b/common/game.cpp
@@ -25,6 +25,7 @@
 #include "ai.h"
 #include "city.h"
 #include "disaster.h"
+#include "effects.h"
 #include "extras.h"
 #include "government.h"
 #include "idex.h"
@@ -650,7 +651,9 @@ void initialize_globals()
             game.info.great_wonder_owners[improvement_index(pimprove)] =
                 player_number(pplayer);
           }
-          pplayer->wonders[improvement_index(pimprove)] = pcity->id;
+          if (get_building_bonus(pcity, pimprove, EFT_WONDER_VISIBLE) > 0) {
+            pplayer->wonders[improvement_index(pimprove)] = pcity->id;
+          }
         }
       }
       city_built_iterate_end;

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -708,3 +708,15 @@ Bombard_Limit_Pct
     .. note::
         This effect is added automatically with a value of 1 and no reqs. This behavior can be turned
         off by requiring the ``+Bombard_Limit_Pct`` option in ``effects.ruleset``.
+
+Wonder_Visible
+    If the value of this effect is larger than 0 for a Small Wonder, the wonder will be visible to all
+    players and reported in the intelligence screen. Great Wonders are always visible to everyone through the
+    Wonders Report. When a Small Wonder is lost (for instance, because the city it is in is lost or some of
+    its requirements become invalid), it also becomes visible to everyone (this is a limitation of the
+    server).
+
+    .. note::
+        This effect is added automatically with a value of 1 for Great Wonders (since they are shown in the
+        Wonders Report anyway). This behavior can be turned off by requiring the ``+Wonder_Visible`` option
+        in ``effects.ruleset``.

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -22,6 +22,7 @@
 #include "citizens.h"
 #include "culture.h"
 #include "diptreaty.h"
+#include "game.h"
 #include "government.h"
 #include "map.h"
 #include "multipliers.h"
@@ -1135,7 +1136,17 @@ static void package_player_common(struct player *plr,
   packet->nturns_idle = plr->nturns_idle;
 
   for (i = 0; i < B_LAST /*improvement_count()*/; i++) {
-    packet->wonders[i] = plr->wonders[i];
+    if (plr->wonders[i] <= 0) {
+      packet->wonders[i] = plr->wonders[i];
+    } else {
+      const auto pimprove = improvement_by_number(i);
+      const auto pcity = game_city_by_number(plr->wonders[i]);
+      if (pimprove && pcity) {
+        if (get_building_bonus(pcity, pimprove, EFT_WONDER_VISIBLE) > 0) {
+          packet->wonders[i] = plr->wonders[i];
+        }
+      }
+    }
   }
   packet->science_cost = plr->ai_common.science_cost;
 }

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1164,6 +1164,13 @@ static void rscompat_optional_capabilities(rscompat_info *info)
     unit_type_iterate_end;
   }
 
+  if (!has_capability(CAP_EFT_WONDER_VISIBLE, info->cap_effects.data())) {
+    // Make Great Wonders visible to everyone
+    auto effect = effect_new(EFT_WONDER_VISIBLE, 1, nullptr);
+    effect_req_append(effect, req_from_str("BuildingGenus", "Local", false,
+                                           true, false, "GreatWonder"));
+  }
+
   if (!has_capability(CAP_VUT_VISIONLAYER, info->cap_effects.data())) {
     // Add vlayer=Main to existing vision effects
     iterate_effect_cache(rscompat_vision_effect_cb, info);

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -16,10 +16,12 @@
 
 #define CAP_EFT_HP_REGEN_MIN "HP_Regen_Min"
 #define CAP_EFT_BOMBARD_LIMIT_PCT "Bombard_Limit_Pct"
+#define CAP_EFT_WONDER_VISIBLE "Wonder_Visible"
 #define CAP_VUT_VISIONLAYER "Vision_Layer"
 #define RULESET_CAPABILITIES                                                \
   "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN                \
-  " " CAP_EFT_BOMBARD_LIMIT_PCT " " CAP_VUT_VISIONLAYER
+  " " CAP_EFT_BOMBARD_LIMIT_PCT " " CAP_EFT_WONDER_VISIBLE                  \
+  " " CAP_VUT_VISIONLAYER
 /*
  * Ruleset capabilities acceptable to this program:
  *


### PR DESCRIPTION
The client has always known which small wonders any player had built (#318). This adds code to show this in the client. For backward compatibility, the patch also hides small wonders by default, keeping only great wonders. This can be controlled using a new effect `Wonder_Visible`. All shipped rulesets use the old way.

Closes #318.