### PR TITLE
Recommend capitalization in fewer cases

### DIFF
--- a/docs/Contributing/capitalized-terms.rst
+++ b/docs/Contributing/capitalized-terms.rst
@@ -1,0 +1,343 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+
+List of Capitalized Terms
+*************************
+
+.. Custom Interpretive Text Roles for longturn.net/Freeciv21
+.. role:: unit
+.. role:: improvement
+.. role:: wonder
+
+This page contains a list of terms that should be capitalized when used in the documentation. It is most
+likely incomplete. Please refer to the :doc:`style-guide` page for more information.
+
+Buildings and Wonders
+=====================
+
+Use them with ``:improvement:`` or ``:woncer:``, :improvement:`Granary` and :wonder:`Pyramids`.
+
+.. hlist::
+  :columns: 3
+
+  * 2nd Palace
+  * Airport
+  * Amphitheater
+  * Apollo Program
+  * Aqueduct
+  * A.Smith's Trading Co.
+  * Atlantic Telegraph Company
+  * Bank
+  * Barracks
+  * Barracks II
+  * Barracks III
+  * Cathedral
+  * City Walls
+  * Coastal Defense
+  * Coinage
+  * Colosseum
+  * Colossus
+  * Copernicus' Observatory
+  * Courthouse
+  * Cure For Cancer
+  * Darwin's Voyage
+  * Ecclesiastical Palace
+  * Eiffel Tower
+  * Factory
+  * Granary
+  * Great Library
+  * Great Wall
+  * Hal Saflieni Hypogeum
+  * Hanging Gardens
+  * Harbor
+  * Hoover Dam
+  * Hospital
+  * Hydro Plant
+  * Internet
+  * Isaac Newton's College
+  * J.S. Bach's Cathedral
+  * King Richard's Crusade
+  * Leonardo's Workshop
+  * Library
+  * Lighthouse
+  * Magellan's Expedition
+  * Manhattan Project
+  * Marco Polo's Embassy
+  * Marketplace
+  * Mass Transit
+  * Mausoleum of Mausolos
+  * Mercantile Exchange
+  * Mfg. Plant
+  * Michelangelo's Chapel
+  * Nuclear Plant
+  * Offshore Platform
+  * Oracle
+  * Palace
+  * Police Station
+  * Port Facility
+  * Power Plant
+  * Pyramids
+  * Recycling Center
+  * Research Lab
+  * SAM Battery
+  * SDI Defense
+  * Secret Police
+  * SETI Program
+  * Sewer System
+  * Shakespeare's Theater
+  * Solar Plant
+  * Space Component
+  * Space Module
+  * Space Structural
+  * Statue of Liberty
+  * Statue of Zeus
+  * Stock Exchange
+  * Sun Tzu's War Academy
+  * Super Highways
+  * Supermarket
+  * Temple
+  * Temple of Artemis
+  * The Internet
+  * Trade Company
+  * Training Facility
+  * Transportation
+  * United Nations
+  * University
+  * Verrocchio's Workshop
+  * Women's Suffrage
+
+Diplomatic States
+=================
+
+Only when referring to the in-game diplomatic state. For instance: "establishing an Alliance allows an
+increased level of cooperation", but "one should always be prepared for war".
+
+.. hlist::
+  :columns: 5
+
+  * Alliance
+  * Armistice
+  * Cease-fire
+  * Peace
+  * War
+
+Disasters
+=========
+
+.. hlist::
+  :columns: 5
+
+  * Earthquake
+  * Famine
+  * Fire
+  * Flood
+  * Global Warming
+  * Industrial Accident
+  * Nuclear Accident
+  * Nuclear Winter
+  * Plague
+
+Governments
+===========
+
+.. hlist::
+  :columns: 5
+
+  * Anarchy
+  * City-States
+  * Communism
+  * Democracy
+  * Despotism
+  * Federation
+  * Fundamentalism
+  * Monarchy
+  * Republic
+  * Tribal
+
+Resources
+=========
+
+.. hlist::
+  :columns: 7
+
+  * Buffalo
+  * Coal
+  * Fish
+  * Fruit
+  * Furs
+  * Game
+  * Gems
+  * Gold
+  * Iron
+  * Ivory
+  * Oasis
+  * Oil
+  * Peat
+  * Pheasant
+  * Resources
+  * River
+  * Silk
+  * Spice
+  * Whales
+  * Wheat
+  * Wine
+
+Specialists
+===========
+
+.. hlist::
+  :columns: 3
+
+  * Entertainer
+  * Scientist
+  * Taxman
+
+Terrains
+========
+
+.. hlist::
+  :columns: 6
+
+  * Desert
+  * Forest
+  * Glacier
+  * Grassland
+  * Hills
+  * Jungle
+  * Lake
+  * Mountains
+  * Ocean
+  * Plains
+  * Swamp
+  * Tundra
+
+Terrain Alterations
+===================
+
+.. hlist::
+  :columns: 7
+
+  * Airbase
+  * Buoy
+  * Fallout
+  * Farmland
+  * Fortress
+  * Irrigation
+  * Mine
+  * Minor Tribe Village
+  * Maglev
+  * Oil Well
+  * Pollution
+  * Railroad
+  * Road
+  * Ruins
+
+Units
+=====
+
+Use them with ``:unit:``, :unit:`Settlers`.
+
+.. hlist::
+  :columns: 4
+
+  * AEGIS Cruiser
+  * Alpine Troops
+  * Archers
+  * Armor
+  * Artillery
+  * AWACS
+  * Barbarian Leader
+  * Barge
+  * Battleship
+  * Bomber
+  * Cannon
+  * Caravan
+  * Caravel
+  * Cargo Aircraft
+  * Carrier
+  * Catapult
+  * Cavalry
+  * Chariot
+  * Cruise Missile
+  * Cruiser
+  * Crusaders
+  * Destroyer
+  * Diplomat
+  * Dragoons
+  * Elephants
+  * Engineers
+  * Explorer
+  * Fanatics
+  * Fighter
+  * Flagship Frigate
+  * Freight
+  * Frigate
+  * Fusion Armor
+  * Fusion Battleship
+  * Fusion Bomber
+  * Fusion Fighter
+  * Galleon
+  * Helicopter
+  * Horsemen
+  * Howitzer
+  * ICBM
+  * Immigrants
+  * Infantry
+  * Intercontinental Missile
+  * Ironclad
+  * Knights
+  * Legion
+  * Longboat
+  * Marines
+  * Mech. Inf.
+  * Migrants
+  * Militia
+  * Missile
+  * Musketeers
+  * Nuclear
+  * Nuclear Bomb
+  * Nuclear Submarine
+  * Operative
+  * Paratroopers
+  * Partisan
+  * Phalanx
+  * Pikemen
+  * Riflemen
+  * Scholar
+  * Scribe
+  * Settlers
+  * Spy
+  * Square-Rigged Caravel
+  * Stealth Bomber
+  * Stealth Fighter
+  * Stealth Spy
+  * Submarine
+  * Swordsmen
+  * Tank
+  * Transport
+  * Trireme
+  * Leader
+  * Tribal Workers
+  * Workers
+  * Warriors
+
+Unit Classes
+============
+
+.. hlist::
+  :columns: 6
+
+  * Air
+  * Amphibious
+  * Big Land
+  * Big Siege
+  * Helicopter
+  * Land
+  * Merchant
+  * Missile
+  * Native
+  * Sea
+  * Small Land
+  * Trireme

