### PR TITLE
Support Libertinus as a Libertine alternative

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -74,6 +74,7 @@
 #include "connectdlg_common.h" // client_kill_server()
 #include "control.h"
 #include "editor.h"
+#include "fonts.h"
 #include "global_worklist.h"
 #include "governor.h"
 #include "mapview_common.h"
@@ -532,6 +533,7 @@ int client_main(int argc, char *argv[])
   init_themes();
 
   options_init();
+  configure_fonts();
   options_load();
 
   script_client_init();

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -19,6 +19,10 @@
 #include "gui_main.h"
 #include "options.h"
 
+static void configure_font(const QString &font_name, const QStringList &sl,
+                           QFont::StyleHint hint, int size,
+                           bool bold = false);
+
 /**
    Font provider constructor
  */
@@ -81,12 +85,9 @@ void fcFont::initFonts()
   options_iterate(client_optset, poption)
   {
     if (option_type(poption) == OT_FONT) {
-      auto f = QFont();
-      auto s = option_font_get(poption);
-      if (f.fromString(s)) {
-        s = option_name(poption);
-        setFont(s, f);
-      }
+      auto f = option_font_get(poption);
+      auto s = option_name(poption);
+      setFont(s, f);
     }
   }
   options_iterate_end;
@@ -100,13 +101,10 @@ void fcFont::setSizeAll(int new_size)
   options_iterate(client_optset, poption)
   {
     if (option_type(poption) == OT_FONT) {
-      QFont font;
-      font.fromString(option_font_get(poption));
+      auto font = option_font_get(poption);
       int old_size = font.pointSize();
       font.setPointSize(old_size + (new_size * old_size) / 100);
-      QString s = font.toString();
-      QByteArray ba = s.toLocal8Bit();
-      option_font_set(poption, ba.data());
+      option_font_set(poption, font);
       gui_qt_apply_font(poption);
     }
   }
@@ -162,9 +160,8 @@ void load_fonts()
 void configure_fonts()
 {
   QStringList sl;
-  QFont font;
 
-  const int max = 16;
+  const int large_size = 16;
   const int default_size = 12;
 
   if (!isFontInstalled(QStringLiteral("Libertinus Sans"))
@@ -177,28 +174,13 @@ void configure_fonts()
      << QStringLiteral("Linux Biolinum O")
      << QStringLiteral("Linux Biolinum");
 
-  font = configure_font(fonts::default_font, sl, QFont::SansSerif, max);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_default,
-               qUtf8Printable(font.toString()), 512);
-  }
-  font = configure_font(fonts::notify_label, sl, QFont::SansSerif,
-                        default_size);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_notify_label,
-               qUtf8Printable(font.toString()), 512);
-  }
-  font = configure_font(fonts::city_names, sl, QFont::SansSerif, max, true);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_city_names,
-               qUtf8Printable(font.toString()), 512);
-  }
-  font = configure_font(fonts::city_productions, sl, QFont::SansSerif,
-                        default_size, true);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_city_productions,
-               qUtf8Printable(font.toString()), 512);
-  }
+  configure_font(fonts::default_font, sl, QFont::SansSerif, default_size);
+
+  configure_font(fonts::notify_label, sl, QFont::SansSerif, default_size);
+  configure_font(fonts::city_names, sl, QFont::SansSerif, default_size,
+                 true);
+  configure_font(fonts::city_productions, sl, QFont::SansSerif,
+                 default_size);
 
   /* Monospace List */
   sl.clear();
@@ -206,23 +188,9 @@ void configure_fonts()
      << QStringLiteral("Linux Libertine Mono O")
      << QStringLiteral("Linux Libertine Mono");
 
