### PR TITLE
Forbid toggling the minimap from the city view

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1475,6 +1475,7 @@ void city_dialog::hideEvent(QHideEvent *event)
     pcity = nullptr;
   }
   queen()->mapview_wdg->show_all_fcwidgets();
+  king()->menu_bar->minimap_status->setEnabled(true);
 }
 
 /**
@@ -1487,6 +1488,7 @@ void city_dialog::showEvent(QShowEvent *event)
   if (pcity) {
     unit_focus_set(nullptr);
     update_map_canvas_visible();
+    king()->menu_bar->minimap_status->setEnabled(false);
   }
 }
 


### PR DESCRIPTION
It's never visible, so the menu would do nothing. The implementation is also
buggy when triggered while the widget is hidden.

Closes #1126.