### PR TITLE
Load Linux Libertine Font

### DIFF
--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -172,11 +172,11 @@ void configure_fonts()
   }
 
   /* Sans Serif List */
-  sl << QStringLiteral("Linux Biolinum O")
-     << QStringLiteral("Liberation Sans") << QStringLiteral("Droid Sans")
-     << QStringLiteral("Ubuntu") << QStringLiteral("Noto Sans")
-     << QStringLiteral("DejaVu Sans") << QStringLiteral("Luxi Sans")
-     << QStringLiteral("Lucida Sans") << QStringLiteral("Arial");
+  sl << QStringLiteral("Linux Biolinum") << QStringLiteral("Liberation Sans")
+     << QStringLiteral("Droid Sans") << QStringLiteral("Ubuntu")
+     << QStringLiteral("Noto Sans") << QStringLiteral("DejaVu Sans")
+     << QStringLiteral("Luxi Sans") << QStringLiteral("Lucida Sans")
+     << QStringLiteral("Arial");
 
   font_name = configure_font(fonts::default_font, sl, max);
   if (!font_name.isEmpty()) {
@@ -202,7 +202,7 @@ void configure_fonts()
   sl.clear();
 
   /* Monospace List */
-  sl << QStringLiteral("Linux Libertine Mono O") << QStringLiteral("Cousine")
+  sl << QStringLiteral("Linux Libertine Mono") << QStringLiteral("Cousine")
      << QStringLiteral("Liberation Mono")
      << QStringLiteral("Source Code Pro")
      << QStringLiteral("Source Code Pro [ADBO]")
@@ -227,11 +227,10 @@ void configure_fonts()
   sl.clear();
 
   /* Serif List */
-  sl << QStringLiteral("Linux Libertine Display O")
-     << QStringLiteral("Arimo") << QStringLiteral("Play")
-     << QStringLiteral("Tinos") << QStringLiteral("Ubuntu")
-     << QStringLiteral("Times New Roman") << QStringLiteral("Droid Sans")
-     << QStringLiteral("Noto Sans");
+  sl << QStringLiteral("Linux Libertine Display") << QStringLiteral("Arimo")
+     << QStringLiteral("Play") << QStringLiteral("Tinos")
+     << QStringLiteral("Ubuntu") << QStringLiteral("Times New Roman")
+     << QStringLiteral("Droid Sans") << QStringLiteral("Noto Sans");
 
   font_name = configure_font(fonts::reqtree_text, sl, max, true);
   if (!font_name.isEmpty()) {

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -133,21 +133,17 @@ bool isFontInstalled(const QString &font_name)
 {
   QFontDatabase database;
 
-  if (database.families().contains(font_name)) {
-    return true;
-  } else {
-    return false;
-  }
+  return database.families().contains(font_name);
 }
 
 /**
-   Loads the fonts into the font database.
+ * Loads the fonts into the font database.
  */
 void load_fonts()
 {
-  QFileInfoList il;
 
-  il = find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
+  const auto il =
+      find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
   if (!il.isEmpty()) {
     for (const auto &info : qAsConst(il)) {
       QDirIterator iterator(
@@ -162,7 +158,7 @@ void load_fonts()
 }
 
 /**
-   Tries to choose good fonts for Freeciv21
+ * Tries to choose good fonts for Freeciv21
  */
 void configure_fonts()
 {

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -141,7 +141,6 @@ bool isFontInstalled(const QString &font_name)
  */
 void load_fonts()
 {
-
   const auto il =
       find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
   if (!il.isEmpty()) {

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -141,31 +141,39 @@ bool isFontInstalled(const QString &font_name)
 }
 
 /**
+   Loads the fonts into the font database.
+ */
+void load_fonts()
+{
+  QFileInfoList il;
+
+  il = find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
+  if (!il.isEmpty()) {
+    for (const auto &info : qAsConst(il)) {
+      QDirIterator iterator(
+          info.absolutePath(),
+          {QStringLiteral("*.otf"), QStringLiteral("*.ttf")}, QDir::Files,
+          QDirIterator::Subdirectories);
+      while (iterator.hasNext()) {
+        QFontDatabase::addApplicationFont(iterator.next());
+      }
+    }
+  }
+}
+
+/**
    Tries to choose good fonts for Freeciv21
  */
 void configure_fonts()
 {
   QStringList sl;
   QString font_name;
-  QFileInfoList il;
-  QFileInfo info;
 
   const int max = 16;
   const int default_size = 12;
 
   if (!isFontInstalled("Linux Libertine")) {
-    il = find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
-    if (!il.isEmpty()) {
-      for (const auto &info : qAsConst(il)) {
-        QDirIterator iterator(
-            info.absolutePath(),
-            {QStringLiteral("*.otf"), QStringLiteral("*.ttf")}, QDir::Files,
-            QDirIterator::Subdirectories);
-        while (iterator.hasNext()) {
-          QFontDatabase::addApplicationFont(iterator.next());
-        }
-      }
-    }
+    load_fonts();
   }
 
   /* Sans Serif List */

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -172,11 +172,11 @@ void configure_fonts()
   }
 
   /* Sans Serif List */
-  sl << QStringLiteral("Linux Biolinum") << QStringLiteral("Liberation Sans")
-     << QStringLiteral("Droid Sans") << QStringLiteral("Ubuntu")
-     << QStringLiteral("Noto Sans") << QStringLiteral("DejaVu Sans")
-     << QStringLiteral("Luxi Sans") << QStringLiteral("Lucida Sans")
-     << QStringLiteral("Arial");
+  sl << QStringLiteral("Linux Biolinum O")
+     << QStringLiteral("Liberation Sans") << QStringLiteral("Droid Sans")
+     << QStringLiteral("Ubuntu") << QStringLiteral("Noto Sans")
+     << QStringLiteral("DejaVu Sans") << QStringLiteral("Luxi Sans")
+     << QStringLiteral("Lucida Sans") << QStringLiteral("Arial");
 
   font_name = configure_font(fonts::default_font, sl, max);
   if (!font_name.isEmpty()) {
@@ -202,7 +202,7 @@ void configure_fonts()
   sl.clear();
 
   /* Monospace List */
-  sl << QStringLiteral("Linux Libertine Mono") << QStringLiteral("Cousine")
+  sl << QStringLiteral("Linux Libertine Mono O") << QStringLiteral("Cousine")
      << QStringLiteral("Liberation Mono")
      << QStringLiteral("Source Code Pro")
      << QStringLiteral("Source Code Pro [ADBO]")
@@ -227,10 +227,11 @@ void configure_fonts()
   sl.clear();
 
   /* Serif List */
-  sl << QStringLiteral("Linux Libertine Display") << QStringLiteral("Arimo")
-     << QStringLiteral("Play") << QStringLiteral("Tinos")
-     << QStringLiteral("Ubuntu") << QStringLiteral("Times New Roman")
-     << QStringLiteral("Droid Sans") << QStringLiteral("Noto Sans");
+  sl << QStringLiteral("Linux Libertine Display O")
+     << QStringLiteral("Arimo") << QStringLiteral("Play")
+     << QStringLiteral("Tinos") << QStringLiteral("Ubuntu")
+     << QStringLiteral("Times New Roman") << QStringLiteral("Droid Sans")
+     << QStringLiteral("Noto Sans");
 
   font_name = configure_font(fonts::reqtree_text, sl, max, true);
   if (!font_name.isEmpty()) {

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
+ Copyright (c) 1996-2022 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
  published by the Free Software Foundation, either version 3 of the
@@ -10,9 +10,11 @@
 
 #include "fonts.h"
 // Qt
+#include <QDirIterator>
 #include <QFontDatabase>
 #include <QGuiApplication>
 #include <QScreen>
+
 // client
 #include "gui_main.h"
 #include "options.h"
@@ -125,73 +127,109 @@ void fcFont::setFont(const QString &name, const QFont &qf)
 }
 
 /**
-   Tries to choose good fonts for freeciv-qt
+ *   Returns if a font is installed
+ */
+bool isFontInstalled(const QString &font_name)
+{
+  QFontDatabase database;
+
+  if (database.families().contains(font_name)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+   Tries to choose good fonts for Freeciv21
  */
 void configure_fonts()
 {
   QStringList sl;
   QString font_name;
+  QFileInfoList il;
+  QFileInfo info;
 
   const int max = 16;
-  const int default_size = 14;
+  const int default_size = 12;
 
-  /* default and help label*/
-  sl << QStringLiteral("Segoe UI") << QStringLiteral("Cousine")
+  if (!isFontInstalled("Linux Libertine")) {
+    il = find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
+    if (!il.isEmpty()) {
+      for (const auto &info : qAsConst(il)) {
+        QDirIterator iterator(
+            info.absolutePath(),
+            {QStringLiteral("*.otf"), QStringLiteral("*.ttf")}, QDir::Files,
+            QDirIterator::Subdirectories);
+        while (iterator.hasNext()) {
+          QFontDatabase::addApplicationFont(iterator.next());
+        }
+      }
+    }
+  }
+
+  /* Sans Serif List */
+  sl << QStringLiteral("Linux Biolinum O")
      << QStringLiteral("Liberation Sans") << QStringLiteral("Droid Sans")
      << QStringLiteral("Ubuntu") << QStringLiteral("Noto Sans")
      << QStringLiteral("DejaVu Sans") << QStringLiteral("Luxi Sans")
-     << QStringLiteral("Lucida Sans") << QStringLiteral("Trebuchet MS")
-     << QStringLiteral("Times New Roman");
+     << QStringLiteral("Lucida Sans") << QStringLiteral("Arial");
+
   font_name = configure_font(fonts::default_font, sl, max);
   if (!font_name.isEmpty()) {
     fc_strlcpy(gui_options.gui_qt_font_default, qUtf8Printable(font_name),
                512);
+  }
+  font_name = configure_font(fonts::notify_label, sl, default_size);
+  if (!font_name.isEmpty()) {
+    fc_strlcpy(gui_options.gui_qt_font_notify_label,
+               qUtf8Printable(font_name), 512);
   }
   font_name = configure_font(fonts::city_names, sl, max, true);
   if (!font_name.isEmpty()) {
     fc_strlcpy(gui_options.gui_qt_font_city_names, qUtf8Printable(font_name),
                512);
   }
-  // default for help text
-  font_name = configure_font(fonts::help_text, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_help_text, qUtf8Printable(font_name),
-               512);
-  }
-  sl.clear();
-
-  // notify
-  sl << QStringLiteral("Cousine") << QStringLiteral("Liberation Mono")
-     << QStringLiteral("Source Code Pro")
-     << QStringLiteral("Source Code Pro [ADBO]")
-     << QStringLiteral("Noto Mono") << QStringLiteral("Ubuntu Mono")
-     << QStringLiteral("Courier New");
-  font_name = configure_font(fonts::notify_label, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_notify_label,
-               qUtf8Printable(font_name), 512);
-  }
-
-  // standard for chat
-  font_name = configure_font(fonts::chatline, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_chatline, qUtf8Printable(font_name),
-               512);
-  }
-
-  // City production
-  sl.clear();
-  sl << QStringLiteral("Arimo") << QStringLiteral("Play")
-     << QStringLiteral("Tinos") << QStringLiteral("Ubuntu")
-     << QStringLiteral("Times New Roman") << QStringLiteral("Droid Sans")
-     << QStringLiteral("Noto Sans");
   font_name =
       configure_font(fonts::city_productions, sl, default_size, true);
   if (!font_name.isEmpty()) {
     fc_strlcpy(gui_options.gui_qt_font_city_productions,
                qUtf8Printable(font_name), 512);
   }
-  // Reqtree
+  sl.clear();
+
+  /* Monospace List */
+  sl << QStringLiteral("Linux Libertine Mono O") << QStringLiteral("Cousine")
+     << QStringLiteral("Liberation Mono")
+     << QStringLiteral("Source Code Pro")
+     << QStringLiteral("Source Code Pro [ADBO]")
+     << QStringLiteral("Noto Mono") << QStringLiteral("Ubuntu Mono")
+     << QStringLiteral("Courier New");
+
+  font_name = configure_font(fonts::help_label, sl, default_size);
+  if (!font_name.isEmpty()) {
+    fc_strlcpy(gui_options.gui_qt_font_help_label, qUtf8Printable(font_name),
+               512);
+  }
+  font_name = configure_font(fonts::help_text, sl, default_size);
+  if (!font_name.isEmpty()) {
+    fc_strlcpy(gui_options.gui_qt_font_help_text, qUtf8Printable(font_name),
+               512);
+  }
+  font_name = configure_font(fonts::chatline, sl, default_size);
+  if (!font_name.isEmpty()) {
+    fc_strlcpy(gui_options.gui_qt_font_chatline, qUtf8Printable(font_name),
+               512);
+  }
+  sl.clear();
+
+  /* Serif List */
+  sl << QStringLiteral("Linux Libertine Display O")
+     << QStringLiteral("Arimo") << QStringLiteral("Play")
+     << QStringLiteral("Tinos") << QStringLiteral("Ubuntu")
+     << QStringLiteral("Times New Roman") << QStringLiteral("Droid Sans")
+     << QStringLiteral("Noto Sans");
+
   font_name = configure_font(fonts::reqtree_text, sl, max, true);
   if (!font_name.isEmpty()) {
     fc_strlcpy(gui_options.gui_qt_font_reqtree_text,

--- a/client/fonts.h
+++ b/client/fonts.h
@@ -45,7 +45,7 @@ public:
 };
 
 bool isFontInstalled(const QString &font_name);
-
+void load_fonts();
 void configure_fonts();
 QString configure_font(const QString &font_name, const QStringList &sl,
                        int size, bool bold = false);

--- a/client/fonts.h
+++ b/client/fonts.h
@@ -44,6 +44,8 @@ public:
   void releaseFonts();
 };
 
+bool isFontInstalled(const QString &font_name);
+
 void configure_fonts();
 QString configure_font(const QString &font_name, const QStringList &sl,
                        int size, bool bold = false);

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -95,6 +95,9 @@ void ui_main()
     if (!load_theme(gui_options.gui_qt_default_theme_name)) {
       gui_clear_theme();
     }
+    if (!isFontInstalled("Linux Libertine")) {
+      configure_fonts();
+    }
     freeciv_qt = new fc_client();
     freeciv_qt->fc_main(qApp);
   }

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -93,7 +93,7 @@ void ui_main()
       migrate_options_from_2_5();
     }
     if (!isFontInstalled("Linux Libertine")) {
-      configure_fonts();
+      load_fonts();
     }
     if (!load_theme(gui_options.gui_qt_default_theme_name)) {
       gui_clear_theme();

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -92,11 +92,11 @@ void ui_main()
     } else if (!gui_options.gui_qt_migrated_from_2_5) {
       migrate_options_from_2_5();
     }
-    if (!load_theme(gui_options.gui_qt_default_theme_name)) {
-      gui_clear_theme();
-    }
     if (!isFontInstalled("Linux Libertine")) {
       configure_fonts();
+    }
+    if (!load_theme(gui_options.gui_qt_default_theme_name)) {
+      gui_clear_theme();
     }
     freeciv_qt = new fc_client();
     freeciv_qt->fc_main(qApp);

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -189,16 +189,16 @@ struct client_options gui_options = {
     true,  //.gui_qt_allied_chat_only =
     0,     // font_increase
     FC_QT_DEFAULT_THEME_NAME,
-    "Linux Biolinum,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
-    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
-                                                 //=
-    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
-    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
-    "Linux Biolinum,16,-1,5,50,1,0,0,0,0",       //.gui_qt_font_city_names =
-    "Linux Biolinum,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
-                                           //=
-    "Linux Libertine Display,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
-                                                    //=
+    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
+                                                   //=
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
+    "Linux Biolinum O,16,-1,5,50,1,0,0,0,0", //.gui_qt_font_city_names =
+    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
+                                             //=
+    "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
+                                                      //=
     {true}, //=?
     true,   //.gui_qt_show_titlebar
     {}};
@@ -1945,45 +1945,45 @@ static struct client_option client_options[] = {
                    COC_FONT, 0, -100, 100, allfont_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_default, "default_font", N_("Default font"),
                     N_("This is default font"), COC_FONT,
-                    "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
+                    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
         N_("This font is used to display server reports such "
            "as the demographic report or historian publications."),
-        COC_FONT, "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
+        COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
         font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_label, "help_label", N_("Help Label"),
                     N_("This font is used to display the help labels in the "
                        "help window."),
-                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_text, "help_text", N_("Help Text"),
                     N_("This font is used to display the help body text in "
                        "the help window."),
-                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
                     N_("This font is used to display the text in the "
                        "chatline area."),
-                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
                     N_("This font is used to the display the city names "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum,16,-1,5,50,1,0,0,0,0",
+                    COC_FONT, "Linux Biolinum O,16,-1,5,50,1,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
                     N_("City Productions"),
                     N_("This font is used to display the city production "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
         N_("This font is used to the display the requirement tree "
            "in the Research report."),
-        COC_FONT, "Linux Libertine Display,14,-1,5,50,0,0,0,0,0",
+        COC_FONT, "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0",
         font_changed_callback),
     GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
                     N_("If this option is set the client will show "

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -189,16 +189,16 @@ struct client_options gui_options = {
     true,  //.gui_qt_allied_chat_only =
     0,     // font_increase
     FC_QT_DEFAULT_THEME_NAME,
-    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
-                                                   //=
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
-    "Linux Biolinum O,16,-1,5,50,1,0,0,0,0", //.gui_qt_font_city_names =
-    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
-                                             //=
-    "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
-                                                      //=
+    "Linux Biolinum,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
+    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
+                                                 //=
+    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
+    "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
+    "Linux Biolinum,16,-1,5,50,1,0,0,0,0",       //.gui_qt_font_city_names =
+    "Linux Biolinum,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
+                                           //=
+    "Linux Libertine Display,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
+                                                    //=
     {true}, //=?
     true,   //.gui_qt_show_titlebar
     {}};
@@ -1945,45 +1945,45 @@ static struct client_option client_options[] = {
                    COC_FONT, 0, -100, 100, allfont_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_default, "default_font", N_("Default font"),
                     N_("This is default font"), COC_FONT,
-                    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
+                    "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
         N_("This font is used to display server reports such "
            "as the demographic report or historian publications."),
-        COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
+        COC_FONT, "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
         font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_label, "help_label", N_("Help Label"),
                     N_("This font is used to display the help labels in the "
                        "help window."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_text, "help_text", N_("Help Text"),
                     N_("This font is used to display the help body text in "
                        "the help window."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
                     N_("This font is used to display the text in the "
                        "chatline area."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
                     N_("This font is used to the display the city names "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum O,16,-1,5,50,1,0,0,0,0",
+                    COC_FONT, "Linux Biolinum,16,-1,5,50,1,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
                     N_("City Productions"),
                     N_("This font is used to display the city production "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Biolinum,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
         N_("This font is used to the display the requirement tree "
            "in the Research report."),
-        COC_FONT, "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0",
+        COC_FONT, "Linux Libertine Display,14,-1,5,50,0,0,0,0,0",
         font_changed_callback),
     GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
                     N_("If this option is set the client will show "

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -1,5 +1,5 @@
 /*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
+/   \          /   \          Copyright (c) 1996-2022 Freeciv21 and Freeciv
 \_   \        /  __/          contributors. This file is part of Freeciv21.
  _\   \      /  /__     Freeciv21 is free software: you can redistribute it
  \___  \____/   __/    and/or modify it under the terms of the GNU  General
@@ -189,15 +189,18 @@ struct client_options gui_options = {
     true,  //.gui_qt_allied_chat_only =
     0,     // font_increase
     FC_QT_DEFAULT_THEME_NAME,
-    "Monospace,8,-1,5,75,0,0,0,0,0",   //.gui_qt_font_notify_label =
-    "Sans Serif,9,-1,5,50,0,0,0,0,0",  //.gui_qt_font_help_label =
-    "Monospace,8,-1,5,50,0,0,0,0,0",   //.gui_qt_font_help_text =
-    "Monospace,8,-1,5,50,0,0,0,0,0",   //.gui_qt_font_chatline =
-    "Sans Serif,10,-1,5,75,0,0,0,0,0", //.gui_qt_font_city_names =
-    "Sans Serif,10,-1,5,50,1,0,0,0,0", //.gui_qt_font_city_productions =
-    "Sans Serif,10,-1,5,50,1,0,0,0,0", //.gui_qt_font_reqtree_text =
-    {true},                            //=?
-    true,                              //.gui_qt_show_titlebar
+    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
+                                                   //=
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
+    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
+    "Linux Biolinum O,16,-1,5,50,1,0,0,0,0", //.gui_qt_font_city_names =
+    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
+                                             //=
+    "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
+                                                      //=
+    {true}, //=?
+    true,   //.gui_qt_show_titlebar
     {}};
 
 /* Set to TRUE after the first call to options_init(), to avoid the usage
@@ -1942,44 +1945,46 @@ static struct client_option client_options[] = {
                    COC_FONT, 0, -100, 100, allfont_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_default, "default_font", N_("Default font"),
                     N_("This is default font"), COC_FONT,
-                    "Sans Serif,10,-1,5,75,0,0,0,0,0",
+                    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
         N_("This font is used to display server reports such "
            "as the demographic report or historian publications."),
-        COC_FONT, "Monospace,9,-1,5,75,0,0,0,0,0", font_changed_callback),
+        COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
+        font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_label, "help_label", N_("Help Label"),
                     N_("This font is used to display the help labels in the "
                        "help window."),
-                    COC_FONT, "Sans Serif,9,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_text, "help_text", N_("Help Text"),
                     N_("This font is used to display the help body text in "
                        "the help window."),
-                    COC_FONT, "Monospace,8,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
                     N_("This font is used to display the text in the "
                        "chatline area."),
-                    COC_FONT, "Monospace,8,-1,5,50,0,0,0,0,0",
+                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
                     N_("This font is used to the display the city names "
                        "on the map."),
-                    COC_FONT, "Sans Serif,10,-1,5,75,0,0,0,0,0",
+                    COC_FONT, "Linux Biolinum O,16,-1,5,50,1,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
                     N_("City Productions"),
                     N_("This font is used to display the city production "
                        "on the map."),
-                    COC_FONT, "Sans Serif,10,-1,5,50,1,0,0,0,0",
+                    COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
         N_("This font is used to the display the requirement tree "
            "in the Research report."),
-        COC_FONT, "Sans Serif,10,-1,5,50,1,0,0,0,0", font_changed_callback),
+        COC_FONT, "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0",
+        font_changed_callback),
     GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
                     N_("If this option is set the client will show "
                        "information and map preview of current savegame."),


### PR DESCRIPTION
Right now it assumes there is no `rc` file and then loads the font if not found in the font database from the filesystem and sets the defaults. I think there might need to be another check, but not sure where from.

Closes #1273 