### PR TITLE
Make nukes destroy infrastructure

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -576,6 +576,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_UNIT_SHIELD_VALUE_PCT:
   case EFT_WONDER_VISIBLE:
   case EFT_NATION_INTELLIGENCE:
+  case EFT_NUKE_INFRASTRUCTURE_PCT:
     break;
     // This has no effect for AI
   case EFT_VISIBLE_WALLS:

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1108,6 +1108,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_MAPS_STOLEN_PCT:
   case EFT_UNIT_SHIELD_VALUE_PCT:
   case EFT_BOMBARD_LIMIT_PCT:
+  case EFT_NUKE_INFRASTRUCTURE_PCT:
     // TRANS: per cent
     return QString(PL_("%1%", "%1%", value)).arg(value);
   case EFT_MAX_STOLEN_GOLD_PM:

--- a/common/effects.h
+++ b/common/effects.h
@@ -311,6 +311,8 @@
 #define SPECENUM_VALUE132NAME "Wonder_Visible"
 #define SPECENUM_VALUE133 EFT_NATION_INTELLIGENCE
 #define SPECENUM_VALUE133NAME "Nation_Intelligence"
+#define SPECENUM_VALUE134 EFT_NUKE_INFRASTRUCTURE_PCT
+#define SPECENUM_VALUE134NAME "Nuke_Infrastructure_Pct"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -666,6 +666,13 @@ Nuke_Improvement_Pct
     Only regular improvements (not wonders) are affected. Improvements protected from Sabotage (Eg: City Walls)
     aren't affected.
 
+Nuke_Infrastructure_Pct
+    Percentage chance that an extra located within a nuclear blast area gets destroyed.
+    Only "Infra" extras such as roads and irrigation are affected, and rmreqs are also checked.
+
+    Note that an `Extra` requirement will match any extra on the tile, not only the one
+    considered for destruction.
+
 Shield2Gold_Factor
     Factor in percent for the conversion of unit shield upkeep to gold upkeep. A value of 200 would transfer
     1 shield upkeep to 2 gold upkeep. The range of this effect must be player or world. Note that only units


### PR DESCRIPTION
Add an effect Nuke_Infrastructure_Pct that allows the destruction of extras located within the blast area of nuclear weapons. Destroying infrastructure makes large-scale nuclear warfare more difficult because roads and rails need be rebuilt before tanks can ride them again to reach the next city.

This is a rewrite of 8691fa8e38c56c6fa066c77aadf1eab1df5e620b in the 2.6 LT repo. Extras of category "Infra" can potentially be destroyed in nuclear blasts, with an effect-configurable chance. Contrary to the original commit, hidden extras can be blasted away just like they can be (target-)pillaged; this can be prevented with suitable rmreqs.

See #1155.

**Test Plan**

Add the following to your fav ruleset and drop a nuke:
```ini
[effect_nuke_infrastructure_pct]
type    = "Nuke_Infrastructure_Pct"
value   = 50
```
About half of the extras within the 3x3 blast radius should be gone (unless SDI went in action).