--- a/docs/Contributing/capitalized-terms.rst
+++ b/docs/Contributing/capitalized-terms.rst
@@ -213,6 +213,111 @@ Terrains
   * Swamp
   * Tundra
 
+Technologies
+============
+
+.. hlist::
+  :columns: 4
+
+  * Advanced Espionage
+  * Advanced Flight
+  * Agriculture
+  * Alphabet
+  * Amphibious Warfare
+  * Astronomy
+  * Atomic Theory
+  * Automobile
+  * Aviation Endurance
+  * Banking
+  * Bridge Building
+  * Bronze Working
+  * Ceremonial Burial
+  * Chemistry
+  * Chivalry
+  * Code of Laws
+  * Combined Arms
+  * Combustion
+  * Communism
+  * Computers
+  * Conscription
+  * Construction
+  * Currency
+  * Democracy
+  * Economics
+  * Electricity
+  * Electronics
+  * Engineering
+  * Environmentalism
+  * Espionage
+  * Explosives
+  * Feudalism
+  * Flight
+  * Fundamentalism
+  * Fusion Power
+  * Genetic Engineering
+  * Guerilla Warfare
+  * Gunpowder
+  * Horseback Riding
+  * Industrialization
+  * Invention
+  * Iron Working
+  * Labor Union
+  * Laser
+  * Leadership
+  * Literacy
+  * Machine Tools
+  * Maglev
+  * Magnetism
+  * Map Making
+  * Martial Law
+  * Masonry
+  * Mass Production
+  * Mathematics
+  * Medicine
+  * Metallurgy
+  * Miniaturization
+  * Mobile Warfare
+  * Monarchy
+  * Monotheism
+  * Mysticism
+  * Navigation
+  * Nuclear Fission
+  * Nuclear Power
+  * Philosophy
+  * Physics
+  * Plastics
+  * Polytheism
+  * Pottery
+  * Radio
+  * Recycling
+  * Refining
+  * Refrigeration
+  * Religion
+  * Road Building
+  * Robotics
+  * Rocketry
+  * Sanitation
+  * Seafaring
+  * Space Flight
+  * Specialist Training
+  * Stealth
+  * Steam Engine
+  * Steel
+  * Superconductors
+  * Supermodule
+  * Tactics
+  * Railroad
+  * The Corporation
+  * Theology
+  * Theory of Evolution
+  * Theory of Gravity
+  * The Republic
+  * The Wheel
+  * Trade
+  * University
+  * Warrior Code
+  * Writing
+
 Terrain Alterations
 ===================
 
