### PR TITLE
Fix CI regression

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,6 @@ jobs:
           export PATH=/mingw64/bin:${PATH}
           export MSYSTEM=MINGW64
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-          export VCPKG_ROOT=
           cmake . -B build -G Ninja \
            -DCMAKE_INSTALL_PREFIX=$PWD/build/install \
            -DCMAKE_BUILD_TYPE=Release
@@ -158,7 +157,7 @@ jobs:
       - name: Configure
         run: cmake -S . -B build -G "Visual Studio 17 2022" \
          -DCMAKE_BUILD_TYPE=Debug -DVCPKG_BUILD_TYPE=debug \
-         -DVCPKG_TARGET_ARCHITECTURE=x64 \
+         -DVCPKG_TARGET_ARCHITECTURE=x64 -DFREECIV_USE_VCPKG=ON \
          -DCMAKE_TOOLCHAIN_FILE="${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake" -A x64 -T ClangCL
       - name: Building
         run: cmake --build build --config Debug

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,6 @@ jobs:
           export PATH=/mingw32/bin:${PATH}
           export MSYSTEM=MINGW32
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw32/lib/pkgconfig:/mingw32/share/pkgconfig
-          export VCPKG_ROOT=
           cmake . -B build -G Ninja \
            -DCMAKE_INSTALL_PREFIX=$PWD/build/install \
            -DCMAKE_BUILD_TYPE=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ else()
 endif()
 
 # Set vcpkg if exists. Used by MacOS and Visual Studio
-if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  message(STATUS "Microsoft VCPKG detected, setting toolset specific settings.")
+if(DEFINED ENV{VCPKG_ROOT} AND FREECIV_USE_VCPKG)
+  message(STATUS "Microsoft VCPKG enabled, setting toolset specific settings.")
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       CACHE STRING "")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,10 @@
       "name": "fullrelease-macos",
       "displayName": "Build for Mac in Release Mode",
       "inherits": "fullrelease",
-      "installDir": ".install"
+      "installDir": ".install",
+      "cacheVariables": {
+        "FREECIV_USE_VCPKG": "ON"
+      }
     },
     {
       "name": "debug",
@@ -82,7 +85,8 @@
         "FREECIV_ENABLE_TOOLS": "ON",
         "FREECIV_ENABLE_SERVER": "ON",
         "FREECIV_ENABLE_CLIENT": "ON",
-        "FREECIV_ENABLE_NLS": "ON"
+        "FREECIV_ENABLE_NLS": "ON",
+        "FREECIV_USE_VCPKG": "ON"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -108,7 +112,8 @@
         "FREECIV_ENABLE_TOOLS": "ON",
         "FREECIV_ENABLE_SERVER": "ON",
         "FREECIV_ENABLE_CLIENT": "ON",
-        "FREECIV_ENABLE_NLS": "ON"
+        "FREECIV_ENABLE_NLS": "ON",
+        "FREECIV_USE_VCPKG": "ON"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/cmake/FreecivBuildOptions.cmake
+++ b/cmake/FreecivBuildOptions.cmake
@@ -47,3 +47,6 @@ if (FREECIV_ENABLE_SERVER
     OR FREECIV_ENABLE_RULEUP)
   set(FREECIV_BUILD_LIBSERVER TRUE)
 endif()
+
+# By default we do not enable VCPKG
+option(FREECIV_USE_VCPKG "Use VCPKG" OFF)

--- a/docs/Contributing/msys2.rst
+++ b/docs/Contributing/msys2.rst
@@ -88,7 +88,6 @@ This chapter is about creating a new MSYS2 build environment.
   export PATH=/mingw64/bin:${PATH}
   export MSYSTEM=MINGW64
   export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  export VCPKG_ROOT=
 
 
 Premade Environment


### PR DESCRIPTION
This PR moves us to asking to use VCPKG at configure time, vs trying to auto-detect it based on the existence of an environment variable.