### PR TITLE
Add a message reminding to close-open the AutoRevision PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,10 @@ jobs:
           commit-message: "Release update of AutoRevision.txt"
           branch: "release/autorevision"
           title: "Release update of AutoRevision.txt"
-          body: "Automatic changes triggered by a new release"
+          body: >
+            Automatic changes triggered by a new release.
+
+            Close and reopen this pull request to start the CI.
           delete-branch: true
   update-archive:
     name: "Update Source Archive"


### PR DESCRIPTION
While it's being added to the documentation, our actions will be more understandable if described in the PRs themselves. And it's also a useful reminder to avoid checking the docs in the first place.

See #1427 and #1435.