@@ -337,7 +442,6 @@ Unit Classes
   * Land
   * Merchant
   * Missile
-  * Native
   * Sea
   * Small Land
   * Trireme

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -1,6 +1,7 @@
 ..
     SPDX-License-Identifier: GPL-3.0-or-later
     SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
 
 Documentation Style Guide
 *************************
@@ -149,143 +150,26 @@ The Oxford Comma
     "and", that is the Oxford comma and its usage is expected in our documentation.
 
 Capitalization
-    For consistent formatting, the following should always use "Title Case" rules:
+    For consistent formatting, the following should always use
+    `"Title Case" rules <https://www.grammarly.com/blog/capitalization-rules/>`_:
 
-    * Section Headings (e.g. the 4 documented above)
-    * Menu Entries in the client
-    * Anything inside of :literal:`:guilabel:` or :literal:`:menuselection:`
-    * The names of Units, City Improvements and Wonders in the :literal:`:unit:`, :literal:`:improvement:` and
-      :literal:`:wonder:` tags respectively
+    * Page and section headings (e.g. the 4 documented above).
+    * The names of specific game items such as units, city improvements, technologies, wonders, etc. Some of
+      them even have special text roles (:literal:`:unit:`, :literal:`:improvement:`, and :literal:`:wonder:`). :doc:`See here for a list. <capitalized-terms>`
 
-    This page provides a good overview of Title Case capitalization rules for US English:
-    https://www.grammarly.com/blog/capitalization-rules/
+      This is particularly useful with words that are used ambiguously in the game, such as "granary" which is
+      both the amount of food a city needs before growing and an improvement in many rulesets or "transport".
 
-    Below is a more exhaustive list of game specific terms that we want to capitalize. The list can be used
-    in a find/replace exercise:
+    When describing elements of the user interface, use the same capitalization as in the game and wrap the
+    text inside markup elements with the :literal:`:guilabel:` or :literal:`:menuselection:` roles. They are
+    rendered as follows: "the :guilabel:`Turn Done` button", "select :menuselection:`Help --> Overview` in
+    the menu".
 
-    :strong:`Game Interface`:
+    .. Get rid of the "WARNING: document isn't included in any toctree"
+    .. toctree::
+      :hidden:
 
