### PR TITLE
Documentation links fixes

### DIFF
--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -75,6 +75,13 @@ to alter is placed inside back-ticks.
 
 * :literal:`:doc:` -- Doc is used to create a hyperlink reference between documents in the documentation
   system.
+* :literal:`:ref:` -- Create a cross-reference link to an anchor in another document. This is similar to
+  :literal:`:doc:`, except it allows you to go to a specific location within a page, instead of the top of the
+  page. To use :literal:`:ref:`, you add an anchor in a page such as :literal:`.. _My Anchor:` and then refer
+  to it like this: :literal:`:ref:`My Anchor``. Notice that the anchor has an underscore at the beginning.
+  This is required for sphinx to recognize it. Also notice the use of the anchor in :literal:`:ref:` leaves
+  the underscore off.
+* :literal:`:numref:` -- Create a cross-reference to a named figure.
 * :literal:`:emphasis:` -- Emphasis is used to :emphasis:`bring attention to something`.
 * :literal:`:file:` -- File is used for file names and paths such as :file:`~/.local/share/freeciv21/saves`.
 * :literal:`:guilabel:` -- GUI Label is used to bring attention to something on the screen like the
@@ -89,6 +96,7 @@ to alter is placed inside back-ticks.
 * :literal:`:title-reference:` -- Title Reference is used notate a :title-reference:`title entry` in the
   in-game help or to refer to a page in the documentation without giving an actual hyperlink reference
   (see :literal:`:doc:` above).
+
 
 The docutils specification allows for custom Interpreted Text Roles and we use this feature. The docutils
 documentation on this feature is available here:

--- a/docs/Manuals/client-manual.rst
+++ b/docs/Manuals/client-manual.rst
@@ -1158,6 +1158,8 @@ selection of cities, buy what is currently being produced, and center the city o
 center the city on the map, the client will close the :guilabel:`Cities View` and open the `Map View`_ and
 place the city in the center of the screen.
 
+.. _Nations and Diplomacy View:
+
 Nations and Diplomacy View
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/Playing/how-to-play.rst
+++ b/docs/Playing/how-to-play.rst
@@ -274,18 +274,18 @@ Interacting with Other Players (Diplomacy)
 
 When one of your units first meets a unit of another nation, or finds one of their cities (or equally if
 they find you), a basic contact is established between the two nations. This provides each with basic
-intelligence about the other, which can be accessed from
-:numref:`Nations and Diplomacy View Button` in the :doc:`/Manuals/client-manual`.
+intelligence about the other, which can be accessed from the
+:ref:`Nations and Diplomacy View`.
 
 This communication will lapse after a ruleset defined number of turns with no contact, which is one turn for
 the Classic Ruleset. Establishing an embassy will give a more permanent communication channel, as well as more
 advanced intelligence such as details of technology. Embassies are one-way, the nation hosting the embassy
 receives no benefit and once established, cannot be revoked.
 
-If you are in contact with another player, then you can arrange a diplomatic meeting. From
-:numref:`Nations and Diplomacy View Button` in the :doc:`/Manuals/client-manual`, this is done by selecting the
-nation with whom you wish to meet and clicking :guilabel:`Meet`. If the entry under the embassy column is not
-blank and the other player is connected (or is a server AI) then a treaty dialog will pop up.
+If you are in contact with another player, then you can arrange a diplomatic meeting. From the
+:ref:`Nations and Diplomacy View`, this is done by selecting the nation with whom you wish to meet and
+clicking :guilabel:`Meet`. If the entry under the embassy column is not blank and the other player is
+connected (or is a server AI) then a treaty dialog will pop up.
 
 In this dialog you can negotiate an exchange of assets (maps, vision, advances, cities, or gold), embassies,
 or relationship pacts such as a Cease-fire or Peace. The list of items that can be traded through diplomacy is


### PR DESCRIPTION
Branch name would suggest game manual, but Discord conversation derailed it. While here, found out how to use `:ref:` role properly. Fixed cross link in how to play and document the usage in style guide. No referenced issue.