### PR TITLE
Port 1945cd8f3ccea261dc8c6ff769e42543aca32a31

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -1465,7 +1465,10 @@ void request_units_return()
   for (const auto unit : get_units_in_focus()) {
     // Find a path to the closest city
     auto finder = freeciv::path_finder(unit);
-    finder.set_unknown_tiles_allowed(gui_options.goto_into_unknown);
+    if (!gui_options.goto_into_unknown) {
+      finder.set_constraint(
+          std::make_unique<freeciv::tile_known_constraint>(client_player()));
+    }
     if (auto path = finder.find_path(
             freeciv::allied_city_destination(unit->owner))) {
       auto steps = path->steps();

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -253,7 +253,10 @@ void enter_goto_state(const std::vector<unit *> &units)
     // This calls path_finder::path_finder(punit) behind the scenes
     // Need to do this because path_finder isn't copy-assignable
     auto [it, _] = goto_finders.emplace(punit->id, punit);
-    it->second.set_unknown_tiles_allowed(gui_options.goto_into_unknown);
+    if (!gui_options.goto_into_unknown) {
+      it->second.set_constraint(
+          std::make_unique<freeciv::tile_known_constraint>(client_player()));
+    }
   }
 }
 

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -276,7 +276,7 @@ void path_finder::path_finder_private::attempt_move(detail::vertex &source)
   {
     bool can_move;
     int move_cost;
-    if (target->terrain == nullptr) {
+    if (tile_get_known(target, unit_owner(&probe)) == TILE_UNKNOWN) {
       // Try to move into the unknown
       can_move = true;
       move_cost = probe.utype->unknown_move_cost;

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -151,6 +151,11 @@ void path_finder::path_finder_private::insert_initial_vertex()
 void path_finder::path_finder_private::maybe_insert_vertex(
     const detail::vertex &v)
 {
+  // Handle any constraint.
+  if (constraint && !constraint->is_allowed(v)) {
+    return;
+  }
+
   // Make a copy because it may change before insertion
   auto insert = v;
 
@@ -645,6 +650,19 @@ path_finder::path_finder(const unit *unit, const path::step &init)
 path_finder::~path_finder()
 {
   // Make sure that the destructor of path_finder_private is known.
+}
+
+/**
+ * Sets a constraint to limit the number of steps considered when trying to
+ * find a path. A path_finder can only have one constraint at a time.
+ *
+ * Takes ownership of the constraint.
+ */
+void path_finder::set_constraint(
+    std::unique_ptr<step_constraint> &&constraint)
+{
+  m_d->constraint = std::move(constraint);
+  m_d->reset();
 }
 
 /**

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -552,10 +552,13 @@ void path_finder::path_finder_private::attempt_action_move(
  * destination tile is reached). Checks if the tile has already been reached
  * before proceeding.
  *
+ * If full is true, the algorithm is only stopped once all possibilities have
+ * been found.
+ *
  * \returns true if a path was found.
  */
 bool path_finder::path_finder_private::run_search(
-    const destination &destination)
+    const destination &destination, bool full)
 {
   // Check if we've already found a path (but keep searching if the tip of
   // the queue is cheaper: we haven't checked every possibility).
@@ -573,7 +576,7 @@ bool path_finder::path_finder_private::run_search(
     // Check if we just arrived
     // Keep the node in the queue so adjacent nodes are generated if the
     // search needs to be expanded later.
-    if (is_reached(destination, v)) {
+    if (!full && is_reached(destination, v)) {
       return true;
     }
 
@@ -714,6 +717,46 @@ void path_finder::unit_changed(const ::unit &unit)
     m_d->queue.pop();
   }
   m_d->insert_initial_vertex();
+}
+
+/**
+ * Runs the path finding algorithm, searching for all paths leading to the
+ * destination.
+ * Make sure to set a harsh step constraint before calling this function, or
+ * it will become very slow very quickly.
+ *
+ * \warning Potentially very expensive.
+ */
+std::vector<path> path_finder::find_all(const destination &destination)
+{
+  // Unit frozen by scenario
+  if (m_d->unit.stay) {
+    return {};
+  }
+
+  m_d->run_search(destination, true);
+
+  // Collect results.
+  auto ret = std::vector<path>();
+  ret.reserve(m_d->best_vertices.size());
+
+  for (const auto &[_, end] : m_d->best_vertices) {
+    // Only use vertices at the destination
+    if (!m_d->is_reached(destination, *end)) {
+      continue;
+    }
+
+    // Build a path
+    auto steps = std::vector<path::step>();
+    for (auto vertex = end.get(); vertex->parent != nullptr;
+         vertex = vertex->parent) {
+      steps.push_back(*vertex);
+    }
+
+    ret.emplace_back(std::vector<path::step>(steps.rbegin(), steps.rend()));
+  }
+
+  return ret;
 }
 
 /**

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -277,8 +277,8 @@ void path_finder::path_finder_private::attempt_move(detail::vertex &source)
     bool can_move;
     int move_cost;
     if (target->terrain == nullptr) {
-      // Maybe move into the unknown
-      can_move = unknown_tiles_allowed;
+      // Try to move into the unknown
+      can_move = true;
       move_cost = probe.utype->unknown_move_cost;
     } else {
       can_move =
@@ -666,18 +666,6 @@ void path_finder::set_constraint(
 }
 
 /**
- * Selects whether paths can use unknown tiles.
- */
-void path_finder::set_unknown_tiles_allowed(bool allowed)
-{
-  bool changed = (allowed != m_d->unknown_tiles_allowed);
-  m_d->unknown_tiles_allowed = allowed;
-  if (changed) {
-    m_d->reset();
-  }
-}
-
-/**
  * Adds a waypoint to the path finding. Waypoints are tiles that the path
  * must go through (in order) before reaching the destination.
  *
@@ -844,6 +832,14 @@ bool refuel_destination::reached(const detail::vertex &vertex) const
   vertex.fill_probe(probe);
 
   return can_unit_survive_at_tile(&(wld.map), &probe, vertex.location);
+}
+
+/**
+ * \copydoc step_constraint::is_allowed
+ */
+bool tile_known_constraint::is_allowed(const path::step &step) const
+{
+  return tile_get_known(step.location, m_player) != TILE_UNKNOWN;
 }
 
 } // namespace freeciv

--- a/common/path_finder.h
+++ b/common/path_finder.h
@@ -73,7 +73,6 @@ private:
         initial_vertex; ///< The starting point in the search graph.
 
     std::unique_ptr<step_constraint> constraint = nullptr;
-    bool unknown_tiles_allowed = false;
 
     // Storage for Dijkstra's algorithm.
     // In most cases, a single vertex will be stored for a given tile. There
@@ -115,14 +114,7 @@ public:
 
   inline path_finder &operator=(path_finder &&other);
 
-  /// Returns whether goto into the unkown is allowed.
-  bool are_unknown_tiles_allowed() const
-  {
-    return m_d->unknown_tiles_allowed;
-  }
-
   void set_constraint(std::unique_ptr<step_constraint> &&constraint);
-  void set_unknown_tiles_allowed(bool allowed);
 
   void push_waypoint(const tile *location);
   bool pop_waypoint();
@@ -271,6 +263,24 @@ public:
    * any turn change calculation is performed.
    */
   virtual bool is_allowed(const path::step &step) const = 0;
+};
+
+/**
+ * \brief A constraint that restricts the search to tiles known by the
+ * player.
+ */
+class tile_known_constraint : public step_constraint {
+public:
+  /// Constructor.
+  explicit tile_known_constraint(const player *player) : m_player(player) {}
+
+  /// Destructor.
+  ~tile_known_constraint() = default;
+
+  bool is_allowed(const path::step &step) const override;
+
+private:
+  const player *m_player;
 };
 
 } // namespace freeciv

--- a/common/path_finder.h
+++ b/common/path_finder.h
@@ -45,6 +45,7 @@ struct vertex : public path::step {
 } // namespace detail
 
 class destination;
+class step_constraint;
 
 /**
  * A path is a succession of moves and actions to go from one location to
@@ -71,6 +72,7 @@ private:
     const detail::vertex
         initial_vertex; ///< The starting point in the search graph.
 
+    std::unique_ptr<step_constraint> constraint = nullptr;
     bool unknown_tiles_allowed = false;
 
     // Storage for Dijkstra's algorithm.
@@ -119,6 +121,7 @@ public:
     return m_d->unknown_tiles_allowed;
   }
 
+  void set_constraint(std::unique_ptr<step_constraint> &&constraint);
   void set_unknown_tiles_allowed(bool allowed);
 
   void push_waypoint(const tile *location);
@@ -247,6 +250,27 @@ protected:
 
 private:
   unit m_unit;
+};
+
+/**
+ * \brief Allows one to limit the scope a path finding search.
+ *
+ * This class allows to limit the scope of the search by forbidding some
+ * steps. Subclass from this class and implement \ref is_allowed to create a
+ * constraint with your own critieria.
+ *
+ * \sa path_finder::set_constraint
+ */
+class step_constraint {
+public:
+  /// Destructor.
+  virtual ~step_constraint() = default;
+
+  /**
+   * Whether a step should be used in the search. Steps are checked before
+   * any turn change calculation is performed.
+   */
+  virtual bool is_allowed(const path::step &step) const = 0;
 };
 
 } // namespace freeciv