-    .. hlist::
-
-      * Airbase
-      * Base
-      * Border
-      * Bulbs
-      * Buoy
-      * Button (a named button)
-      * Chat
-      * City / Cities
-      * Dialog (a named dialog)
-      * Embassy / Embassies
-      * Fort and Fortress
-      * Improvement
-      * Map
-      * Menu (a named menu)
-      * Messages (widget)
-      * Minimap (widget)
-      * Small Great Wonder (only with Wonders)
-      * Tax Rate
-      * Technology Advance
-      * Top Controls Bar
-      * Unit
-      * View (a named view)
-      * Vision Radius Shared (only for City Radius, Shared Vision)
-      * Widget (a named widget)
-      * World
-
-    :strong:`City Dialog Items`:
-
-    .. hlist::
-
-      * Citizen
-      * Angry
-      * Celebrate
-      * Content
-      * Happy
-      * Unhappy
-      * Civil War
-      * Civilization
-      * Corruption
-      * Culture
-      * Gold
-      * Granary
-      * Food
-      * Luxury Goods (always plural)
-      * Nation
-      * Nationality
-      * Plague
-      * Pollution
-      * Production (only when discussing Production points)
-      * Science
-      * Trade Route
-      * Waste
-
-    :strong:`Gameplay`:
-
-    .. hlist::
-
-      * Migration
-      * Entertainer
-      * Taxman
-      * Scientist
-      * Specialist
-      * Global Warming
-      * National Budget
-      * Nuclear Winter
-
-    :strong:`Map`:
-
-    .. hlist::
-
-      * Buffalo
-      * Coal
-      * Desert
-      * Fish
-      * Forest
-      * Grassland
-      * Hills
-      * Jungle
-      * Lake
-      * Mountain
-      * Oasis
-      * Ocean
-      * Pheasant
-      * Plains
-      * River
-      * Shield
-      * Silk
-      * Special (as in Tile Special)
-      * Tile
-      * Tundra
-      * Whale
-      * Wheat
-      * Wine
-
-    :strong:`Diplomacy`:
-
-    .. hlist::
-
-      * Alliance
-      * Armistice
-      * Cease-fire
-      * Diplomacy
-      * Peace
-      * War
-
-    :strong:`Governments`:
-
-    .. hlist::
-
-      * Anarchy
-      * Democracy
-      * City-States
-      * Communism
-      * Despotism
-      * Federation
-      * Fundamentalism
-      * Monarchy
-      * Republic
-      * Tribal
+      capitalized-terms
 
 Language Contractions
     Language Contractions are when two words are combined together with an apostrophe ( ``'`` ). For example,

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -158,7 +158,7 @@ Capitalization
       them even have special text roles (:literal:`:unit:`, :literal:`:improvement:`, and :literal:`:wonder:`). :doc:`See here for a list. <capitalized-terms>`
 
       This is particularly useful with words that are used ambiguously in the game, such as "granary" which is
-      both the amount of food a city needs before growing and an improvement in many rulesets or "transport".
+      both the amount of food a city needs before growing and an improvement in many rulesets, or "transport".
 
     When describing elements of the user interface, use the same capitalization as in the game and wrap the
     text inside markup elements with the :literal:`:guilabel:` or :literal:`:menuselection:` roles. They are

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -155,7 +155,8 @@ Capitalization
 
     * Page and section headings (e.g. the 4 documented above).
     * The names of specific game items such as units, city improvements, technologies, wonders, etc. Some of
-      them even have special text roles (:literal:`:unit:`, :literal:`:improvement:`, and :literal:`:wonder:`). :doc:`See here for a list. <capitalized-terms>`
+      them even have special text roles (:literal:`:unit:`, :literal:`:improvement:`, and :literal:`:wonder:`).
+      :doc:`See here for a list. <capitalized-terms>`
 
       This is particularly useful with words that are used ambiguously in the game, such as "granary" which is
       both the amount of food a city needs before growing and an improvement in many rulesets, or "transport".


### PR DESCRIPTION
As we discussed on Discord, capitalizing generic terms such as `tile` and `city` looks terrible in some cases:

> For the display of national Borders (similar to those used in Sid Meier’s Alpha Centauri) each Map Tile also has an owner field, to identify which nation lays claim to it. If game.borders is non-zero, each City claims a circle of Tiles game.borders in Vision Radius. In the case of neighbouring enemy Cities, Tiles are divided equally, with the older City winning any ties. Cities claim all immediately adjacent Tiles, plus any other Tiles within the Border radius on the same continent. Land Cities also claim Ocean Tiles if they are surrounded by 5 land Tiles on the same continent. This is a crude detection of inland seas or Lakes, which should be improved upon.

I propose to ditch capitalization for generic terms and only use it for specific in-game items (as is already the case in the auto-generated help).