-  font =
-      configure_font(fonts::help_label, sl, QFont::Monospace, default_size);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_help_label,
-               qUtf8Printable(font.toString()), 512);
-  }
-  font =
-      configure_font(fonts::help_text, sl, QFont::Monospace, default_size);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_help_text,
-               qUtf8Printable(font.toString()), 512);
-  }
-  font = configure_font(fonts::chatline, sl, QFont::Monospace, default_size);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_chatline,
-               qUtf8Printable(font.toString()), 512);
-  }
+  configure_font(fonts::help_label, sl, QFont::Monospace, default_size);
+  configure_font(fonts::help_text, sl, QFont::Monospace, default_size);
+  configure_font(fonts::chatline, sl, QFont::Monospace, default_size);
 
   /* Serif List */
   sl.clear();
@@ -230,33 +198,34 @@ void configure_fonts()
      << QStringLiteral("Linux Libertine Display O")
      << QStringLiteral("Linux Libertine Display");
 
-  font = configure_font(fonts::reqtree_text, sl, QFont::Serif, max, true);
-  if (font.exactMatch()) {
-    fc_strlcpy(gui_options.gui_qt_font_reqtree_text,
-               qUtf8Printable(font.toString()), 512);
-  }
+  configure_font(fonts::reqtree_text, sl, QFont::Serif, large_size);
 }
 
 /**
    Returns long font name, sets given for for use
  */
-QFont configure_font(const QString &font_name, const QStringList &sl,
-                     QFont::StyleHint hint, int size, bool bold)
+void configure_font(const QString &font_name, const QStringList &sl,
+                    QFont::StyleHint hint, int size, bool bold)
 {
+  auto opt = optset_option_by_name(client_optset, qUtf8Printable(font_name));
+  fc_assert_ret(opt);
+
   // FIXME Qt 6: Use QFont(QStringList...)
   QFontDatabase database;
+  QFont font;
 
   for (auto const &str : sl) {
     if (database.families().contains(str)) {
-      auto font = QFont(str, size, bold ? QFont::Bold : QFont::Normal);
+      font = QFont(str, size, bold ? QFont::Bold : QFont::Normal);
       font.setStyleHint(hint);
+      option_font_set_default(opt, font);
       fcFont::instance()->setFont(font_name, font);
-      return font;
+      return;
     }
   }
 
-  auto font = QFont();
+  font = QFont();
   font.setStyleHint(hint);
+  option_font_set_default(opt, font);
   fcFont::instance()->setFont(font_name, font);
-  return font;
 }

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -162,101 +162,101 @@ void load_fonts()
 void configure_fonts()
 {
   QStringList sl;
-  QString font_name;
+  QFont font;
 
   const int max = 16;
   const int default_size = 12;
 
-  if (!isFontInstalled("Linux Libertine")) {
+  if (!isFontInstalled(QStringLiteral("Libertinus Sans"))
+      && !isFontInstalled(QStringLiteral("Linux Libertine"))) {
     load_fonts();
   }
 
   /* Sans Serif List */
-  sl << QStringLiteral("Linux Biolinum O")
-     << QStringLiteral("Liberation Sans") << QStringLiteral("Droid Sans")
-     << QStringLiteral("Ubuntu") << QStringLiteral("Noto Sans")
-     << QStringLiteral("DejaVu Sans") << QStringLiteral("Luxi Sans")
-     << QStringLiteral("Lucida Sans") << QStringLiteral("Arial");
+  sl << QStringLiteral("Libertinus Sans")
+     << QStringLiteral("Linux Biolinum O")
+     << QStringLiteral("Linux Biolinum");
 
-  font_name = configure_font(fonts::default_font, sl, max);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_default, qUtf8Printable(font_name),
-               512);
+  font = configure_font(fonts::default_font, sl, QFont::SansSerif, max);
+  if (font.exactMatch()) {
+    fc_strlcpy(gui_options.gui_qt_font_default,
+               qUtf8Printable(font.toString()), 512);
   }
-  font_name = configure_font(fonts::notify_label, sl, default_size);
-  if (!font_name.isEmpty()) {
+  font = configure_font(fonts::notify_label, sl, QFont::SansSerif,
+                        default_size);
+  if (font.exactMatch()) {
     fc_strlcpy(gui_options.gui_qt_font_notify_label,
-               qUtf8Printable(font_name), 512);
+               qUtf8Printable(font.toString()), 512);
   }
-  font_name = configure_font(fonts::city_names, sl, max, true);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_city_names, qUtf8Printable(font_name),
-               512);
+  font = configure_font(fonts::city_names, sl, QFont::SansSerif, max, true);
+  if (font.exactMatch()) {
+    fc_strlcpy(gui_options.gui_qt_font_city_names,
+               qUtf8Printable(font.toString()), 512);
   }
