### PR TITLE
Make clang-tidy unhappy

### DIFF
--- a/common/unit.cpp
+++ b/common/unit.cpp
@@ -1602,6 +1602,8 @@ void unit_virtual_destroy(struct unit *punit)
   unit_transport_unload(punit);
   fc_assert(!unit_transported(punit));
 
+  auto unused = unit_transported(punit); // Should trigger clang-tidy
+
   // Check for transported units. Use direct access to the list.
   if (unit_list_size(punit->transporting) != 0) {
     // Unload all units.


### PR DESCRIPTION
It seems I uploaded clang-tidy results ages ago and for that reason we don't see the new ones. Trigger a new warning to test the integration.