### PR TITLE
Amplio2 Units compatibility fix

### DIFF
--- a/data/amplio2/units.spec
+++ b/data/amplio2/units.spec
@@ -1,0 +1,9 @@
+[spec]
+
+; Format and options of this spec file:
+options = "+Freeciv-spec-Devel-2019-Jul-03"
+
+[info]
+
+; compatability - units moved to misc.
+*include "misc/units.spec"

--- a/docs/Modding/Rulesets/nations.rst
+++ b/docs/Modding/Rulesets/nations.rst
@@ -1,3 +1,8 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 2021 louis94 <m_louis30@yahoo.com>
+    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+
 Nation Sets and Flags
 *********************
 
@@ -145,16 +150,16 @@ Flag Specifics
 
 To add a flag you'll have to edit the following files:
 
-* :file:`data/flags/<flagname>.svg`
+* :file:`data/tilesets/flags/<flagname>.svg`
 
 Here is the SVG flag image. This is not used directly by Freeciv21 but is  rendered into PNG files (at various
 resolutions for different tilesets). The SVG file is not used in Freeciv21, but all the other steps for adding
 flags are the same. The :code:`<flagname>` should either be the name of the country that represents the flag,
 or the common name for the actual flag. When in doubt, use the same name as the name of the nation.
 
-* :file:`data/flags/<flagname>.png`
+* :file:`data/tilesets/flags/<flagname>.png`
 
-* :file:`data/flags/<flagname>-shield.png`
+* :file:`data/tilesets/flags/<flagname>-shield.png`
 
 These are the flag images that are used by Freeciv21. They are rendered from the SVG file. Once this file has
 been created it can be used with older versions of Freeciv21 as well. To run the conversion program you will

--- a/docs/Modding/Tilesets/ts-breaking-changes.rst
+++ b/docs/Modding/Tilesets/ts-breaking-changes.rst
@@ -1,0 +1,21 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+
+Tileset Breaking Changes
+************************
+
+This page lists in reverse chronilogical order breaking changes merged into the ``master`` branch of the
+GitHub repository to aid Tileset modders keep thier tilesets up to date.
+
+Post Beta.4 before Beta.5
+=========================
+
+* Removed the need for ``main_intro_file`` for all :file:`*.tilespec` files. Tileset modders no longer need to
+  include this tag in their tilesets.
+* Wonder sprites removed from :file:`data/misc/buildings.spec` and moved into :file:`data/misc/wonders.spec`.
+  Tileset modders will need to include a new file to get the small wonder sprites.
+* Removed :file:`data/amplio2/units.spec`. Consolidated all unit sprites into :file:`data/misc/units.spec`.
+  Tileset modders utilizing the Amplio2 unit sprites will want to instead use the new ``units.spec`` file. It
+  is the new home of the Amplio style units utilized by the Tier 1 tilesets in Freeciv21: Amplio2 and
+  Hexemplio.

--- a/docs/Modding/index.rst
+++ b/docs/Modding/index.rst
@@ -81,6 +81,7 @@ guides document specific aspects of tileset creation:
   Tilesets/terrain.rst
   Tilesets/debugger.rst
   Tilesets/compatibility.rst
+  Tilesets/ts-breaking-changes.rst
   Rulesets/nations.rst
   :maxdepth: 1
 


### PR DESCRIPTION
Add a compatibility file for tilesets relying on Amplio2 `units.spec`. Also documents breaking changes.

Closes #1429 