-  font_name =
-      configure_font(fonts::city_productions, sl, default_size, true);
-  if (!font_name.isEmpty()) {
+  font = configure_font(fonts::city_productions, sl, QFont::SansSerif,
+                        default_size, true);
+  if (font.exactMatch()) {
     fc_strlcpy(gui_options.gui_qt_font_city_productions,
-               qUtf8Printable(font_name), 512);
+               qUtf8Printable(font.toString()), 512);
   }
-  sl.clear();
 
   /* Monospace List */
-  sl << QStringLiteral("Linux Libertine Mono O") << QStringLiteral("Cousine")
-     << QStringLiteral("Liberation Mono")
-     << QStringLiteral("Source Code Pro")
-     << QStringLiteral("Source Code Pro [ADBO]")
-     << QStringLiteral("Noto Mono") << QStringLiteral("Ubuntu Mono")
-     << QStringLiteral("Courier New");
-
-  font_name = configure_font(fonts::help_label, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_help_label, qUtf8Printable(font_name),
-               512);
-  }
-  font_name = configure_font(fonts::help_text, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_help_text, qUtf8Printable(font_name),
-               512);
-  }
-  font_name = configure_font(fonts::chatline, sl, default_size);
-  if (!font_name.isEmpty()) {
-    fc_strlcpy(gui_options.gui_qt_font_chatline, qUtf8Printable(font_name),
-               512);
-  }
   sl.clear();
+  sl << QStringLiteral("Libertinus Mono")
+     << QStringLiteral("Linux Libertine Mono O")
+     << QStringLiteral("Linux Libertine Mono");
+
+  font =
+      configure_font(fonts::help_label, sl, QFont::Monospace, default_size);
+  if (font.exactMatch()) {
+    fc_strlcpy(gui_options.gui_qt_font_help_label,
+               qUtf8Printable(font.toString()), 512);
+  }
+  font =
+      configure_font(fonts::help_text, sl, QFont::Monospace, default_size);
+  if (font.exactMatch()) {
+    fc_strlcpy(gui_options.gui_qt_font_help_text,
+               qUtf8Printable(font.toString()), 512);
+  }
+  font = configure_font(fonts::chatline, sl, QFont::Monospace, default_size);
+  if (font.exactMatch()) {
+    fc_strlcpy(gui_options.gui_qt_font_chatline,
+               qUtf8Printable(font.toString()), 512);
+  }
 
   /* Serif List */
-  sl << QStringLiteral("Linux Libertine Display O")
-     << QStringLiteral("Arimo") << QStringLiteral("Play")
-     << QStringLiteral("Tinos") << QStringLiteral("Ubuntu")
-     << QStringLiteral("Times New Roman") << QStringLiteral("Droid Sans")
-     << QStringLiteral("Noto Sans");
+  sl.clear();
+  sl << QStringLiteral("Libertinus Display")
+     << QStringLiteral("Linux Libertine Display O")
+     << QStringLiteral("Linux Libertine Display");
 
-  font_name = configure_font(fonts::reqtree_text, sl, max, true);
-  if (!font_name.isEmpty()) {
+  font = configure_font(fonts::reqtree_text, sl, QFont::Serif, max, true);
+  if (font.exactMatch()) {
     fc_strlcpy(gui_options.gui_qt_font_reqtree_text,
-               qUtf8Printable(font_name), 512);
+               qUtf8Printable(font.toString()), 512);
   }
 }
 
 /**
    Returns long font name, sets given for for use
  */
