### PR TITLE
Fix slanted lines in the minimap view rectangle

### DIFF
--- a/client/minimap.cpp
+++ b/client/minimap.cpp
@@ -99,8 +99,10 @@ void overview_pos_nowrap(const struct tileset *t, int *ovr_x, int *ovr_y,
   gui_to_natural_pos(t, &ntl_x, &ntl_y, gui_x, gui_y);
 
   // Now convert straight to overview coordinates.
-  *ovr_x = floor((ntl_x - gui_options.overview.map_x0) * OVERVIEW_TILE_SIZE);
-  *ovr_y = floor((ntl_y - gui_options.overview.map_y0) * OVERVIEW_TILE_SIZE);
+  *ovr_x =
+      std::round((ntl_x - gui_options.overview.map_x0) * OVERVIEW_TILE_SIZE);
+  *ovr_y =
+      std::round((ntl_y - gui_options.overview.map_y0) * OVERVIEW_TILE_SIZE);
 }
 
 } // namespace


### PR DESCRIPTION
Tiny differences between the results of floating-point calculations that would
yield the exact same results in infinite precision culminated into off-by-one
errors in the calculation of the viewport coordinates on the minimap. Round the
floating-point results when converting them back to integers. This change might
lose some formal accuracy but the difference is invisible in practice.

Closes #1128.