### PR TITLE
Goto: Avoid paradropping if it's not faster

### DIFF
--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -129,8 +129,10 @@ bool vertex::operator==(const vertex &other) const
  */
 bool vertex::operator>(const vertex &other) const
 {
-  return std::tie(turns, other.moves_left, other.health, other.fuel_left)
-         > std::tie(other.turns, moves_left, health, fuel_left);
+  return std::tie(turns, other.moves_left, other.health, paradropped,
+                  other.fuel_left)
+         > std::tie(other.turns, moves_left, health, other.paradropped,
+                    fuel_left);
 }
 
 } // namespace detail


### PR DESCRIPTION
This preserves the paradropping ability for the player to use later on. The optimal algorithm depends on the requirements for "Paradrop Unit". MinMoveFrags is common so try to preserve MP (and health), but this is a heuristic.

Closes #1474.