### PR TITLE
Protect can_step_taken_wrt_to_zoc against null terrain

### DIFF
--- a/common/movement.cpp
+++ b/common/movement.cpp
@@ -511,8 +511,10 @@ bool can_step_taken_wrt_to_zoc(const struct unit_type *punittype,
   if (tile_city(src_tile) || tile_city(dst_tile)) {
     return true;
   }
-  if (terrain_has_flag(tile_terrain(src_tile), TER_NO_ZOC)
-      || terrain_has_flag(tile_terrain(dst_tile), TER_NO_ZOC)) {
+  const auto src_terrain = tile_terrain(src_tile);
+  const auto dst_terrain = tile_terrain(dst_tile);
+  if ((src_terrain && terrain_has_flag(src_terrain, TER_NO_ZOC))
+      || (dst_terrain && terrain_has_flag(dst_terrain, TER_NO_ZOC))) {
     return true;
   }
 


### PR DESCRIPTION
Using can_step_taken_wrt_to_zoc in the path finding code (through
unit_can_move_to_tile) makes it possible that unseen tiles are passed to it. We
should therefore not assume that the terrain of the tile is known.

Given our inability to reproduce #1315, this may not be a complete fix. It does protect the code path shown in the stack trace there. I looked around a bit and couldn't find any other unchecked use of `tile->terrain` in the path finding code.

Closes #1315.