### PR TITLE
Add support for fc21:// on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,6 +233,11 @@ jobs:
         with:
           files: |
             Freeciv21-*.dmg
+      - name: Upload a build
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOS-dmg
+          path: Freeciv21-*.dmg
 
   wasm:
     name: "WebAssembly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,6 +197,11 @@ jobs:
         with:
           configurePreset: 'fullrelease-macos'
           buildPreset: 'fullrelease-macos'
+      - name: Split Branch Name
+        env:
+          BRANCH: ${{github.ref_name}}
+        id: split
+        run: echo "::set-output name=fragment::${BRANCH##*/}"
       - name: Create App Bundle
         run: |
           mkdir -p Freeciv21.app/Contents/MacOS Freeciv21.app/Contents/Resources
@@ -222,12 +227,14 @@ jobs:
             --icon "Freeciv21.app" 200 190 \
             --hide-extension "Freeciv21.app" \
             --app-drop-link 600 185 \
-            "Freeciv21-${{github.ref_name}}.dmg" \
+            "Freeciv21-${{steps.split.outputs.fragment}}.dmg" \
             "staging/"
-          sha256sum --binary *.dmg > Freeciv21-${{github.ref_name}}.sha256
+          sha256sum --binary *.dmg > Freeciv21-${{steps.split.outputs.fragment}}.sha256
       - name: Debug
         if: failure()
-        run: cat CMakeCache.txt
+        run: |
+          cat CMakeCache.txt
+          echo ${{steps.split.outputs.fragment}}
       - name: Upload package
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -224,6 +224,7 @@ jobs:
             --app-drop-link 600 185 \
             "Freeciv21-${{github.ref_name}}.dmg" \
             "staging/"
+            sha256sum --binary *.dmg > Freeciv21-${{github.ref_name}}.sha256
       - name: Debug
         if: failure()
         run: cat CMakeCache.txt
@@ -233,6 +234,7 @@ jobs:
         with:
           files: |
             Freeciv21-*.dmg
+            Freeciv21-*.sha256
       - name: Upload a build
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -224,7 +224,7 @@ jobs:
             --app-drop-link 600 185 \
             "Freeciv21-${{github.ref_name}}.dmg" \
             "staging/"
-            sha256sum --binary *.dmg > Freeciv21-${{github.ref_name}}.sha256
+          sha256sum --binary *.dmg > Freeciv21-${{github.ref_name}}.sha256
       - name: Debug
         if: failure()
         run: cat CMakeCache.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,7 +229,7 @@ jobs:
             --app-drop-link 600 185 \
             "Freeciv21-${{steps.split.outputs.fragment}}.dmg" \
             "staging/"
-          sha256sum --binary *.dmg > Freeciv21-${{steps.split.outputs.fragment}}.sha256
+          shasum -a 256 Freeciv21-${{steps.split.outputs.fragment}}.dmg > Freeciv21-${{steps.split.outputs.fragment}}.dmg.sha256
       - name: Debug
         if: failure()
         run: |
@@ -241,7 +241,7 @@ jobs:
         with:
           files: |
             Freeciv21-*.dmg
-            Freeciv21-*.sha256
+            Freeciv21-*.dmg.sha256
       - name: Upload a build
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,7 +237,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: macOS-dmg
-          path: *.dmg
+          path: merge.dmg
 
   wasm:
     name: "WebAssembly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -246,7 +246,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: macOS-dmg
-          path: merge.dmg
+          path: Freeciv21-*.dmg
 
   wasm:
     name: "WebAssembly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,7 +237,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: macOS-dmg
-          path: Freeciv21-*.dmg
+          path: *.dmg
 
   wasm:
     name: "WebAssembly"

--- a/dist/Info.plist
+++ b/dist/Info.plist
@@ -10,16 +10,16 @@
   <string>freeciv21-client</string>
   <key>CFBundleIconFile</key>
   <string>client.icns</string>
-</dict>
-<key>CFBundleURLTypes</key>
-<array>
+  <key>CFBundleURLTypes</key>
+  <array>
     <dict>
-        <key>CFBundleURLName</key>
+      <key>CFBundleURLName</key>
         <string>Freeciv21 Handler</string>
         <key>CFBundleURLSchemes</key>
         <array>
-            <string>fc21</string>
+          <string>fc21</string>
         </array>
     </dict>
-</array>
+  </array>
+</dict>
 </plist>

--- a/dist/Info.plist
+++ b/dist/Info.plist
@@ -11,4 +11,15 @@
   <key>CFBundleIconFile</key>
   <string>client.icns</string>
 </dict>
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleURLName</key>
+        <string>Freeciv21 Handler</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>fc21</string>
+        </array>
+    </dict>
+</array>
 </plist>


### PR DESCRIPTION
This PR does two things:

1. It adds support for fc21:// links on macOS
2. It adds support of uploading a `.dmg` to a build's artifact list to aid testing outside of a release

Closes #916 