### PR TITLE
Fix a bug where the Messages widget could be moved

### DIFF
--- a/client/widgetdecorations.cpp
+++ b/client/widgetdecorations.cpp
@@ -208,13 +208,7 @@ void resizable_widget::mousePressEvent(QMouseEvent *event)
   }
   if (event->button() == Qt::LeftButton) {
     // Get flag from mouse position
-    auto flags = get_in_event_mouse(event);
-
-    // Check the flag and widget for the presence of a flag
-    if (resizeFlags | flags) {
-      // Save flag and mouse position for mouse move event
-      eventFlags = flags;
-    }
+    eventFlags = resizeFlags & get_in_event_mouse(event);
   }
   event->setAccepted(true);
 }


### PR DESCRIPTION
It was possible to grab a corner of the Messages widget and move it in a direction in which moves supposedly were disallowed (for the top left corner, up or down; for the bottom right corner, left or right), effectively moving the widget out of the corner. Fix the logic used to determine which edges can be moved in a drag-and-drop.