### PR TITLE
Restore goto into the unknown

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -1465,6 +1465,7 @@ void request_units_return()
   for (const auto unit : get_units_in_focus()) {
     // Find a path to the closest city
     auto finder = freeciv::path_finder(unit);
+    finder.set_unknown_tiles_allowed(gui_options.goto_into_unknown);
     if (auto path = finder.find_path(
             freeciv::allied_city_destination(unit->owner))) {
       auto steps = path->steps();

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -252,7 +252,8 @@ void enter_goto_state(const std::vector<unit *> &units)
   for (const auto punit : units) {
     // This calls path_finder::path_finder(punit) behind the scenes
     // Need to do this because path_finder isn't copy-assignable
-    goto_finders.emplace(punit->id, punit);
+    auto [it, _] = goto_finders.emplace(punit->id, punit);
+    it->second.set_unknown_tiles_allowed(gui_options.goto_into_unknown);
   }
 }
 

--- a/common/path_finder.h
+++ b/common/path_finder.h
@@ -71,6 +71,8 @@ private:
     const detail::vertex
         initial_vertex; ///< The starting point in the search graph.
 
+    bool unknown_tiles_allowed = false;
+
     // Storage for Dijkstra's algorithm.
     // In most cases, a single vertex will be stored for a given tile. There
     // are situations, however, where more vertices are needed. This is for
@@ -101,6 +103,7 @@ private:
     void attempt_action_move(detail::vertex &source);
 
     bool run_search(const destination &destination);
+    void reset();
   };
 
 public:
@@ -109,6 +112,14 @@ public:
   virtual ~path_finder();
 
   inline path_finder &operator=(path_finder &&other);
+
+  /// Returns whether goto into the unkown is allowed.
+  bool are_unknown_tiles_allowed() const
+  {
+    return m_d->unknown_tiles_allowed;
+  }
+
+  void set_unknown_tiles_allowed(bool allowed);
 
   void push_waypoint(const tile *location);
   bool pop_waypoint();


### PR DESCRIPTION
Add a flag to the path finder class to control whether it should include
unknown tiles in the search. Bind it to the corresponding gui option when
creating the finders.

This restores the ability to produce paths going through unknown parts of the
map, which is useful in some circumstances.

Closes #890.