### PR TITLE
Implement contact_intel with effects

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -575,6 +575,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_MAPS_STOLEN_PCT:
   case EFT_UNIT_SHIELD_VALUE_PCT:
   case EFT_WONDER_VISIBLE:
+  case EFT_NATION_INTELLIGENCE:
     break;
     // This has no effect for AI
   case EFT_VISIBLE_WALLS:
@@ -834,6 +835,7 @@ bool dai_can_requirement_be_met_in_city(const struct requirement *preq,
   case VUT_GOOD:
   case VUT_MINCALFRAG:
   case VUT_VISIONLAYER:
+  case VUT_NINTEL:
   case VUT_COUNT:
     // No sensible implementation possible with data available.
     break;

--- a/client/diplodlg.cpp
+++ b/client/diplodlg.cpp
@@ -9,6 +9,9 @@
  */
 
 #include "diplodlg.h"
+
+#include <limits>
+
 // Qt
 #include <QApplication>
 #include <QCloseEvent>
@@ -155,12 +158,12 @@ diplo_wdg::diplo_wdg(int counterpart, int initiated_from)
   gold_edit2 = new QSpinBox;
   gold_edit1->setMinimum(0);
   gold_edit2->setMinimum(0);
+  gold_edit1->setMaximum(std::numeric_limits<std::int32_t>::max());
+  gold_edit2->setMaximum(std::numeric_limits<std::int32_t>::max());
   gold_edit1->setFocusPolicy(Qt::ClickFocus);
   gold_edit2->setFocusPolicy(Qt::ClickFocus);
-  if (game.info.trading_gold) {
-    gold_edit2->setMaximum(player_by_number(player1)->economic.gold);
-    gold_edit1->setMaximum(player_by_number(player2)->economic.gold);
-  }
+  gold_edit1->setEnabled(game.info.trading_gold);
+  gold_edit2->setEnabled(game.info.trading_gold);
   connect(gold_edit1, qOverload<int>(&QSpinBox::valueChanged), this,
           &diplo_wdg::gold_changed1);
   connect(gold_edit2, qOverload<int>(&QSpinBox::valueChanged), this,

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -29,6 +29,7 @@
 // common
 #include "achievements.h"
 #include "actions.h"
+#include "capability.h"
 #include "capstr.h"
 #include "citizens.h"
 #include "events.h"
@@ -2300,6 +2301,14 @@ void handle_player_info(const struct packet_player_info *pinfo)
      * redundant as the values are initialised with 0 due to fc_calloc(). */
     client_player_init(pplayer);
   }
+
+  // Information visibility
+  if (!has_capability("player-intel-visibility", client.conn.capability)) {
+    // Providing full backward compat here would be too much work. Let the
+    // client believe that it knows everything.
+    BV_SET_ALL(pplayer->client.visible);
+  }
+  pplayer->client.visible = pinfo->visible;
 
   // Team.
   tslot = team_slot_by_number(pinfo->team);

--- a/client/plrdlg_common.cpp
+++ b/client/plrdlg_common.cpp
@@ -290,12 +290,9 @@ static int cmp_score(const struct player *player1,
  */
 QString col_government(const struct player *them)
 {
-  const struct player *me = client_player();
-
-  //  'contact' gives the knowledge of other's government
-  if (me == them || client_is_global_observer()
-      || player_has_embassy(me, them)
-      || player_diplstate_get(me, them)->contact_turns_left > 0) {
+  if (!them || !them->is_alive) {
+    return _("-");
+  } else if (BV_ISSET(them->client.visible, NI_GOVERNMENT)) {
     return government_name_for_player(them);
   } else {
     return _("?");
@@ -317,15 +314,9 @@ static int cmp_culture(const struct player *player1,
  */
 QString get_culture_info(const struct player *them)
 {
-  const struct player *me = client_player();
-
-  // FIXME: Try to avoid this code duplication same code repeated in every
-  // column
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)))) {
+  } else if (BV_ISSET(them->client.visible, NI_CULTURE)) {
     return QString::number(them->client.culture);
   } else {
     return _("?");
@@ -355,15 +346,9 @@ static int cmp_gold(const struct player *player1,
  */
 QString col_gold(const struct player *them)
 {
-  const struct player *me = client_player();
-
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)
-                     || player_diplstate_get(me, them)->contact_turns_left
-                            > 0))) {
+  } else if (BV_ISSET(them->client.visible, NI_GOLD)) {
     return QString::number(them->economic.gold);
   } else {
     return _("?");
@@ -385,13 +370,9 @@ static int cmp_tax(const struct player *player1,
  */
 QString col_tax(const struct player *them)
 {
-  const struct player *me = client_player();
-
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)))) {
+  } else if (BV_ISSET(them->client.visible, NI_TAX_RATES)) {
     return QString::number(them->economic.tax);
   } else {
     return _("?");
@@ -413,13 +394,9 @@ static int cmp_science(const struct player *player1,
  */
 QString col_science(const struct player *them)
 {
-  const struct player *me = client_player();
-
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)))) {
+  } else if (BV_ISSET(them->client.visible, NI_TAX_RATES)) {
     return QString::number(them->economic.science);
   } else {
     return _("?");
@@ -441,13 +418,9 @@ static int cmp_luxury(const struct player *player1,
  */
 QString col_luxury(const struct player *them)
 {
-  const struct player *me = client_player();
-
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)))) {
+  } else if (BV_ISSET(them->client.visible, NI_TAX_RATES)) {
     return QString::number(them->economic.luxury);
   } else {
     return _("?");
@@ -459,13 +432,9 @@ QString col_luxury(const struct player *them)
  */
 QString col_research(const struct player *them)
 {
-  const struct player *me = client_player();
-
   if (them == nullptr || !them->is_alive) {
     return _("-");
-  } else if (client_is_global_observer()
-             || (me != nullptr
-                 && (me == them || player_has_embassy(me, them)))) {
+  } else if (BV_ISSET(them->client.visible, NI_TECHS)) {
     struct research *research = research_get(them);
     return research_advance_name_translation(research,
                                              research->researching);

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -628,7 +628,7 @@ int get_target_bonus_effects(
                         target_building, target_tile, target_unit,
                         target_unittype, target_output, target_specialist,
                         target_action, &peffect->reqs, RPT_CERTAIN,
-                        vision_layer)) {
+                        vision_layer, nintel)) {
       /* This code will add value of effect. If there's multiplier for
        * effect and target_player aren't null, then value is multiplied
        * by player's multiplier factor. */
@@ -1216,6 +1216,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_STEALINGS_IGNORE:
   case EFT_CASUS_BELLI_COMPLETE:
   case EFT_WONDER_VISIBLE:
+  case EFT_NATION_INTELLIGENCE:
   case EFT_COUNT:
     return QStringLiteral("%1").arg(value);
   }

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -616,7 +616,7 @@ int get_target_bonus_effects(
     const struct output_type *target_output,
     const struct specialist *target_specialist,
     const struct action *target_action, enum effect_type effect_type,
-    enum vision_layer vision_layer)
+    enum vision_layer vision_layer, enum national_intelligence nintel)
 {
   int bonus = 0;
 
@@ -771,6 +771,27 @@ int get_player_output_bonus(const struct player *pplayer,
   return get_target_bonus_effects(nullptr, pplayer, nullptr, nullptr,
                                   nullptr, nullptr, nullptr, nullptr,
                                   poutput, nullptr, nullptr, effect_type);
+}
+
+/**
+ * Gets the player effect bonus of a national intelligence.
+ */
+int get_player_intel_bonus(const struct player *pplayer,
+                           const struct player *pother,
+                           enum national_intelligence nintel,
+                           enum effect_type effect_type)
+{
+  if (!initialized) {
+    return 0;
+  }
+
+  fc_assert_ret_val(pplayer != nullptr, 0);
+  fc_assert_ret_val(pother != nullptr, 0);
+  fc_assert_ret_val(national_intelligence_is_valid(nintel), 0);
+  fc_assert_ret_val(effect_type != EFT_COUNT, 0);
+  return get_target_bonus_effects(
+      nullptr, pplayer, pother, nullptr, nullptr, nullptr, nullptr, nullptr,
+      nullptr, nullptr, nullptr, effect_type, V_COUNT, nintel);
 }
 
 /**

--- a/common/effects.h
+++ b/common/effects.h
@@ -309,6 +309,8 @@
 #define SPECENUM_VALUE131NAME "Trade_Revenue_Exponent"
 #define SPECENUM_VALUE132 EFT_WONDER_VISIBLE
 #define SPECENUM_VALUE132NAME "Wonder_Visible"
+#define SPECENUM_VALUE133 EFT_NATION_INTELLIGENCE
+#define SPECENUM_VALUE133NAME "Nation_Intelligence"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"
@@ -386,6 +388,10 @@ int get_tile_output_bonus(const struct city *pcity, const struct tile *ptile,
 int get_player_output_bonus(const struct player *pplayer,
                             const struct output_type *poutput,
                             enum effect_type effect_type);
+int get_player_intel_bonus(const struct player *pplayer,
+                           const struct player *pother,
+                           enum national_intelligence nintel,
+                           enum effect_type effect_type);
 int get_city_output_bonus(const struct city *pcity,
                           const struct output_type *poutput,
                           enum effect_type effect_type);
@@ -418,7 +424,8 @@ int get_target_bonus_effects(
     const struct output_type *target_output,
     const struct specialist *target_specialist,
     const struct action *target_action, enum effect_type effect_type,
-    enum vision_layer vision_layer = V_COUNT);
+    enum vision_layer vision_layer = V_COUNT,
+    enum national_intelligence nintel = NI_COUNT);
 
 bool building_has_effect(const struct impr_type *pimprove,
                          enum effect_type effect_type);

--- a/common/fc_types.h
+++ b/common/fc_types.h
@@ -520,12 +520,41 @@ typedef int Unit_Class_id;
 // Used in the network protocol.
 #define SPECENUM_NAME vision_layer
 #define SPECENUM_VALUE0 V_MAIN
-#define SPECENUM_VALUE0NAME "Main"
+#define SPECENUM_VALUE0NAME N_("Main")
 #define SPECENUM_VALUE1 V_INVIS
-#define SPECENUM_VALUE1NAME "Stealth"
+#define SPECENUM_VALUE1NAME N_("Stealth")
 #define SPECENUM_VALUE2 V_SUBSURFACE
-#define SPECENUM_VALUE2NAME "Subsurface"
+#define SPECENUM_VALUE2NAME N_("Subsurface")
 #define SPECENUM_COUNT V_COUNT
+#include "specenum_gen.h"
+
+// Used in the network protocol.
+#define SPECENUM_NAME national_intelligence
+#define SPECENUM_VALUE0 NI_MULTIPLIERS
+#define SPECENUM_VALUE0NAME N_("Multipliers")
+#define SPECENUM_VALUE1 NI_WONDERS
+#define SPECENUM_VALUE1NAME N_("Wonders")
+#define SPECENUM_VALUE2 NI_SCORE
+#define SPECENUM_VALUE2NAME N_("Score")
+#define SPECENUM_VALUE3 NI_GOLD
+#define SPECENUM_VALUE3NAME N_("Gold")
+#define SPECENUM_VALUE4 NI_GOVERNMENT
+#define SPECENUM_VALUE4NAME N_("Government")
+#define SPECENUM_VALUE5 NI_DIPLOMACY
+#define SPECENUM_VALUE5NAME N_("Diplomacy")
+#define SPECENUM_VALUE6 NI_TECHS
+#define SPECENUM_VALUE6NAME N_("Techs")
+#define SPECENUM_VALUE7 NI_TAX_RATES
+#define SPECENUM_VALUE7NAME N_("Tax Rates")
+#define SPECENUM_VALUE8 NI_CULTURE
+#define SPECENUM_VALUE8NAME N_("Culture")
+#define SPECENUM_VALUE9 NI_MOOD
+#define SPECENUM_VALUE9NAME N_("Mood")
+#define SPECENUM_VALUE10 NI_HISTORY
+#define SPECENUM_VALUE10NAME N_("History")
+#define SPECENUM_VALUE11 NI_INFRAPOINTS
+#define SPECENUM_VALUE11NAME N_("Infra Points")
+#define SPECENUM_COUNT NI_COUNT
 #include "specenum_gen.h"
 
 // A server setting + its value.
@@ -566,6 +595,7 @@ typedef union {
   enum citytile_type citytile;
   enum citystatus_type citystatus;
   enum vision_layer vlayer;
+  enum national_intelligence nintel;
   int minsize;
   int minculture;
   int minforeignpct;
@@ -699,6 +729,8 @@ typedef union {
 #define SPECENUM_VALUE45NAME "Activity"
 #define SPECENUM_VALUE46 VUT_VISIONLAYER
 #define SPECENUM_VALUE46NAME "VisionLayer"
+#define SPECENUM_VALUE47 VUT_NINTEL
+#define SPECENUM_VALUE47NAME "NationalIntelligence"
 // Keep this last.
 #define SPECENUM_COUNT VUT_COUNT
 #include "specenum_gen.h"

--- a/common/fc_types.h
+++ b/common/fc_types.h
@@ -557,6 +557,9 @@ typedef int Unit_Class_id;
 #define SPECENUM_COUNT NI_COUNT
 #include "specenum_gen.h"
 
+// Used in the network protocol.
+BV_DEFINE(bv_intel_visible, NI_COUNT);
+
 // A server setting + its value.
 typedef int ssetv;
 

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -279,6 +279,7 @@ type BV_RMCAUSES        = bitvector(bv_rmcauses)
 type BV_CITY_OPTIONS    = bitvector(bv_city_options)
 type BV_IMPR_FLAGS      = bitvector(bv_impr_flags)
 type BV_IMPRS           = bitvector(bv_imprs)
+type BV_INTEL_VISIBLE   = bitvector(bv_intel_visible)
 type BV_PLAYER          = bitvector(bv_player)
 type BV_SPECIAL         = bitvector(bv_special)
 type BV_STARTPOS_NATIONS= bitvector(bv_startpos_nations)
@@ -937,6 +938,8 @@ PACKET_PLAYER_INFO = 51; sc, is-info
   UINT8  multip_count;
   SINT32 multiplier[MAX_NUM_MULTIPLIERS:multip_count];
   SINT32 multiplier_target[MAX_NUM_MULTIPLIERS:multip_count];
+
+  BV_INTEL_VISIBLE visible; add-cap(player-intel-visibility)
 end
 
 PACKET_PLAYER_PHASE_DONE = 52; cs, dsend

--- a/common/player.cpp
+++ b/common/player.cpp
@@ -1415,7 +1415,7 @@ bool is_diplrel_between(const struct player *player1,
     return player_diplstate_get(player1, player2)->type == diplrel;
   }
 
-  switch (diplrel) {
+  switch (static_cast<diplrel_other>(diplrel)) {
   case DRO_GIVES_SHARED_VISION:
     return gives_shared_vision(player1, player2);
   case DRO_RECEIVES_SHARED_VISION:
@@ -1434,6 +1434,10 @@ bool is_diplrel_between(const struct player *player1,
     return 0 < player_diplstate_get(player2, player1)->has_reason_to_cancel;
   case DRO_FOREIGN:
     return player1 != player2;
+  case DRO_HAS_CONTACT:
+    return player_diplstate_get(player2, player1)->contact_turns_left > 0;
+  case DRO_LAST:
+    break;
   }
 
   fc_assert_msg(false, "diplrel_between(): invalid diplrel number %d.",

--- a/common/player.h
+++ b/common/player.h
@@ -171,12 +171,14 @@ struct player_ai {
 #define SPECENUM_VALUE14NAME N_("Provided Casus Belli")
 #define SPECENUM_VALUE15 DRO_FOREIGN
 #define SPECENUM_VALUE15NAME N_("Foreign")
+#define SPECENUM_VALUE16 DRO_HAS_CONTACT
+#define SPECENUM_VALUE16NAME N_("Has Contact")
 #define SPECENUM_COUNT DRO_LAST
 #include "specenum_gen.h"
 
 BV_DEFINE(bv_diplrel_all_reqs,
           // Reserve a location for each possible DiplRel requirement.
-          ((DRO_LAST - 1) * 2) * REQ_RANGE_COUNT);
+          ((DRO_LAST - 1) * 2) * REQ_RANGE_COUNT + 2);
 
 enum dipl_reason {
   DIPL_OK,

--- a/common/player.h
+++ b/common/player.h
@@ -352,6 +352,10 @@ struct player {
       bool color_changeable;
 
       int culture;
+
+      /// Which information is actually visible to the client (and can thus
+      /// be trusted)
+      bv_intel_visible visible;
     } client;
   };
 };

--- a/common/reqtext.cpp
+++ b/common/reqtext.cpp
@@ -2854,6 +2854,22 @@ bool req_text_insert(char *buf, size_t bufsz, struct player *pplayer,
     }
     break;
 
+  case VUT_NINTEL:
+    fc_strlcat(buf, prefix, bufsz);
+    if (preq->present) {
+      // TRANS: "For Wonders intelligence." Very rare.
+      cat_snprintf(buf, bufsz, _("For %s intelligence."),
+                   qUtf8Printable(national_intelligence_translated_name(
+                       preq->source.value.nintel)));
+    } else {
+      // TRANS: "For intelligence other than Wonders." Very rare.
+      cat_snprintf(buf, bufsz, _("For intelligence other than %s."),
+                   qUtf8Printable(national_intelligence_translated_name(
+                       preq->source.value.nintel)));
+    }
+    return true;
+    break;
+
   case VUT_COUNT:
     break;
   }

--- a/common/requirements.h
+++ b/common/requirements.h
@@ -108,7 +108,8 @@ bool is_req_active(
     const struct specialist *target_specialist,
     const struct action *target_action, const struct requirement *req,
     const enum req_problem_type prob_type,
-    const enum vision_layer vision_layer = V_COUNT);
+    const enum vision_layer vision_layer = V_COUNT,
+    const enum national_intelligence nintel = NI_COUNT);
 bool are_reqs_active(const struct player *target_player,
                      const struct player *other_player,
                      const struct city *target_city,
@@ -121,7 +122,8 @@ bool are_reqs_active(const struct player *target_player,
                      const struct action *target_action,
                      const struct requirement_vector *reqs,
                      const enum req_problem_type prob_type,
-                     const enum vision_layer vision_layer = V_COUNT);
+                     const enum vision_layer vision_layer = V_COUNT,
+                     const enum national_intelligence nintel = NI_COUNT);
 
 bool is_req_unchanging(const struct requirement *req);
 

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -287,7 +287,8 @@ static bool reqs_may_activate(const struct player *target_player,
                               const struct action *target_action,
                               const struct requirement_vector *reqs,
                               const enum req_problem_type prob_type,
-                              const enum vision_layer vision_layer)
+                              const enum vision_layer vision_layer,
+                              const enum national_intelligence nintel)
 {
   requirement_vector_iterate(reqs, preq)
   {
@@ -295,7 +296,8 @@ static bool reqs_may_activate(const struct player *target_player,
         && !is_req_active(target_player, other_player, target_city,
                           target_building, target_tile, target_unit,
                           target_unittype, target_output, target_specialist,
-                          target_action, preq, prob_type, vision_layer)) {
+                          target_action, preq, prob_type, vision_layer,
+                          nintel)) {
       return false;
     }
   }
@@ -322,7 +324,8 @@ static bool research_allowed(
         const struct unit_type *tutype, const struct output_type *top,
         const struct specialist *tspe, const struct action *tact,
         const struct requirement_vector *reqs,
-        const enum req_problem_type ptype, const enum vision_layer vlayer))
+        const enum req_problem_type ptype, const enum vision_layer vlayer,
+        const enum national_intelligence nintel))
 {
   struct advance *adv;
 
@@ -337,7 +340,7 @@ static bool research_allowed(
   {
     if (reqs_eval(pplayer, nullptr, nullptr, nullptr, nullptr, nullptr,
                   nullptr, nullptr, nullptr, nullptr, &(adv->research_reqs),
-                  RPT_CERTAIN, V_COUNT)) {
+                  RPT_CERTAIN, V_COUNT, NI_COUNT)) {
       /* It is enough that one player that shares research is allowed to
        * research it.
        * Reasoning: Imagine a tech with that requires a nation in the

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -67,6 +67,7 @@ if (FREECIV_ENABLE_SERVER OR FREECIV_ENABLE_RULEDIT)
     FILES
     default/ai_effects.ruleset
     default/default.lua
+    default/nation_intelligence_effects.ruleset
     default/nationlist.ruleset
     DESTINATION
     "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/default"

--- a/data/alien/effects.ruleset
+++ b/data/alien/effects.ruleset
@@ -13,7 +13,7 @@
 
 [datafile]
 description="Alien World effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -1152,3 +1152,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Upgrade Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/civ1/effects.ruleset
+++ b/data/civ1/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ1 effects data for Freeciv (approximate)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -1193,7 +1193,7 @@ reqs    =
     { "type", "name", "range"
       "Tech", "Flight", "Player"
     }
-    
+
 [effect_railroad_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -585
@@ -1512,3 +1512,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Recycle Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/civ2/effects.ruleset
+++ b/data/civ2/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2 effects data for Freeciv (incomplete)"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -2194,7 +2194,7 @@ reqs    =
     { "type", "name", "range"
       "Tech", "Flight", "Player"
     }
-    
+
 [effect_railroad_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -585
@@ -2218,11 +2218,11 @@ type	= "Trade_Revenue_Bonus"
 value	= 1585
 
 [effect_tithes_fundamentalism]
-type    = "Happiness_To_Gold" 
-value   = 1 
-reqs    = 
-    { "type", "name", "range" 
-      "Gov", "Fundamentalism", "Player" 
+type    = "Happiness_To_Gold"
+value   = 1
+reqs    =
+    { "type", "name", "range"
+      "Gov", "Fundamentalism", "Player"
     }
 
 ; This calendar is based on civ2 "King" level
@@ -2615,3 +2615,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Upgrade Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/civ2civ3/effects.ruleset
+++ b/data/civ2civ3/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Civ2Civ3 effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -1724,9 +1724,9 @@ reqs    =
     }
 
 [effect_tithes_fundamentalism]
-type    = "Happiness_To_Gold" 
-value   = 1 
-reqs    = 
+type    = "Happiness_To_Gold"
+value   = 1
+reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Fundamentalism", "Player", TRUE
     }
@@ -3898,7 +3898,7 @@ reqs	=
     { "type", "name", "range"
       "Building", "Women's Suffrage", "City"
     }
-;pow(2, value/1000) -> Base = 50% 
+;pow(2, value/1000) -> Base = 50%
 [effect_base_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -1000
@@ -4417,3 +4417,5 @@ reqs    =
 [effect_nuke_improvement_pct]
 type    = "Nuke_Improvement_Pct"
 value   = 100
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/classic/effects.ruleset
+++ b/data/classic/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Classic effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -2254,7 +2254,7 @@ reqs    =
     { "type", "name", "range"
       "Tech", "Flight", "Player"
     }
-    
+
 [effect_railroad_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -585
@@ -2670,3 +2670,5 @@ reqs    =
 [effect_nuke_improvement_pct]
 type    = "Nuke_Improvement_Pct"
 value   = 50
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/default/nation_intelligence_effects.ruleset
+++ b/data/default/nation_intelligence_effects.ruleset
@@ -1,0 +1,122 @@
+; This file contains the Nation_Intelligence effects used in most rulesets.
+; Include it in effects.ruleset with:
+;
+; *include default/nation_intelligence_effects.ruleset
+;
+; You'll also want to add the +Nation_Intelligence option to effects.ruleset.
+
+[effect_ni_multipliers_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Multipliers",  "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_wonders]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",     "range",  "present"
+      "NationalIntelligence", "Wonders",  "Player", TRUE
+    }
+
+[effect_ni_score_contact]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Score",        "Player", TRUE
+      "DiplRel",              "Has Contact",  "Local",  TRUE
+    }
+
+[effect_ni_score_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Score",        "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_gold_contact]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Gold",         "Player", TRUE
+      "DiplRel",              "Has Contact",  "Local",  TRUE
+    }
+
+[effect_ni_gold_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Gold",         "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_gov_contact]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Government",   "Player", TRUE
+      "DiplRel",              "Has Contact",  "Local",  TRUE
+    }
+
+[effect_ni_gov_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Government",   "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_diplomacy_contact]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Diplomacy",    "Player", TRUE
+      "DiplRel",              "Has Contact",  "Local",  TRUE
+    }
+
+[effect_ni_diplomacy_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Diplomacy",    "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_techs_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Techs",        "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_tax_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Tax Rates",    "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }
+
+[effect_ni_culture_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Culture",      "Player", TRUE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }

--- a/data/default/nation_intelligence_effects.ruleset
+++ b/data/default/nation_intelligence_effects.ruleset
@@ -1,7 +1,7 @@
 ; This file contains the Nation_Intelligence effects used in most rulesets.
 ; Include it in effects.ruleset with:
 ;
-; *include default/nation_intelligence_effects.ruleset
+; *include "default/nation_intelligence_effects.ruleset"
 ;
 ; You'll also want to add the +Nation_Intelligence option to effects.ruleset.
 

--- a/data/experimental/effects.ruleset
+++ b/data/experimental/effects.ruleset
@@ -14,7 +14,7 @@
 
 [datafile]
 description="Experimental effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -2497,7 +2497,7 @@ reqs    =
     { "type", "name", "range"
       "Tech", "Flight", "Player"
     }
-    
+
 [effect_railroad_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -585
@@ -3040,3 +3040,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Upgrade Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/granularity/effects.ruleset
+++ b/data/granularity/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Granularity effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -73,7 +73,7 @@ value   = 1
 [effect_tech_cost_base]
 type    = "Tech_Cost_Factor"
 value   = 1
-  	 
+
 ; Cities can always work tiles
 [effect_tile_workable]
 type    = "Tile_Workable"
@@ -210,3 +210,5 @@ reqs    =
     { "type", "name", "range"
       "Extra", "Irrigation", "Local"
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/multiplayer/effects.ruleset
+++ b/data/multiplayer/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Multiplayer effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -2289,11 +2289,11 @@ reqs    =
     }
 
 [effect_tithes_fundamentalism]
-type    = "Happiness_To_Gold" 
-value   = 1 
-reqs    = 
-    { "type", "name", "range" 
-      "Gov", "Fundamentalism", "Player" 
+type    = "Happiness_To_Gold"
+value   = 1
+reqs    =
+    { "type", "name", "range"
+      "Gov", "Fundamentalism", "Player"
     }
 
 [effect_max_rates_fundamentalism]
@@ -2711,3 +2711,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Upgrade Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -581,8 +581,8 @@ reqs    =
       "Gov", "Federation", "Player", TRUE
       "OutputType", "Trade", "Local", FALSE
     }
-	
-	
+
+
 ; federation gets 100% boost for science
 [effect_bonus_sci_federation]
 type    = "Output_Bonus_2"
@@ -592,8 +592,8 @@ reqs    =
       "Gov", "Federation", "Player"
       "OutputType", "Science", "Local"
     }
-	
-	
+
+
 ; Corruption and Waste
 ; Note: no autohelptexts for these!
 ;
@@ -917,9 +917,9 @@ reqs   =
 ;      "Gov", "Republic", "Player", FALSE
 ;      "Gov", "Democracy", "Player", FALSE
     }
-	
-	
-; Doubled for city size >= 9 - democracy will not get an extra unit at any size 
+
+
+; Doubled for city size >= 9 - democracy will not get an extra unit at any size
 [effect_upkeep_free_mil_city_1]
 type    = "Make_Content_Mil"
 value   = 1
@@ -936,7 +936,7 @@ reqs    =
 ;      "Gov", "Republic", "Player", FALSE
       "Gov", "Democracy", "Player", FALSE
     }
-	
+
 
 
 ; Govs with 2 free units (exclusive with previous)
@@ -955,8 +955,8 @@ reqs   =
       "Gov", "Republic", "Player", FALSE
       "Gov", "Democracy", "Player", FALSE
     }
-	
-	
+
+
 ; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_2]
 type    = "Make_Content_Mil"
@@ -991,8 +991,8 @@ reqs   =
       "Gov", "Republic", "Player", FALSE
       "Gov", "Democracy", "Player", FALSE
     }
-	
-	
+
+
 
 ; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_3]
@@ -1664,8 +1664,8 @@ reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Communism", "Player", TRUE
     }
-	
-	
+
+
 [effect_martial_law_max_despotism]
 type    = "Martial_Law_Max"
 value   = 20
@@ -1872,9 +1872,9 @@ reqs    =
     }
 
 [effect_tithes_fundamentalism]
-type    = "Happiness_To_Gold" 
-value   = 1 
-reqs    = 
+type    = "Happiness_To_Gold"
+value   = 1
+reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Fundamentalism", "Player", TRUE
     }
@@ -2032,7 +2032,7 @@ reqs    =
       "Building", "Bank", "City"
       "OutputType", "Luxury", "Local"
     }
-	
+
 [effect_mercantile_exchange_1]
 type    = "Output_Bonus"
 value   = 30
@@ -2954,8 +2954,8 @@ reqs    =
       "DiplRel", "Foreign", "Local", TRUE
       "DiplRel", "Team", "Local", FALSE
     }
-	
-	
+
+
 [effect_sdi_i_defense_2]
 type    = "Nuke_Proof"
 value   = 70
@@ -2974,8 +2974,8 @@ reqs    =
       "Building", "SDI Defense I", "City"
       "UnitClass", "Missile", "Local"
     }
-	
-	
+
+
 [effect_sdi_i_defense_4]
 type    = "Defend_Bonus"
 value   = 70
@@ -2985,9 +2985,9 @@ reqs    =
 	  "Building", "Palace", "City"
       "UnitClass", "Missile", "Local"
     }
-	
 
-	
+
+
 [effect_sdi_ii_defense_1]
 type    = "Nuke_Proof"
 value   = 30
@@ -2998,7 +2998,7 @@ reqs    =
       "DiplRel", "Foreign", "Local", TRUE
       "DiplRel", "Team", "Local", FALSE
     }
-	
+
 
 [effect_sdi_ii_defense_2]
 type    = "Defend_Bonus"
@@ -3009,8 +3009,8 @@ reqs    =
       "Building", "Palace", "City", FALSE
       "UnitClass", "Missile", "Local", TRUE
     }
-	
-	
+
+
 [effect_sdi_iii_defense_1]
 type    = "Nuke_Proof"
 value   = 30
@@ -3021,7 +3021,7 @@ reqs    =
       "DiplRel", "Foreign", "Local", TRUE
       "DiplRel", "Team", "Local", FALSE
     }
-	
+
 
 [effect_sdi_iii_defense_2]
 type    = "Defend_Bonus"
@@ -3032,7 +3032,7 @@ reqs    =
       "Building", "Palace", "City", FALSE
       "UnitClass", "Missile", "Local", TRUE
     }
-	
+
 
 
 [effect_sewer_system]
@@ -4104,9 +4104,9 @@ reqs	=
     { "type", "name", "range"
       "Building", "United Nations", "City"
     }
-	
-	
-;pow(2, value/1000) -> Base = 50% 
+
+
+;pow(2, value/1000) -> Base = 50%
 [effect_base_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -1000

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Royale effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -4744,3 +4744,5 @@ reqs    =
 ; [effect_conquest_tech]
 ; type    = "Conquest_Tech_Pct"
 ; value   = 0
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/data/royale/effects.ruleset
+++ b/data/royale/effects.ruleset
@@ -4745,4 +4745,25 @@ reqs    =
 ; type    = "Conquest_Tech_Pct"
 ; value   = 0
 
-*include "default/nation_intelligence_effects.ruleset"
+; Having contact with another player lets one see their score.
+[effect_ni_score_contact]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Score",        "Player", TRUE
+      "DiplRel",              "Has Contact",  "Local",  TRUE
+    }
+
+; Having an embassy lets one see almost everything. In fact, the things we
+; disable are not even shown in the client.
+[effect_ni_any_embassy]
+type  = "Nation_Intelligence"
+value = 1
+reqs  =
+    { "type",                 "name",         "range",  "present"
+      "NationalIntelligence", "Mood",         "Player", FALSE
+      "NationalIntelligence", "History",      "Player", FALSE
+      "NationalIntelligence", "Infra Points", "Player", FALSE
+      "DiplRel",              "Has embassy",  "Local",  TRUE
+    }

--- a/data/sandbox/effects.ruleset
+++ b/data/sandbox/effects.ruleset
@@ -11,7 +11,7 @@
 
 [datafile]
 description="Sandbox effects data for Freeciv"
-options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer"
+options="+Freeciv-ruleset-Devel-2017.Jan.02 +HP_Regen_Min +Bombard_Limit_Pct +Vision_Layer +Nation_Intelligence"
 format_version=20
 
 ; /* <-- avoid gettext warnings
@@ -1758,9 +1758,9 @@ reqs    =
     }
 
 [effect_tithes_fundamentalism]
-type    = "Happiness_To_Gold" 
-value   = 1 
-reqs    = 
+type    = "Happiness_To_Gold"
+value   = 1
+reqs    =
     { "type", "name", "range", "quiet"
       "Gov", "Fundamentalism", "Player", TRUE
     }
@@ -3938,7 +3938,7 @@ reqs	=
     { "type", "name", "range"
       "Building", "Women's Suffrage", "City"
     }
-;pow(2, value/1000) -> Base = 50% 
+;pow(2, value/1000) -> Base = 50%
 [effect_base_trade_revenue_reduce]
 type    = "Trade_Revenue_Bonus"
 value   = -1000
@@ -4557,3 +4557,5 @@ reqs    =
     { "type",   "name",         "range", "present"
       "Action", "Upgrade Unit", "Local", TRUE
     }
+
+*include "default/nation_intelligence_effects.ruleset"

--- a/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
+++ b/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
@@ -12,7 +12,7 @@ Nation_Intelligence
     Add the ``+Nation_Intelligence`` option to ``effects.ruleset``.
 
 The ``Nation_Intelligence`` effect controls what kind of information about a
-foreign nation is visible in the players report. A value of ``0`` or lower hides
+foreign nation is visible in the Nations View. A value of ``0`` or lower hides
 the information, while it becomes visible when the effect evaluates to ``1`` or
 bigger. For instance, the following effect repurposes the
 :wonder:`United Nations` to reveal everyone's secrets to everone else:

--- a/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
+++ b/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
@@ -1,0 +1,94 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+
+.. Custom Interpretive Text Roles for longturn.net/Freeciv21
+.. role:: wonder
+
+Nation_Intelligence
+*******************
+
+.. versionadded:: 3.0
+    Add the ``+Nation_Intelligence`` option to ``effects.ruleset``.
+
+The ``Nation_Intelligence`` effect controls what kind of information about a
+foreign nation is visible in the players report. A value of ``0`` or lower hides
+the information, while it becomes visible when the effect evaluates to ``1`` or
+bigger. For instance, the following effect repurposes the
+:wonder:`United Nations` to reveal everyone's secrets to everone else:
+
+.. code-block:: ini
+
+    [effect_united_nations_intelligence]
+    type  = "Nation_Intelligence"
+    value = 1
+    reqs  =
+        { "type",     "name",           "range",  "present"
+          "Building", "United Nations", "World",  TRUE
+        }
+
+The true power of ``Nation_Intelligence``, however, comes from its combined use
+with ``NationalIntelligence`` requirements. ``NationalIntelligence`` lets you
+select precisely what is visible to a player. Let us say that we want a player
+owning the :wonder:`Marco Polo Embassy` to know the wonders built by any other
+player it has ever met. This could be achieved as follows:
+
+.. code-block:: ini
+
+    [effect_marco_polo_intelligence]
+    type  = "Nation_Intelligence"
+    value = 1
+    reqs  =
+        { "type",                 "name",                 "range",  "present"
+          "NationalIntelligence", "Wonders",              "Local",  TRUE
+          "Building",             "Marco Polo's Embassy", "Player", TRUE
+          "DiplRel",              "Never met",            "Local",  FALSE
+        }
+
+It is important to note that the effect works from the point of view of the
+player who *sees* the information. It cannot depend on what the other player
+does (except when using ``DiplRel`` requirements).
+
+.. note::
+    Note the ``Local`` range used in the ``DiplRel`` requirement above. This is
+    very important: if we had used ``Player``, the effect would be enabled only
+    once the player has met every other player in the game (no player satisfies
+    ``Never met``).
+
+The possible values for ``NationalIntelligence`` requirements are as follows:
+
+================ ===
+``Culture``      The amount of culture accumulated by a player. Not yet shown in
+                 the user interface.
+``Diplomacy``    Diplomatic agreements such as Peace, Alliance, and shared
+                 vision.
+``Infra Points`` Infrastructure points. Not yet shown in the user interface.
+``Gold``         The amount of gold in the treasury.
+``Government``   The other player's government.
+``History``      The history accumulated by a player. Not yet shown in the user
+                 interface.
+``Multipliers``  The value of multipliers selected by the other player. Not yet
+                 shown in the user interface.
+``Mood``         For an AI player, whether it is currently farming or building
+                 up an army. Not yet shown in the user interface.
+``Score``        The game score.
+``Tax Rates``    The rates of gold, science and luxury in the national budget.
+``Techs``        The techs discovered by a player as well as the current
+                 research.
+``Wonders``      The list of wonders owned by the player (see also the
+                 ``Wonder_Visible`` effect).
+================ ===
+
+Compatibility
+=============
+
+For legacy rulesets, the traditional rules are added automatically if the
+``Nation_Intelligence`` option is not requested in ``effects.ruleset``. They are
+rather complicated; to facilitate porting rulesets, we provide a ready-made file
+implementing them. It can be imported directly from within ``effects.ruleset``:
+
+.. code-block:: ini
+
+    *include "default/nation_intelligence_effects.ruleset"
+
+Most shipped rulesets use this technique.

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -47,58 +47,59 @@ on the game rules.
 Requirement types and supported ranges
 ======================================
 
-==================== ================
-Requirement          Supported ranges
-==================== ================
-``Tech``             ``World``, ``Alliance``, ``Team``, ``Player``
-``TechFlag``         ``World``, ``Alliance``, ``Team``, ``Player``
-``MinTechs``         ``World``, ``Player``
-``Achievement``      ``World``, ``Alliance``, ``Team``, ``Player``
-``Gov``              ``Player``
-``Building``         ``World``, ``Alliance``, ``Team``, ``Player``, ``Continent``, ``Traderoute``, ``City``, ``Local``
-``BuildingGenus``    ``Local``
-``Extra``            ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``BaseFlag``         ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``RoadFlag``         ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``ExtraFlag``        ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``Terrain``          ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``Good``             ``City``
-``UnitType``         ``Local``
-``UnitFlag``         ``Local``
-``UnitClass``        ``Local``
-``UnitClassFlag``    ``Local``
-``Nation``           ``World``, ``Alliance``, ``Team``, ``Player``
-``NationGroup``      ``World``, ``Alliance``, ``Team``, ``Player``
-``Nationality``      ``Traderoute``, ``City``
-``DiplRel``          ``World``, ``Alliance``, ``Team``, ``Player``, ``Local``
-``Action``           ``Local``
-``OutputType``       ``Local``
-``Specialist``       ``Local``
-``MinYear``          ``World``
-``MinCalFrag``       ``World``
-``Topology``         ``World``
-``ServerSetting``    ``World``
-``Age`` (of unit)    ``Local``
-``Age`` (of city)    ``City``
-``Age`` (of player)  ``Player``
-``MinSize``          ``Traderoute``, ``City``
-``MinCulture``       ``World``, ``Alliance``, ``Team``, ``Player``, ``Traderoute``, ``City``
-``MinForeignPct``    ``Traderoute``, ``City``
-``AI``               ``Player``
-``MaxUnitsOnTile``   ``Local``, ``Adjacent``, ``CAdjacent``
-``TerrainClass``     ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``TerrainFlag``      ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
-``TerrainAlter``     ``Local``
-``CityTile``         ``Local``, ``Adjacent``, ``CAdjacent``
-``CityStatus``       ``Traderoute``, ``City``
-``Style``            ``Player``
-``UnitState``        ``Local``
-``Activity``         ``Local``
-``MinMoveFrags``     ``Local``
-``MinVeteran``       ``Local``
-``MinHitPoints``     ``Local``
-``VisionLayer``      ``Local``
-==================== ================
+======================== ================
+Requirement              Supported ranges
+======================== ================
+``Tech``                 ``World``, ``Alliance``, ``Team``, ``Player``
+``TechFlag``             ``World``, ``Alliance``, ``Team``, ``Player``
+``MinTechs``             ``World``, ``Player``
+``Achievement``          ``World``, ``Alliance``, ``Team``, ``Player``
+``Gov``                  ``Player``
+``Building``             ``World``, ``Alliance``, ``Team``, ``Player``, ``Continent``, ``Traderoute``, ``City``, ``Local``
+``BuildingGenus``        ``Local``
+``Extra``                ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``BaseFlag``             ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``RoadFlag``             ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``ExtraFlag``            ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``Terrain``              ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``Good``                 ``City``
+``UnitType``             ``Local``
+``UnitFlag``             ``Local``
+``UnitClass``            ``Local``
+``UnitClassFlag``        ``Local``
+``Nation``               ``World``, ``Alliance``, ``Team``, ``Player``
+``NationGroup``          ``World``, ``Alliance``, ``Team``, ``Player``
+``Nationality``          ``Traderoute``, ``City``
+``DiplRel``              ``World``, ``Alliance``, ``Team``, ``Player``, ``Local``
+``Action``               ``Local``
+``OutputType``           ``Local``
+``Specialist``           ``Local``
+``MinYear``              ``World``
+``MinCalFrag``           ``World``
+``Topology``             ``World``
+``ServerSetting``        ``World``
+``Age`` (of unit)        ``Local``
+``Age`` (of city)        ``City``
+``Age`` (of player)      ``Player``
+``MinSize``              ``Traderoute``, ``City``
+``MinCulture``           ``World``, ``Alliance``, ``Team``, ``Player``, ``Traderoute``, ``City``
+``MinForeignPct``        ``Traderoute``, ``City``
+``AI``                   ``Player``
+``MaxUnitsOnTile``       ``Local``, ``Adjacent``, ``CAdjacent``
+``TerrainClass``         ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``TerrainFlag``          ``Local``, ``Adjacent``, ``CAdjacent``, ``Traderoute``, ``City``
+``TerrainAlter``         ``Local``
+``CityTile``             ``Local``, ``Adjacent``, ``CAdjacent``
+``CityStatus``           ``Traderoute``, ``City``
+``Style``                ``Player``
+``UnitState``            ``Local``
+``Activity``             ``Local``
+``MinMoveFrags``         ``Local``
+``MinVeteran``           ``Local``
+``MinHitPoints``         ``Local``
+``VisionLayer``          ``Local``
+``NationalIntelligence`` ``Local``
+======================== ================
 
 * MinSize is the minimum size of a city required.
 * AI is ai player difficulty level.
@@ -194,6 +195,11 @@ MovedThisTurn
 
 HasHomeCity
     is fulfilled if the unit has a home city.
+
+The NationalIntelligence requirement type
+-----------------------------------------
+
+This is only used with the :doc:`Nation_Intelligence effect <Effects/Nation_Intelligence>`.
 
 Effect types
 ------------
@@ -720,3 +726,12 @@ Wonder_Visible
         This effect is added automatically with a value of 1 for great wonders (since they are shown in the
         wonders report anyway). This behavior can be turned off by requiring the ``+Wonder_Visible`` option
         in ``effects.ruleset``.
+
+Nation_Intelligence
+    Controls the information available in the players report. :doc:`See the
+    detailed description. <Effects/Nation_Intelligence>`
+
+    .. toctree::
+        :hidden:
+
+        Effects/Nation_Intelligence

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -728,7 +728,7 @@ Wonder_Visible
         in ``effects.ruleset``.
 
 Nation_Intelligence
-    Controls the information available in the players report. :doc:`See the
+    Controls the information available in the Nations View. :doc:`See the
     detailed description. <Effects/Nation_Intelligence>`
 
     .. toctree::

--- a/docs/Modding/Rulesets/index.rst
+++ b/docs/Modding/Rulesets/index.rst
@@ -1,0 +1,21 @@
+Editing Rulesets
+****************
+
+Rulsets are a collection of plain text files that are formatted in a particular way in order to create the
+rules of a Freeciv21 game. Rulesets are broken down into the following categories:
+
+* Buildings
+* Cities
+* Effects
+* Game
+* Governments
+* Nations
+* Styles
+* Technology Tree
+* Terrain
+* Units
+
+.. toctree::
+  effects.rst
+  :maxdepth: 1
+

--- a/docs/Modding/Tilesets/units.rst
+++ b/docs/Modding/Tilesets/units.rst
@@ -1,0 +1,53 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 1999-2021 Freeciv and Freeciv21 contributors
+    SPDX-FileCopyrightText: 2022 louis94 <m_louis30@yahoo.com>
+
+Units
+*****
+
+In addition to the unit sprite itself, the following are drawn:
+
+* For selected units, an animated selection indicator is displayed underneath the unit. Optionally, the selected units
+  can blink instead. `select_offset_x` and `select_offset_y`
+* The unit flag is also drawn under the unit picture (unless Freeciv21 is configured to display a solid color behind
+  units, in which case that color is shown instead). `unit_flag_offset_x`, `unit_flag_offset_y`
+* Then, the sprite for the unit type is added. It can depend on the unit orientation. `unit_offset_x`, `unit_offset_y`
+* Loaded transports are marked as such
+* A sprite is added to represent the unit activity. `activity_offset_x`, `activity_offset_y`
+* Units on autosettler and autoexplorer commands are tagged. `activity_offset_x`, `activity_offset_y` for autoexplore
+* The patrol indicator is added for units with repeating orders, or the "connect" indicator for units with this kind of
+  orders, or the "G" sprite for units on goto (with `activity_offset_x`, `activity_offset_y`).
+* Units awaiting a decision by the players are marked with a question mark sprite. `activity_offset_x` and
+  `activity_offset_y`
+* The battlegroup sprite is added.
+* Low fuel
+* Tired
+* The "plus" symbol is added for stacked units and loaded transports
+* Veterancy
+* HP
+
+Unless mentioned otherwise, the sprites are drawn like "full sprites".
+
+Unit Sprites
+------------
+
+Units sprites can be either unoriented or oriented, in which case the sprite that is displayed depends on the
+direction the unit is facing (it turns when it moves or fights).
+
+Unoriented sprites are specified as :code:`u.phalanx`. Oriented sprites have a direction suffix:
+:code:`u.phalanx_s`, :code:`u.phalanx_nw` and so on. For each unit type, either an unoriented sprite or a full
+set of the oriented sprites needed for the tileset topology must be provided (you can also provide both, see
+below).
+
+The game sometimes needs to draw a sprite for a unit type that doesn't correspond to a specific unit, so is
+not facing a particular direction. There are several options for oriented tilesets:
+
+* If the :code:`unit_default_orientation` is specified for the tileset, the game will by default use that directional
+  sprite. (The direction doesn't have to be a valid one for the tileset.)
+
+* Specific unit types may override this by providing an unoriented sprite as well as the oriented ones; this
+  doesn't have to be distinct, so it can point to one of the oriented sprites, allowing choice of the best
+  orientation for each individual unit type. If unit_default_orientation is not specified, an unoriented sprite
+  must be specified for *every* unit.
+

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -1754,6 +1754,7 @@ static bool worklist_item_postpone_req_vec(struct universal *target,
       case VUT_CITYTILE:
       case VUT_CITYSTATUS:
       case VUT_VISIONLAYER:
+      case VUT_NINTEL:
         // Will only happen with a bogus ruleset.
         qCritical("worklist_change_build_target() has bogus preq");
         break;

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -1156,7 +1156,7 @@ static void package_player_info(struct player *plr,
 
   // Teamed players always share their information -- it's in their best
   // interest to communicate anyway.
-  if (players_on_same_team(plr, receiver)) {
+  if (receiver && players_on_same_team(plr, receiver)) {
     send_all = true;
   }
 
@@ -1171,16 +1171,16 @@ static void package_player_info(struct player *plr,
 
     // Players on a team share the intelligence they gather -- it's in their
     // best interest to communicate anyway.
-    players_iterate(aplayer)
+    const auto team = team_members(plr->team);
+    player_list_iterate(team, team_mate)
     {
-      if (players_on_same_team(receiver, aplayer)
-          && get_player_intel_bonus(aplayer, plr, nintel,
-                                    EFT_NATION_INTELLIGENCE)
-                 > 0) {
+      if (get_player_intel_bonus(team_mate, plr, nintel,
+                                 EFT_NATION_INTELLIGENCE)
+          > 0) {
         return true;
       }
     }
-    players_iterate_end;
+    player_list_iterate_end;
 
     return false;
   };
@@ -1309,8 +1309,7 @@ static void package_player_info(struct player *plr,
     }
   }
 
-  // Separate from tech because it gives more information
-  if (visible(NI_TECH_UPKEEP)) {
+  if (visible(NI_TECHS)) {
     packet->tech_upkeep = player_tech_upkeep(plr);
   } else {
     packet->tech_upkeep = 0;

--- a/server/plrhand.h
+++ b/server/plrhand.h
@@ -20,8 +20,6 @@ struct rgbcolor;
 struct section_file;
 struct unit_list;
 
-enum plr_info_level { INFO_MINIMUM, INFO_MEETING, INFO_EMBASSY, INFO_FULL };
-
 struct player *server_create_player(int player_id, const char *ai_tname,
                                     struct rgbcolor *prgbcolor,
                                     bool allow_ai_type_fallbacking);

--- a/server/rssanity.cpp
+++ b/server/rssanity.cpp
@@ -304,6 +304,7 @@ static bool sanity_check_req_set(int reqs_of_type[],
     case VUT_IMPR_GENUS:
     case VUT_CITYSTATUS:
     case VUT_VISIONLAYER:
+    case VUT_NINTEL:
       /* There can be only one requirement of these types (with current
        * range limitations)
        * Requirements might be identical, but we consider multiple

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -18,10 +18,11 @@
 #define CAP_EFT_BOMBARD_LIMIT_PCT "Bombard_Limit_Pct"
 #define CAP_EFT_WONDER_VISIBLE "Wonder_Visible"
 #define CAP_VUT_VISIONLAYER "Vision_Layer"
+#define CAP_EFT_NATION_INTELLIGENCE "Nation_Intelligence"
 #define RULESET_CAPABILITIES                                                \
   "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN                \
   " " CAP_EFT_BOMBARD_LIMIT_PCT " " CAP_EFT_WONDER_VISIBLE                  \
-  " " CAP_VUT_VISIONLAYER
+  " " CAP_VUT_VISIONLAYER " " CAP_EFT_NATION_INTELLIGENCE
 /*
  * Ruleset capabilities acceptable to this program:
  *

--- a/tools/ruledit/univ_value.cpp
+++ b/tools/ruledit/univ_value.cpp
@@ -214,6 +214,9 @@ bool universal_value_initial(struct universal *src)
   case VUT_VISIONLAYER:
     src->value.vlayer = V_MAIN;
     return true;
+  case VUT_NINTEL:
+    src->value.nintel = NI_CULTURE; // We like culture
+    return true;
   case VUT_COUNT:
     fc_assert(src->kind != VUT_COUNT);
     return false;
@@ -466,6 +469,12 @@ void universal_kind_values(struct universal *univ, univ_kind_values_cb cb,
   case VUT_VISIONLAYER:
     for (i = 0; i < V_COUNT; i++) {
       cb(vision_layer_name(vision_layer(i)), univ->value.vlayer == i, data);
+    }
+    break;
+  case VUT_NINTEL:
+    for (i = 0; i < NI_COUNT; i++) {
+      cb(national_intelligence_name(static_cast<national_intelligence>(i)),
+         univ->value.nintel == i, data);
     }
     break;
   case VUT_MINSIZE:

--- a/utility/fc_version.h.in
+++ b/utility/fc_version.h.in
@@ -16,7 +16,8 @@
 # endif
 #endif
 
-#define NETWORK_CAPSTRING "+Freeciv21.21April13 killunhomed-is-game-info"
+#define NETWORK_CAPSTRING                                                   \
+  "+Freeciv21.21April13 killunhomed-is-game-info player-intel-visibility"
 
 #ifndef FOLLOWTAG
 #define FOLLOWTAG "S_HAXXOR"


### PR DESCRIPTION
Second part of #1154, giving fine-grained control over what is shown in the players dialog with effects. Was a *little* more difficult than I thought...

~Documentation is still TODO but I'd appreciate functional and code reviews already.~ See the changes at the end of Royale to get an idea of what is (should be) possible.

Some ideas for testing:
* Add a wonder giving limited info about everyone (e.g. just the score or the gov)
* Or a player researching a tech could give embassy-like info to everyone
* Or alliance without embassy could give away some info as well
* Check that teams share their intel, and observers get the right info

Closes #1154.
Closes #320.