-QString configure_font(const QString &font_name, const QStringList &sl,
-                       int size, bool bold)
+QFont configure_font(const QString &font_name, const QStringList &sl,
+                     QFont::StyleHint hint, int size, bool bold)
 {
+  // FIXME Qt 6: Use QFont(QStringList...)
   QFontDatabase database;
 
   for (auto const &str : sl) {
     if (database.families().contains(str)) {
-      auto f = QFont(str, size);
-      if (bold) {
-        f.setBold(true);
-      }
-      fcFont::instance()->setFont(font_name, f);
-      return f.toString();
+      auto font = QFont(str, size, bold ? QFont::Bold : QFont::Normal);
+      font.setStyleHint(hint);
+      fcFont::instance()->setFont(font_name, font);
+      return font;
     }
   }
-  return QString();
+
+  auto font = QFont();
+  font.setStyleHint(hint);
+  fcFont::instance()->setFont(font_name, font);
+  return font;
 }

--- a/client/fonts.h
+++ b/client/fonts.h
@@ -46,5 +46,3 @@ public:
 bool isFontInstalled(const QString &font_name);
 void load_fonts();
 void configure_fonts();
-QFont configure_font(const QString &font_name, const QStringList &sl,
-                     QFont::StyleHint hint, int size, bool bold = false);

--- a/client/fonts.h
+++ b/client/fonts.h
@@ -10,10 +10,9 @@
 #pragma once
 
 // Qt
+#include <QFont>
 #include <QMap>
 #include <QStringList>
-
-class QFont;
 
 namespace fonts {
 const char *const default_font = "gui_qt_font_default";
@@ -47,5 +46,5 @@ public:
 bool isFontInstalled(const QString &font_name);
 void load_fonts();
 void configure_fonts();
-QString configure_font(const QString &font_name, const QStringList &sl,
-                       int size, bool bold = false);
+QFont configure_font(const QString &font_name, const QStringList &sl,
+                     QFont::StyleHint hint, int size, bool bold = false);

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -92,7 +92,8 @@ void ui_main()
     } else if (!gui_options.gui_qt_migrated_from_2_5) {
       migrate_options_from_2_5();
     }
