### PR TITLE
Fix reported chat bug, don't fix not reported ones

### DIFF
--- a/client/chatline.h
+++ b/client/chatline.h
@@ -121,9 +121,9 @@ public:
 
   /// Returns whether the chat widget is currently visible.
   bool is_chat_visible() const { return m_chat_visible; }
+  void set_chat_visible(bool visible);
 
 private slots:
-  void set_chat_visible(bool visible);
   void update_menu() override {}
   void rm_links();
   void anchor_clicked(const QUrl &link);

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -517,12 +517,16 @@ bool fc_game_tab_widget::event(QEvent *event)
           qRound(size.width() * king()->qt_settings.chat_fwidth),
           qRound(size.height() * king()->qt_settings.chat_fheight));
       queen()->message->move(size.width() - queen()->message->width(), 0);
-      queen()->chat->resize(
-          qRound(size.width() * king()->qt_settings.chat_fwidth),
-          qRound(size.height() * king()->qt_settings.chat_fheight));
-      queen()->chat->move(
-          qRound(size.width() * king()->qt_settings.chat_fx_pos),
-          qRound(size.height() * king()->qt_settings.chat_fy_pos));
+
+      auto chat = queen()->chat;
+      const bool visible = chat->is_chat_visible(); // Save old state
+      chat->set_chat_visible(true);
+      chat->resize(qRound(size.width() * king()->qt_settings.chat_fwidth),
+                   qRound(size.height() * king()->qt_settings.chat_fheight));
+      chat->move(qRound(size.width() * king()->qt_settings.chat_fx_pos),
+                 qRound(size.height() * king()->qt_settings.chat_fy_pos));
+      chat->set_chat_visible(visible); // Restore state
+
       queen()->battlelog_wdg->set_scale(king()->qt_settings.battlelog_scale);
       queen()->battlelog_wdg->move(
           qRound(king()->qt_settings.battlelog_x * mapview.width),


### PR DESCRIPTION
The reported bug was that the widget will acquire a wrong size if the map view
is resized while it's closed.

Hoping that nobody will find the not-reported bugs.

Closes #1290.