### PR TITLE
Fix a few path finding bugs

### DIFF
--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -49,7 +49,9 @@ vertex vertex::child_for_action(action_id action, const unit &probe,
   ret.order.action = action;
   ret.order.target = target->index;
   ret.order.dir = DIR8_ORIGIN;
-  ret.moves_left = unit_pays_mp_for_action(action_by_number(action), &probe);
+  ret.moves_left =
+      probe.moves_left
+      - unit_pays_mp_for_action(action_by_number(action), &probe);
   ret.location = target;
   return ret;
 }

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -107,7 +107,7 @@ bool vertex::operator==(const vertex &other) const
   return std::tie(location, loaded, moved, paradropped, is_final, waypoints,
                   turns, moves_left, health, fuel_left)
          == std::tie(other.location, other.loaded, other.moved,
-                     other.is_final, other.paradropped, other.waypoints,
+                     other.paradropped, other.is_final, other.waypoints,
                      other.turns, other.moves_left, other.health,
                      other.fuel_left);
 }

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -579,7 +579,7 @@ bool path_finder::path_finder_private::run_search(
     const auto [begin, end] = best_vertices.equal_range(v.location);
     const auto it = std::find_if(
         begin, end, [&v](const auto &pair) { return *pair.second == v; });
-    if (it == best_vertices.end()) {
+    if (it == end) {
       // Not found, we processed something else in the meantime. Since we
       // processed it earlier, that path was at least as short.
       continue;

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -49,10 +49,20 @@ vertex vertex::child_for_action(action_id action, const unit &probe,
   ret.order.action = action;
   ret.order.target = target->index;
   ret.order.dir = DIR8_ORIGIN;
-  ret.moves_left =
-      probe.moves_left
-      - unit_pays_mp_for_action(action_by_number(action), &probe);
+  ret.moves_left = probe.moves_left;
   ret.location = target;
+
+  const auto action_ptr = action_by_number(action);
+  if (utype_is_moved_to_tgt_by_action(action_ptr, probe.utype)) {
+    // We need a second probe because EFT_ACTION_SUCCESS_MOVE_COST is
+    // evaluated after the unit has moved
+    auto moved_probe = probe;
+    moved_probe.tile = target;
+    ret.moves_left -= unit_pays_mp_for_action(action_ptr, &moved_probe);
+  } else {
+    ret.moves_left -= unit_pays_mp_for_action(action_ptr, &probe);
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
Fix three rather stupid bugs due to rapid development of the path finding algo, including #1360.

~~**Bug:** unloading foot soldiers from a boat gives incorrect results now :(~~

Closes #1360.

### Testing

I tested unloading bombers and fighters from a carrier and dropping paratroops.
