### PR TITLE
Add sha256 hash files to the source archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,16 +36,22 @@ jobs:
       - name: Make build directory
         run: mkdir -p -v $PWD/build
       - name: Create tar.gz
-        run: git archive --format=tar.gz -o $PWD/build/Freeciv21-${{github.ref_name}}.tar.gz HEAD
+        run: |
+          git archive --format=tar.gz -o $PWD/build/Freeciv21-${{github.ref_name}}.tar.gz HEAD
+          sha256sum --binary $PWD/build/Freeciv21-${{github.ref_name}}.tar.gz > $PWD/build/Freeciv21-${{github.ref_name}}.tar.gz.sha256
       - name: Create zip
-        run: git archive --format=zip -o $PWD/build/Freeciv21-${{github.ref_name}}.zip HEAD
+        run: |
+          git archive --format=zip -o $PWD/build/Freeciv21-${{github.ref_name}}.zip HEAD
+          sha256sum --binary $PWD/build/Freeciv21-${{github.ref_name}}.zip > $PWD/build/Freeciv21-${{github.ref_name}}.zip.sha256
       - name: Upload package
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             build/Freeciv21-${{github.ref_name}}.tar.gz
+            build/Freeciv21-${{github.ref_name}}.tar.gz.sha256
             build/Freeciv21-${{github.ref_name}}.zip
+            build/Freeciv21-${{github.ref_name}}.zip.sha256
   i686-windows:
     name: "Create i686 Windows Package"
     runs-on: windows-latest


### PR DESCRIPTION
No related issue. Added since we are doing the same for the macOS `.dmg`, figured it good to offer for all of our assets at release.