### PR TITLE
Handle non-interactive stdin better

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -663,6 +663,8 @@ void server::input_on_stdin()
   } else {
     QFile f;
     f.open(stdin, QIODevice::ReadOnly);
+    // Force it to try and read something
+    f.peek(1);
     // Read from the input
     if (f.atEnd() && m_stdin_notifier != nullptr) {
       // QSocketNotifier gets mad after EOF. Turn it off.


### PR DESCRIPTION
At least on Linux, one needs to force QFile to read from stdin for it to notice
that it can read a line or that EOF was reached.

This is a redo of c8427ec2dc6cfcd2383af85f0648630fe894dcbd after it was undone in 38eac2f98d4a8e5975a4060c654d3003398214b5.
Closes #1342.