### PR TITLE
Fix deadlocks in the main menu

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -154,6 +154,7 @@ target_link_libraries(client PUBLIC Qt5::Svg)
 target_link_libraries(client PUBLIC ${SDL2_MIXER_LIBRARIES} ${SDL2_LIBRARY})
 
 target_link_libraries(client PUBLIC client_gen)
+target_link_libraries(client_gen PUBLIC client) # Needed to link
 target_link_libraries(client PUBLIC cvercmp)
 target_link_libraries(client PUBLIC luascript)
 

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -57,7 +57,6 @@ static void close_socket_nomessage(struct connection *pc)
   connection_common_close(pc);
   remove_net_input();
   popdown_races_dialog();
-  close_connection_dialog();
 
   set_client_state(C_S_DISCONNECTED);
 }

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -130,6 +130,8 @@ static int try_to_connect(const QUrl &url, char *errbuf, int errbufsize)
           }
           client.conn.used = false;
         });
+    QObject::connect(client.conn.sock, &QAbstractSocket::disconnected,
+                     [] { client.conn.used = false; });
   }
 
   client.conn.sock->connectToHost(url.host(), url.port());

--- a/client/connectdlg.cpp
+++ b/client/connectdlg.cpp
@@ -20,17 +20,6 @@
 #include "qtg_cxxside.h"
 
 /**
-   Close and destroy the dialog. But only if we don't have a local
-   server running (that we started).
- */
-void close_connection_dialog()
-{
-  if (king()->current_page() != PAGE_NETWORK) {
-    real_set_client_page(PAGE_MAIN);
-  }
-}
-
-/**
    Configure the dialog depending on what type of authentication request the
    server is making.
  */

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -201,6 +201,9 @@ void fc_client::switch_page(int new_pg)
   page = new_page;
   switch (new_page) {
   case PAGE_MAIN:
+    if (client.conn.used) {
+      disconnect_from_server();
+    }
     break;
   case PAGE_START:
     voteinfo_gui_update();

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -331,9 +331,8 @@ void fc_client::slot_disconnect()
 {
   if (client.conn.used) {
     disconnect_from_server();
+    switch_page(PAGE_MAIN);
   }
-
-  switch_page(PAGE_MAIN);
 }
 
 /**

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -106,16 +106,16 @@ fc_client::fc_client() : QMainWindow(), current_file(QLatin1String(""))
   page_game->chat->installEventFilter(this); // To save its location
   pages[PAGE_GAME] = page_game;
 
-  pages[PAGE_GAME + 1] = new QWidget(central_wdg);
+  pages[PAGE_LOADING] = new QWidget(central_wdg);
   create_loading_page();
-  pages[PAGE_GAME + 1]->setLayout(pages_layout[PAGE_GAME + 1]);
+  pages[PAGE_LOADING]->setLayout(pages_layout[PAGE_LOADING]);
   central_layout->addWidget(pages[PAGE_MAIN]);
   central_layout->addWidget(pages[PAGE_NETWORK]);
   central_layout->addWidget(pages[PAGE_LOAD]);
   central_layout->addWidget(pages[PAGE_SCENARIO]);
   central_layout->addWidget(pages[PAGE_START]);
   central_layout->addWidget(pages[PAGE_GAME]);
-  central_layout->addWidget(pages[PAGE_GAME + 1]);
+  central_layout->addWidget(pages[PAGE_LOADING]);
   central_wdg->setLayout(central_layout);
   setCentralWidget(central_wdg);
   resize(pages[PAGE_MAIN]->minimumSizeHint());
@@ -179,10 +179,7 @@ void fc_client::closing() { quitting = true; }
  */
 void fc_client::switch_page(int new_pg)
 {
-  enum client_pages new_page;
-  int i_page;
-
-  new_page = static_cast<client_pages>(new_pg);
+  const auto new_page = static_cast<client_pages>(new_pg);
 
   if ((new_page == PAGE_SCENARIO || new_page == PAGE_LOAD)
       && !is_server_running()) {
@@ -202,8 +199,7 @@ void fc_client::switch_page(int new_pg)
   QApplication::alert(king()->central_wdg);
   central_layout->setCurrentWidget(pages[new_pg]);
   page = new_page;
-  i_page = new_page;
-  switch (i_page) {
+  switch (new_page) {
   case PAGE_MAIN:
     break;
   case PAGE_START:
@@ -253,13 +249,8 @@ void fc_client::switch_page(int new_pg)
     qobject_cast<page_network *>(pages[PAGE_NETWORK])
         ->set_connection_state(LOGIN_TYPE);
     break;
-  case (PAGE_GAME + 1):
-    break;
-  default:
-    if (client.conn.used) {
-      disconnect_from_server();
-    }
-    set_client_page(PAGE_MAIN);
+  case PAGE_LOADING:
+  case PAGE_COUNT:
     break;
   }
 
@@ -644,9 +635,8 @@ void fc_client::create_loading_page()
 {
   QLabel *label = new QLabel(_("Loading..."));
 
-  pages_layout[PAGE_GAME + 1] = new QGridLayout;
-  pages_layout[PAGE_GAME + 1]->addWidget(label, 0, 0, 1, 1,
-                                         Qt::AlignHCenter);
+  pages_layout[PAGE_LOADING] = new QGridLayout;
+  pages_layout[PAGE_LOADING]->addWidget(label, 0, 0, 1, 1, Qt::AlignHCenter);
 }
 
 /**

--- a/client/fc_client.h
+++ b/client/fc_client.h
@@ -93,7 +93,7 @@ class fc_client : public QMainWindow {
   Q_OBJECT
 
   enum client_pages page;
-  QGridLayout *pages_layout[PAGE_GAME + 2];
+  QGridLayout *pages_layout[PAGE_COUNT];
   QLabel *status_bar_label{nullptr};
   QSocketNotifier *server_notifier{nullptr};
   QStackedLayout *central_layout{nullptr};

--- a/client/include/pages_g.h
+++ b/client/include/pages_g.h
@@ -20,6 +20,8 @@
 #define SPECENUM_VALUE3 PAGE_LOAD     // Load saved game page.
 #define SPECENUM_VALUE4 PAGE_NETWORK  // Connect to network page.
 #define SPECENUM_VALUE5 PAGE_GAME     // In game page.
+#define SPECENUM_VALUE6 PAGE_LOADING  // Loading something.
+#define SPECENUM_COUNT PAGE_COUNT
 #include "specenum_gen.h"
 
 void update_start_page(void);

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -333,7 +333,6 @@ void handle_server_join_reply(bool you_can_join, const char *message,
   const char *s_capability = client.conn.capability;
 
   conn_set_capability(&client.conn, capability);
-  close_connection_dialog();
 
   if (you_can_join) {
     struct packet_client_info client_info;

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -136,7 +136,7 @@ void page_load::start_from_save()
 
     c_bytes = current_file.toLocal8Bit();
     send_chat_printf("/load %s", c_bytes.data());
-    gui->switch_page(PAGE_GAME + 1);
+    gui->switch_page(PAGE_LOADING);
   }
 }
 

--- a/client/page_scenario.cpp
+++ b/client/page_scenario.cpp
@@ -109,7 +109,7 @@ void page_scenario::start_scenario()
 
     c_bytes = current_file.toLocal8Bit();
     send_chat_printf("/load %s", c_bytes.data());
-    king->switch_page(PAGE_GAME + 1);
+    king->switch_page(PAGE_LOADING);
   }
 }
 

--- a/client/qtg_cxxside.h
+++ b/client/qtg_cxxside.h
@@ -23,7 +23,6 @@ void set_rulesets(int num_rulesets, QStringList rulesets);
 void add_net_input(QTcpSocket *sock);
 void remove_net_input();
 void real_conn_list_dialog_update(void *unused);
-void close_connection_dialog();
 void sound_bell();
 
 void real_set_client_page(client_pages page);


### PR DESCRIPTION
This fixes two cases in which the game would become unusable:

* Connect to network game, but don't enter your password; go back to the main page and try again (this is likely #785)
* Start new game, go back to the main page and try again (#1009)

Doing it in a single PR because the two issues ended up sharing a common root cause.

Closes #785.
Closes #1009.