--- a/common/path_finder.h
+++ b/common/path_finder.h
@@ -103,7 +103,7 @@ private:
     void attempt_paradrop(detail::vertex &source);
     void attempt_action_move(detail::vertex &source);
 
-    bool run_search(const destination &destination);
+    bool run_search(const destination &destination, bool full = false);
     void reset();
   };
 
@@ -121,6 +121,7 @@ public:
 
   void unit_changed(const unit &unit);
 
+  std::vector<path> find_all(const destination &destination);
   std::optional<path> find_path(const destination &destination);
 
 private:

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -1384,10 +1384,12 @@ void bounce_unit(struct unit *punit, bool verbose, bounce_reason reason,
       notify_player(pplayer, punit_tile, E_UNIT_LOST_MISC, ftc_server,
                     // TRANS: A unit is disbanded to resolve stack conflicts.
                     _("Disbanded your %s."), unit_tile_link(punit));
+      break;
     case bounce_reason::terrain_change:
       notify_player(pplayer, punit_tile, E_UNIT_LOST_MISC, ftc_server,
                     _("Disbanded your %s due to changing terrain."),
                     unit_tile_link(punit));
+      break;
     }
   }
   wipe_unit(punit, ULR_STACK_CONFLICT, nullptr);

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -4744,7 +4744,17 @@ void unit_did_action(struct unit *punit)
     return;
   }
 
