### PR TITLE
Fix a crash when auto-upgrading unique units

### DIFF
--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -410,6 +410,16 @@ static void do_upgrade_effects(struct player *pplayer)
     const struct unit_type *type_to =
         can_upgrade_unittype(pplayer, type_from);
 
+    if (type_to == nullptr) {
+      /* This is unlikely but it can happen with unique units. If the target
+       * unit type is a unique unit and some other unit has been upgraded
+       * first, punit can no longer be upgraded and can_upgrade_unittype
+       * returns nullptr. Thus punit is no longer a good candidate and we
+       * just remove it from the list. */
+      unit_list_remove(candidates, punit);
+      continue;
+    }
+
     transform_unit(punit, type_to, true);
     notify_player(pplayer, unit_tile(punit), E_UNIT_UPGRADED, ftc_server,
                   _("%s was upgraded for free to %s."),


### PR DESCRIPTION
When Leonardo's Workshop upgrades units, it starts by collecting a list of upgradeable units and then pick upgrades at random. This doesn't work if upgrading one unit prevents another from being upgraded, which can happen with unique units. Consider for instance the following upgrade chain of unique units:

    A -> B -> C

If a player has one A and one B, and discovers the technology for C, both the A and the B units will be candidates for Leo upgrade. Once one of them is upgraded, the second can't be upgraded anymore because it would create two C units. This patch fixes the handling of this corner case in the server.

This is a straightforward port of a LT commit.
Closes #1153.