-    if (!isFontInstalled("Linux Libertine")) {
+    if (!isFontInstalled(QStringLiteral("Libertinus Sans"))
+        && !isFontInstalled(QStringLiteral("Linux Libertine"))) {
       load_fonts();
     }
     if (!load_theme(gui_options.gui_qt_default_theme_name)) {

--- a/client/optiondlg.h
+++ b/client/optiondlg.h
@@ -51,12 +51,12 @@ private:
   void set_enum(struct option *poption, int index);
   void set_bitwise(struct option *poption, unsigned value);
   void set_color(struct option *poption, struct ft_color color);
-  void set_font(struct option *poption, const QString &s);
+  void set_font(struct option *poption, const QFont &font);
   void get_color(struct option *poption, QByteArray &a1, QByteArray &a2);
   bool get_bool(struct option *poption);
   int get_int(struct option *poption);
   QFont get_font(struct option *poption);
-  QByteArray get_button_font(struct option *poption);
+  QFont get_button_font(struct option *poption);
   QByteArray get_string(struct option *poption);
   int get_enum(struct option *poption);
   struct option *get_color_option();

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -87,10 +87,9 @@ struct client_options gui_options = {
     true, //.save_options_on_exit =
 
     /** Migrations **/
-    false, //.first_boot =
-    "\0",  //.default_tileset_overhead_name =
-    "\0",  //.default_tileset_iso_name =
-    false, //.gui_qt_migrated_from_2_5 =
+    true, //.first_boot =
+    "\0", //.default_tileset_overhead_name =
+    "\0", //.default_tileset_iso_name =
 
     false, //.migrate_fullscreen =
 
@@ -189,18 +188,15 @@ struct client_options gui_options = {
     true, //.gui_qt_allied_chat_only =
     0,    // font_increase
     FC_QT_DEFAULT_THEME_NAME,
-    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_notify_label =
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_label
-                                                   //=
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_help_text =
-    "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_chatline =
-    "Linux Biolinum O,16,-1,5,50,1,0,0,0,0", //.gui_qt_font_city_names =
-    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0", //.gui_qt_font_city_productions
-                                             //=
-    "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0", //.gui_qt_font_reqtree_text
-                                                      //=
-    {true}, //=?
-    true,   //.gui_qt_show_titlebar
+    QFont(), //.gui_qt_font_default =
+    QFont(), //.gui_qt_font_notify_label =
+    QFont(), //.gui_qt_font_help_label =
+    QFont(), //.gui_qt_font_help_text =
+    QFont(), //.gui_qt_font_chatline =
+    QFont(), //.gui_qt_font_city_names =
+    QFont(), //.gui_qt_font_city_productions =
+    QFont(), //.gui_qt_font_reqtree_text =
+    true,    //.gui_qt_show_titlebar
     {}};
 
 /* Set to TRUE after the first call to options_init(), to avoid the usage
@@ -318,10 +314,11 @@ struct option_bitwise_vtable {
 };
 // Specific font accessors (OT_FONT == type).
 struct option_font_vtable {
-  const char *(*get)(const struct option *);
-  const char *(*def)(const struct option *);
-  const char *(*target)(const struct option *);
-  bool (*set)(struct option *, const char *);
+  QFont (*get)(const struct option *);
+  QFont (*def)(const struct option *);
+  void (*set_def)(const struct option *, const QFont &font);
+  QString (*target)(const struct option *);
+  bool (*set)(struct option *, const QFont &);
 };
 // Specific color accessors (OT_COLOR == type).
 struct option_color_vtable {
@@ -873,10 +870,10 @@ bool option_bitwise_set(struct option *poption, unsigned val)
 /**
    Returns the current value of this font option.
  */
-const QString option_font_get(const struct option *poption)
+QFont option_font_get(const struct option *poption)
 {
-  fc_assert_ret_val(nullptr != poption, nullptr);
-  fc_assert_ret_val(OT_FONT == poption->type, nullptr);
+  fc_assert_ret_val(nullptr != poption, QFont());
+  fc_assert_ret_val(OT_FONT == poption->type, QFont());
 
   return poption->font_vtable->get(poption);
 }
@@ -884,21 +881,32 @@ const QString option_font_get(const struct option *poption)
 /**
    Returns the default value of this font option.
  */
-const QString option_font_def(const struct option *poption)
+QFont option_font_def(const struct option *poption)
 {
-  fc_assert_ret_val(nullptr != poption, nullptr);
-  fc_assert_ret_val(OT_FONT == poption->type, nullptr);
+  fc_assert_ret_val(nullptr != poption, QFont());
+  fc_assert_ret_val(OT_FONT == poption->type, QFont());
 
   return poption->font_vtable->def(poption);
 }
 
 /**
+   Returns the default value of this font option.
+ */
+void option_font_set_default(const struct option *poption, const QFont &font)
+{
+  fc_assert_ret(nullptr != poption);
+  fc_assert_ret(OT_FONT == poption->type);
+
+  poption->font_vtable->set_def(poption, font);
+}
+
+/**
    Returns the target style name of this font option.
  */
-const QString option_font_target(const struct option *poption)
+QString option_font_target(const struct option *poption)
 {
-  fc_assert_ret_val(nullptr != poption, nullptr);
-  fc_assert_ret_val(OT_FONT == poption->type, nullptr);
+  fc_assert_ret_val(nullptr != poption, QString());
+  fc_assert_ret_val(OT_FONT == poption->type, QString());
 
   return poption->font_vtable->target(poption);
 }
@@ -906,13 +914,12 @@ const QString option_font_target(const struct option *poption)
 /**
    Sets the value of this font option. Returns TRUE if the value changed.
  */
-bool option_font_set(struct option *poption, const QString &font)
+bool option_font_set(struct option *poption, const QFont &font)
 {
   fc_assert_ret_val(nullptr != poption, false);
   fc_assert_ret_val(OT_FONT == poption->type, false);
-  fc_assert_ret_val(nullptr != font, false);
 
-  if (poption->font_vtable->set(poption, qUtf8Printable(font))) {
+  if (poption->font_vtable->set(poption, font)) {
     option_changed(poption);
     return true;
   }
@@ -1037,14 +1044,18 @@ static const struct option_str_vtable client_option_str_vtable = {
     .values = client_option_str_values,
     .set = client_option_str_set};
 
-static const char *client_option_font_get(const struct option *poption);
-static const char *client_option_font_def(const struct option *poption);
-static const char *client_option_font_target(const struct option *poption);
-static bool client_option_font_set(struct option *poption, const char *font);
+static QFont client_option_font_get(const struct option *poption);
+static QFont client_option_font_def(const struct option *poption);
+static void client_option_font_set_def(const struct option *poption,
+                                       const QFont &font);
+static QString client_option_font_target(const struct option *poption);
+static bool client_option_font_set(struct option *poption,
+                                   const QFont &font);
 
 static const struct option_font_vtable client_option_font_vtable = {
     .get = client_option_font_get,
     .def = client_option_font_def,
+    .set_def = client_option_font_set_def,
     .target = client_option_font_target,
     .set = client_option_font_set};
 
@@ -1080,7 +1091,7 @@ struct client_option {
   const char *help_text;   // Paragraph-length help text
   enum client_option_category category;
 
-  union {
+  struct {
     // OT_BOOLEAN type option.
     struct {
       bool *const pvalue;
@@ -1118,10 +1129,9 @@ struct client_option {
     } bitwise;
     // OT_FONT type option.
     struct {
-      char *const pvalue;
-      const size_t size;
-      const char *const def;
-      const char *const target;
+      QFont value;
+      QFont def;
+      QString target;
     } font;
     // OT_COLOR type option.
     struct {
@@ -1330,11 +1340,10 @@ struct client_option {
  * ohelp: The help text for the client option.  Should be used with the N_()
  *        macro.
  * ocat:  The client_option_class of this client option.
- * odef:  The default string for this client option.
  * ocb:   A callback function of type void (*)(struct option *) called when
  *        the option changed.
  */
-#define GEN_FONT_OPTION(oname, otgt, odesc, ohelp, ocat, odef, ocb)         \
+#define GEN_FONT_OPTION(oname, otgt, odesc, ohelp, ocat, ocb)               \
   {                                                                         \
     .base_option = OPTION_FONT_INIT(&client_optset_static,                  \
                                     client_option_common_vtable,            \
@@ -1343,9 +1352,8 @@ struct client_option {
     .category = ocat,                                                       \
     .u =                                                                    \
     {.font = {                                                              \
-         .pvalue = gui_options.oname,                                       \
-         .size = sizeof(gui_options.oname),                                 \
-         .def = odef,                                                       \
+         .value = gui_options.oname,                                        \
+         .def = QFont(),                                                    \
          .target = otgt,                                                    \
      } }                                                                    \
   }
@@ -1945,46 +1953,38 @@ static struct client_option client_options[] = {
                    COC_FONT, 0, -100, 100, allfont_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_default, "default_font", N_("Default font"),
                     N_("This is default font"), COC_FONT,
-                    "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
                     font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
         N_("This font is used to display server reports such "
            "as the demographic report or historian publications."),
-        COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
-        font_changed_callback),
+        COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_label, "help_label", N_("Help Label"),
                     N_("This font is used to display the help labels in the "
                        "help window."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
-                    font_changed_callback),
+                    COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_help_text, "help_text", N_("Help Text"),
                     N_("This font is used to display the help body text in "
                        "the help window."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
-                    font_changed_callback),
+                    COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
                     N_("This font is used to display the text in the "
                        "chatline area."),
-                    COC_FONT, "Linux Libertine Mono O,12,-1,5,50,0,0,0,0,0",
-                    font_changed_callback),
+                    COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
                     N_("This font is used to the display the city names "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum O,16,-1,5,50,1,0,0,0,0",
-                    font_changed_callback),
+                    COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
                     N_("City Productions"),
                     N_("This font is used to display the city production "
                        "on the map."),
-                    COC_FONT, "Linux Biolinum O,12,-1,5,50,0,0,0,0,0",
-                    font_changed_callback),
+                    COC_FONT, font_changed_callback),
     GEN_FONT_OPTION(
         gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
         N_("This font is used to the display the requirement tree "
            "in the Research report."),
-        COC_FONT, "Linux Libertine Display O,14,-1,5,50,0,0,0,0,0",
-        font_changed_callback),
+        COC_FONT, font_changed_callback),
     GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
                     N_("If this option is set the client will show "
                        "information and map preview of current savegame."),
@@ -2287,23 +2287,32 @@ static const char *client_option_bitwise_secfile_str(secfile_data_t data,
 /**
    Returns the value of this client option of type OT_FONT.
  */
-static const char *client_option_font_get(const struct option *poption)
+static QFont client_option_font_get(const struct option *poption)
 {
-  return CLIENT_OPTION(poption)->u.font.pvalue;
+  return CLIENT_OPTION(poption)->u.font.value;
 }
 
 /**
    Returns the default value of this client option of type OT_FONT.
  */
-static const char *client_option_font_def(const struct option *poption)
+static QFont client_option_font_def(const struct option *poption)
 {
   return CLIENT_OPTION(poption)->u.font.def;
 }
 
 /**
-   Returns the target style name of this client option of type OT_FONT.
+   Returns the default value of this client option of type OT_FONT.
  */
-static const char *client_option_font_target(const struct option *poption)
+static void client_option_font_set_def(const struct option *poption,
+                                       const QFont &font)
+{
+  CLIENT_OPTION(poption)->u.font.def = font;
+}
+
+/**
+   Returns the default value of this client option of type OT_FONT.
+ */
+static QString client_option_font_target(const struct option *poption)
 {
   return CLIENT_OPTION(poption)->u.font.target;
 }
@@ -2312,16 +2321,15 @@ static const char *client_option_font_target(const struct option *poption)
    Set the value of this client option of type OT_FONT.  Returns TRUE if
    the value changed.
  */
-static bool client_option_font_set(struct option *poption, const char *font)
+static bool client_option_font_set(struct option *poption, const QFont &font)
 {
   struct client_option *pcoption = CLIENT_OPTION(poption);
 
-  if (strlen(font) >= pcoption->u.font.size
-      || 0 == strcmp(pcoption->u.font.pvalue, font)) {
+  if (pcoption->u.font.value == font) {
     return false;
   }
 
-  fc_strlcpy(pcoption->u.font.pvalue, font, pcoption->u.font.size);
+  pcoption->u.font.value = font;
   return true;
 }
 
@@ -2424,11 +2432,14 @@ static bool client_option_load(struct option *poption,
             && option_bitwise_set(poption, value));
   }
   case OT_FONT: {
-    const char *string;
+    const char *string =
+        secfile_lookup_str(sf, "client.%s", option_name(poption));
+    if (!string) {
+      return false;
+    }
 
-    return (
-        (string = secfile_lookup_str(sf, "client.%s", option_name(poption)))
-        && option_font_set(poption, string));
+    QFont font;
+    return font.fromString(string) && option_font_set(poption, font);
   }
   case OT_COLOR: {
     struct ft_color color;
@@ -2476,7 +2487,8 @@ static void client_option_save(struct option *poption,
                              "client.%s", option_name(poption));
     break;
   case OT_FONT:
-    secfile_insert_str(sf, qUtf8Printable(option_font_get(poption)),
+    secfile_insert_str(sf,
+                       qUtf8Printable(option_font_get(poption).toString()),
                        "client.%s", option_name(poption));
     break;
   case OT_COLOR: {
@@ -4418,10 +4430,6 @@ void options_load()
   gui_options.migrate_fullscreen = secfile_lookup_bool_default(
       sf, gui_options.migrate_fullscreen, "%s.fullscreen_mode", prefix);
 
-  gui_options.gui_qt_migrated_from_2_5 =
-      secfile_lookup_bool_default(sf, gui_options.gui_qt_migrated_from_2_5,
-                                  "%s.migration_qt_from_2_5", prefix);
-
   str = secfile_lookup_str_default(sf, nullptr,
                                    "client.default_tileset_overhead_name");
   if (str != nullptr) {
@@ -4521,9 +4529,6 @@ void options_save(option_save_log_callback log_cb)
                       "client.save_options_on_exit");
   secfile_insert_bool_comment(sf, gui_options.migrate_fullscreen,
                               "deprecated", "client.fullscreen_mode");
-
-  secfile_insert_bool(sf, gui_options.gui_qt_migrated_from_2_5,
-                      "client.migration_qt_from_2_5");
 
   // prevent saving that option
   gui_options.gui_qt_increase_fonts = 0; // gui-enabled options

--- a/client/options.h
+++ b/client/options.h
@@ -10,6 +10,8 @@
 **************************************************************************/
 #pragma once
 
+#include <QFont>
+
 // common
 #include "events.h"
 #include "featured_text.h" // struct ft_color
@@ -67,7 +69,6 @@ struct client_options {
   char default_tileset_overhead_name[512]; /* 2.6 had separate tilesets for
                                               ... */
   char default_tileset_iso_name[512];      // ...overhead and iso topologies.
-  bool gui_qt_migrated_from_2_5;
 
   bool migrate_fullscreen;
 
@@ -156,14 +157,14 @@ struct client_options {
   bool gui_qt_allied_chat_only;
   int gui_qt_increase_fonts;
   char gui_qt_default_theme_name[512];
-  char gui_qt_font_default[512];
-  char gui_qt_font_notify_label[512];
-  char gui_qt_font_help_label[512];
-  char gui_qt_font_help_text[512];
-  char gui_qt_font_chatline[512];
-  char gui_qt_font_city_names[512];
-  char gui_qt_font_city_productions[512];
-  char gui_qt_font_reqtree_text[512];
+  QFont gui_qt_font_default;
+  QFont gui_qt_font_notify_label;
+  QFont gui_qt_font_help_label;
+  QFont gui_qt_font_help_text;
+  QFont gui_qt_font_chatline;
+  QFont gui_qt_font_city_names;
+  QFont gui_qt_font_city_productions;
+  QFont gui_qt_font_reqtree_text;
   bool gui_qt_show_titlebar;
 
   struct overview overview;
@@ -263,10 +264,12 @@ const QVector<QString> *option_bitwise_values(const struct option *poption);
 bool option_bitwise_set(struct option *poption, unsigned val);
 
 // Option type OT_FONT functions.
-const QString option_font_get(const struct option *poption);
-const QString option_font_def(const struct option *poption);
-const QString option_font_target(const struct option *poption);
-bool option_font_set(struct option *poption, const QString &font);
+QFont option_font_get(const struct option *poption);
+QFont option_font_def(const struct option *poption);
+void option_font_set_default(const struct option *poption,
+                             const QFont &font);
+QString option_font_target(const struct option *poption);
+bool option_font_set(struct option *poption, const QFont &font);
 
 // Option type OT_COLOR functions.
 struct ft_color option_color_get(const struct option *poption);

--- a/client/qtg_cxxside.h
+++ b/client/qtg_cxxside.h
@@ -34,7 +34,7 @@ void popup_combat_info(int attacker_unit_id, int defender_unit_id,
 void set_unit_icon(int idx, unit *punit);
 void set_unit_icons_more_arrow(bool onoff);
 void real_focus_units_changed();
-void gui_update_font(const QString &font_name, const QString &font_value);
+void gui_update_font(const QString &font_name, const QFont &font_value);
 
 void editgui_refresh();
 void editgui_notify_object_created(int tag, int id);


### PR DESCRIPTION
Support both the Linux Libertine and Libertinus font families. Give priority to the latter because the Libertine project is dead.

Closes #1428.