### PR TITLE
Docs: Add missing libsqlite3-dev package to Debian steps

### DIFF
--- a/docs/Getting/compile.rst
+++ b/docs/Getting/compile.rst
@@ -160,8 +160,9 @@ following commands:
      libqt5svg5-dev \
      libkf5archive-dev \
      liblua5.3-dev \
-     libmagickwand-dev \
+     libsqlite3-dev \
      libsdl2-mixer-dev \
+     libmagickwand-dev \
      libunwind-dev \
      libdw-dev \
      python3-sphinx \


### PR DESCRIPTION
Docs: Add missing libsqlite3-dev package to Debian steps. I wiped my laptop to start from scratch and found an error in the set of packages. No related issue.