### PR TITLE
Help: Add expand/collapse code when clicking on headers

### DIFF
--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -320,6 +320,7 @@ void help_dialog::set_topic(const help_item *topic)
   for (; i != topics_map.cend(); ++i) {
     if (i.value() == topic) {
       tree_wdg->setCurrentItem(i.key());
+      tree_wdg->expandItem(i.key());
       break;
     }
   }
@@ -331,14 +332,20 @@ void help_dialog::set_topic(const help_item *topic)
 void help_dialog::history_forward()
 {
   QTreeWidgetItem *i;
+  QTreeWidgetItem *j;
 
   update_history = false;
   if (history_pos < item_history.count()) {
     history_pos++;
   }
+  j = item_history.value(history_pos - 1);
+  if (j != nullptr) {
+    tree_wdg->collapseItem(j);
+  }
   i = item_history.value(history_pos);
   if (i != nullptr) {
     tree_wdg->setCurrentItem(i);
+    tree_wdg->expandItem(i);
   }
 }
 
@@ -348,14 +355,20 @@ void help_dialog::history_forward()
 void help_dialog::history_back()
 {
   QTreeWidgetItem *i;
+  QTreeWidgetItem *j;
 
   update_history = false;
   if (history_pos > 0) {
     history_pos--;
   }
+  j = item_history.value(history_pos + 1);
+  if (j != nullptr) {
+    tree_wdg->collapseItem(j);
+  }
   i = item_history.value(history_pos);
   if (i != nullptr) {
     tree_wdg->setCurrentItem(i);
+    tree_wdg->expandItem(i);
   }
 }
 
@@ -394,6 +407,16 @@ void help_dialog::item_changed(QTreeWidgetItem *item, QTreeWidgetItem *prev)
     update_history = true;
   }
   update_buttons();
+
+  if (!item->parent()) {
+    tree_wdg->collapseAll();
+  }
+  if (prev && prev->isExpanded()) {
+    tree_wdg->collapseItem(prev);
+  }
+  if (!item->isExpanded() && item->childCount() != 0) {
+    tree_wdg->expandItem(item);
+  }
 }
 
 /**


### PR DESCRIPTION
Use Cases:
* Open Help -> Topic (such as Units), help opens to Units and Units expands
* Click on a top level item and notice that all nodes collapse
* Click on Terrain, notice terrain will expand. Now click on Terrain -> Resources to see it expand
* After clicking around you will be able to use the arrow buttons on the lower left and entries will expand and collapse as needed

Some quirks:
* If you click on a top level item to expand it and then click a node (e.g. Units -> Phalanx), you will get a collapse and expand motion which is kind of funky
* You will notice that the blue highlight showing the currently selected item moves off of the actual selected item in certain cases, but eveltually will come back. To reproduce: Click Overview to collapse all, click Terrain, Click Deep Ocean. You will see the blue bar over Economy instead of on Deep Ocean. If you click on Desert, it reverts to proper.