### PR TITLE
Fix MSYS2 CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,6 +108,10 @@ jobs:
             mingw-w64-x86_64-karchive-qt5
       - name: Configure
         run: |
+          export PATH=/mingw64/bin:${PATH}
+          export MSYSTEM=MINGW64
+          export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+          export VCPKG_ROOT=
           cmake . -B build -G Ninja \
            -DCMAKE_INSTALL_PREFIX=$PWD/build/install \
            -DCMAKE_BUILD_TYPE=Release

--- a/docs/Contributing/msys2.rst
+++ b/docs/Contributing/msys2.rst
@@ -81,6 +81,15 @@ This chapter is about creating a new MSYS2 build environment.
 
     * mingw-w64-i686-nsis / mingw-w64-x86_64-nsis
 
+#. Add some environment variables to the ``.bash_profile`` file. The code sample assumes x86_64.
+
+.. code-block:: sh
+
+  export PATH=/mingw64/bin:${PATH}
+  export MSYSTEM=MINGW64
+  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+  export VCPKG_ROOT=
+
 
 Premade Environment
 ===================


### PR DESCRIPTION
Explicitly adds some environment variables that we set in `release.yaml` to `build.yaml` to ensure that MSYS2 knows some extra path information as well as that we do not want to use `vcpkg`.