-  punit->action_timestamp = time(nullptr);
+  const auto now = time(nullptr);
+
+  // Units can do UWT-protected actions while under UWT when forced by the game
+  // to do so, for instance when an alliance is broken and the unit gets bounced
+  // off a city or transport. In this case, the original UWT stays in effect.
+  if (punit->action_turn == game.info.turn - 1 &&
+      now < punit->action_timestamp + game.server.unitwaittime) {
+    return;
+  }
+
+  punit->action_timestamp = now;
   punit->action_turn = game.info.turn;
 }
 

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -1215,9 +1215,11 @@ bool teleport_unit_to_city(struct unit *punit, struct city *pcity,
  * find a random safe tile within a given distance of the unit's current tile
  * and move the unit there. If no tiles are found, the unit is disbanded. If
  * 'verbose' is true, a message is sent to the unit owner regarding what
- * happened. The maximum distance it 2 by default for backward compatibility.
+ * happened (the exact message depends on 'reason'). The maximum distance it
+ * 2 by default for backward compatibility.
  */
-void bounce_unit(struct unit *punit, bool verbose, int max_distance)
+void bounce_unit(struct unit *punit, bool verbose, bounce_reason reason,
+                 int max_distance)
 {
   struct player *pplayer;
   struct tile *punit_tile;
@@ -1268,9 +1270,18 @@ void bounce_unit(struct unit *punit, bool verbose, int max_distance)
     struct tile *ptile = tiles[fc_rand(tiles.size())];
 
     if (verbose) {
-      notify_player(pplayer, ptile, E_UNIT_RELOCATED, ftc_server,
-                    // TRANS: A unit is moved to resolve stack conflicts.
-                    _("Moved your %s."), unit_link(punit));
+      switch (reason) {
+      case bounce_reason::generic:
+        notify_player(pplayer, ptile, E_UNIT_RELOCATED, ftc_server,
+                      // TRANS: A unit is moved to resolve stack conflicts.
+                      _("Moved your %s."), unit_link(punit));
+        break;
+      case bounce_reason::terrain_change:
+        notify_player(pplayer, ptile, E_UNIT_RELOCATED, ftc_server,
+                      _("Moved your %s due to changing terrain."),
+                      unit_link(punit));
+        break;
+      }
     }
     /* TODO: should a unit be able to bounce to a transport like is done
      * below? What if the unit can't legally enter the transport, say
@@ -1290,9 +1301,16 @@ void bounce_unit(struct unit *punit, bool verbose, int max_distance)
   }
 
   if (verbose) {
-    notify_player(pplayer, punit_tile, E_UNIT_LOST_MISC, ftc_server,
-                  // TRANS: A unit is disbanded to resolve stack conflicts.
-                  _("Disbanded your %s."), unit_tile_link(punit));
+    switch (reason) {
+    case bounce_reason::generic:
+      notify_player(pplayer, punit_tile, E_UNIT_LOST_MISC, ftc_server,
+                    // TRANS: A unit is disbanded to resolve stack conflicts.
+                    _("Disbanded your %s."), unit_tile_link(punit));
+    case bounce_reason::terrain_change:
+      notify_player(pplayer, punit_tile, E_UNIT_LOST_MISC, ftc_server,
+                    _("Disbanded your %s due to changing terrain."),
+                    unit_tile_link(punit));
+    }
   }
   wipe_unit(punit, ULR_STACK_CONFLICT, nullptr);
 }

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -19,7 +19,9 @@
 // utility
 #include "bitvector.h"
 #include "fcintl.h"
+#include "hand_gen.h"
 #include "log.h"
+#include "path_finder.h"
 #include "rand.h"
 #include "shared.h"
 #include "support.h"
@@ -1210,6 +1212,85 @@ bool teleport_unit_to_city(struct unit *punit, struct city *pcity,
   return false;
 }
 
+namespace /* anonymous */ {
+
+/**
+ * The destination of bouncing paths. If @c SAFE is @c true, any tile where
+ * the unit can survive is accepted. Otherwise, any tile is accepted as a
+ * destination.
+ *
+ * The bouncing algorithm first tries to find a safe destination. If it
+ * can't, it falls back to unsafe tiles.
+ */
+template <bool SAFE> class bounce_destination : public freeciv::destination {
+public:
+  /// Constructor.
+  explicit bounce_destination(const unit *unit) : m_unit(unit) {}
+
+  /// Destructor.
+  ~bounce_destination() {}
+
+protected:
+  bool reached(const freeciv::detail::vertex &vertex) const override;
+
+private:
+  const unit *m_unit;
+};
+
+/**
+ * \copydoc freeciv::destination::reached
+ */
+template <bool SAFE>
+bool bounce_destination<SAFE>::reached(
+    const freeciv::detail::vertex &vertex) const
+{
+  if constexpr (SAFE) {
+    return vertex.location != m_unit->tile
+           && can_unit_survive_at_tile(&(wld.map), m_unit, vertex.location);
+  } else {
+    return vertex.location != m_unit->tile
+           && can_unit_exist_at_tile(&(wld.map), m_unit, vertex.location);
+  }
+}
+
+/**
+ * Paths used to bounce units must last less than one turn and be certain
+ * (use known tiles only). Some orders are disallowed (ORDER_FULL_MP and
+ * ORDER_ACTION_MOVE). This class implements the constraint.
+ */
+class bounce_path_constraint : public freeciv::step_constraint {
+public:
+  /// Constructor
+  explicit bounce_path_constraint(const player *player,
+                                  const tile *start_from, int max_distance)
+      : m_player(player), m_distance(max_distance)
+  {
+  }
+
+  /// Destructor
+  virtual ~bounce_path_constraint() = default;
+
+  bool is_allowed(const freeciv::path::step &step) const override;
+
+private:
+  const player *m_player;
+  const tile *m_start;
+  const int m_distance;
+};
+
+/**
+ * \copydoc freeciv::step_constraint::is_allowed
+ */
+bool bounce_path_constraint::is_allowed(
+    const freeciv::path::step &step) const
+{
+  return step.order.order != ORDER_FULL_MP
+         && step.order.order != ORDER_ACTION_MOVE && step.turns < 1
+         && map_distance(m_start, step.location) <= m_distance
+         && tile_get_known(step.location, m_player) != TILE_UNKNOWN;
+}
+} // anonymous namespace
+
 /**
  * Move or remove a unit due to stack conflicts. This function will try to
  * find a random safe tile within a given distance of the unit's current tile
@@ -1221,81 +1302,78 @@ bool teleport_unit_to_city(struct unit *punit, struct city *pcity,
 void bounce_unit(struct unit *punit, bool verbose, bounce_reason reason,
                  int max_distance)
 {
-  struct player *pplayer;
-  struct tile *punit_tile;
-  struct unit_list *pcargo_units;
-
   if (!punit) {
     return;
   }
 
-  pplayer = unit_owner(punit);
-  punit_tile = unit_tile(punit);
+  const auto pplayer = unit_owner(punit);
+  const auto punit_tile = unit_tile(punit);
 
-  auto tiles = std::vector<tile *>();
+  auto finder = freeciv::path_finder(punit);
+  finder.set_constraint(std::make_unique<bounce_path_constraint>(
+      pplayer, punit_tile, max_distance));
 
-  square_iterate(&(wld.map), punit_tile, max_distance, ptile)
-  {
-    if (ptile == punit_tile) {
-      continue;
-    }
-
-    if (can_unit_survive_at_tile(&(wld.map), punit, ptile)
-        && !is_non_allied_city_tile(ptile, pplayer)
-        && !is_non_allied_unit_tile(ptile, pplayer)) {
-      tiles.push_back(ptile);
-    }
-  }
-  square_iterate_end;
-
-  if (tiles.empty()) {
-    /* If no place unit can survive try the same with tiles the unit can just
-     * exist inspite of losing health or fuel*/
-    square_iterate(&(wld.map), punit_tile, max_distance, ptile)
-    {
-      if (ptile == punit_tile) {
-        continue;
-      }
-
-      if (can_unit_exist_at_tile(&(wld.map), punit, ptile)
-          && !is_non_allied_city_tile(ptile, pplayer)
-          && !is_non_allied_unit_tile(ptile, pplayer)) {
-        tiles.push_back(ptile);
-      }
-    }
-    square_iterate_end;
+  // Collect possible reactions for the unit. Bouncing units are pushed out
+  // and need to act on their own, so they pick something at random.
+  auto paths = finder.find_all(bounce_destination<true>(punit));
+  if (paths.empty()) {
+    paths = finder.find_all(bounce_destination<false>(punit));
   }
 
-  if (!tiles.empty()) {
-    struct tile *ptile = tiles[fc_rand(tiles.size())];
+  qDebug() << "Bouncing: found" << paths.size() << "possible paths";
+
+  if (!paths.empty()) {
+    const auto path = paths[fc_rand(paths.size())];
+    const auto steps = path.steps();
+    const auto end_tile = path.steps().back().location;
 
     if (verbose) {
       switch (reason) {
       case bounce_reason::generic:
-        notify_player(pplayer, ptile, E_UNIT_RELOCATED, ftc_server,
+        notify_player(pplayer, end_tile, E_UNIT_RELOCATED, ftc_server,
                       // TRANS: A unit is moved to resolve stack conflicts.
                       _("Moved your %s."), unit_link(punit));
         break;
       case bounce_reason::terrain_change:
-        notify_player(pplayer, ptile, E_UNIT_RELOCATED, ftc_server,
+        notify_player(pplayer, end_tile, E_UNIT_RELOCATED, ftc_server,
                       _("Moved your %s due to changing terrain."),
                       unit_link(punit));
         break;
       }
     }
-    /* TODO: should a unit be able to bounce to a transport like is done
-     * below? What if the unit can't legally enter the transport, say
-     * because the transport is Unreachable and the unit doesn't have it in
-     * its embarks field or because "Transport Embark" isn't enabled? Kept
-     * like it was to preserve the old rules for now. -- Sveinung */
-    unit_move(punit, ptile, 0, nullptr, true, false);
-    return;
+
+    // Execute the orders making up the path. See control.cpp in the client
+    // (FIXME: write a nice function)
+    if (steps.size() < MAX_LEN_ROUTE) {
+      auto packet = packet_unit_orders{};
+      packet.unit_id = punit->id;
+      packet.dest_tile = steps.back().location->index;
+      packet.src_tile = punit->tile->index;
+      packet.repeat = false;
+      packet.vigilant = false;
+
+      packet.length = steps.size();
+
+      for (std::size_t i = 0; i < steps.size(); ++i) {
+        packet.orders[i] = steps[i].order;
+      }
+
+      unit_server_side_agent_set(pplayer, punit, SSA_NONE);
+      handle_unit_orders(pplayer, &packet);
+
+      // Make sure we do something sensible even if the unit fails to move
+      // (below). In principle it should be fine...
+      if (punit->tile != punit_tile) {
+        return;
+      }
+    }
+    fc_assert(punit->tile != punit_tile);
   }
 
   /* Didn't find a place to bounce the unit, going to disband it.
    * Try to bounce transported units. */
   if (0 < get_transporter_occupancy(punit)) {
-    pcargo_units = unit_transport_cargo(punit);
+    const auto pcargo_units = unit_transport_cargo(punit);
     unit_list_iterate(pcargo_units, pcargo) { bounce_unit(pcargo, verbose); }
     unit_list_iterate_end;
   }

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -104,7 +104,7 @@ int get_unit_vision_at(struct unit *punit, const struct tile *ptile,
                        enum vision_layer vlayer);
 void unit_refresh_vision(struct unit *punit);
 void unit_list_refresh_vision(struct unit_list *punitlist);
-void bounce_unit(struct unit *punit, bool verbose);
+void bounce_unit(struct unit *punit, bool verbose, int max_distance = 2);
 bool unit_activity_needs_target_from_client(enum unit_activity activity);
 void unit_assign_specific_activity_target(struct unit *punit,
                                           enum unit_activity *activity,

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -104,7 +104,15 @@ int get_unit_vision_at(struct unit *punit, const struct tile *ptile,
                        enum vision_layer vlayer);
 void unit_refresh_vision(struct unit *punit);
 void unit_list_refresh_vision(struct unit_list *punitlist);
-void bounce_unit(struct unit *punit, bool verbose, int max_distance = 2);
+
+/// Why do we need to bounce a unit?
+enum class bounce_reason {
+  generic,        ///< We just need to do it
+  terrain_change, ///< We need to do it because of changing terrain
+};
+void bounce_unit(struct unit *punit, bool verbose,
+                 bounce_reason reason = bounce_reason::generic,
+                 int max_distance = 2);
 bool unit_activity_needs_target_from_client(enum unit_activity activity);
 void unit_assign_specific_activity_target(struct unit *punit,
                                           enum unit_activity *activity,


### PR DESCRIPTION
This has grown quite big...

The original commit https://github.com/longturn/freeciv/commit/1945cd8f3c solved two issues:

* UWT could be bypassed by forced moves on the server side (e.g. terraforming).
* Bounced units when breaking an alliance allowed disembarking without losing MP (related to a now-removed `slow_invasions` server setting)

I think the first issue is better fixed elsewhere, so I have a very simple commit for that.

The second issue looks totally different in Fc21 because unit moves are now controlled by action enablers. After a few failed attempts, I chose to run the fully-fledged path finding algorithm to legal paths for the unit and pick one at random.

### Testing

Here are a few cases where unit "bouncing" happens:
* Upon breaking alliance, units in transports and cities get bounced out
* When civil war is triggered, allied units are kicked out of the civil war nation
* When bribing or exchanging a city supporting a gameloss unit, the King flees away
* When capturing or bribing a unit in a stack, the bribed unit may need to leave the stack
* Terrain changes (terraforming, GW)

### See also

Part of #1153
#1360 is a bug in the path finding code indirectly affecting this