### PR TITLE
Add support for scroll events on the map

### DIFF
--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -371,6 +371,32 @@ void map_view::resizeEvent(QResizeEvent *event)
 }
 
 /**
+ * The user wants to scroll.
+ */
+void map_view::wheelEvent(QWheelEvent *event)
+{
+  auto delta = event->pixelDelta();
+  if (delta.isNull()) {
+    delta = event->angleDelta();
+  }
+
+  if (event->modifiers() == Qt::NoModifier) {
+    // Scrolling
+    m_renderer->set_origin(m_renderer->origin() - delta);
+  } else if (event->modifiers() == Qt::ShiftModifier) {
+    // Horizontal scrolling
+    m_renderer->set_origin(m_renderer->origin() - delta.transposed());
+  } else if (event->modifiers() == Qt::ControlModifier) {
+    // Zooming
+    if (delta.y() > 0) {
+      zoom_in();
+    } else if (delta.y() < 0) {
+      zoom_out();
+    }
+  }
+}
+
+/**
    Sets new point for new search
  */
 void map_view::resume_searching(int pos_x, int pos_y, int &w, int &h,

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -385,7 +385,8 @@ void map_view::wheelEvent(QWheelEvent *event)
     m_renderer->set_origin(m_renderer->origin() - delta);
   } else if (event->modifiers() == Qt::ShiftModifier) {
     // Horizontal scrolling
-    m_renderer->set_origin(m_renderer->origin() - delta.transposed());
+    std::swap(delta.rx(), delta.ry()); // FIXME Qt 6 QPoint::transposed()
+    m_renderer->set_origin(m_renderer->origin() - delta);
   } else if (event->modifiers() == Qt::ControlModifier) {
     // Zooming
     if (delta.y() > 0) {

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -94,6 +94,7 @@ protected:
   void focusOutEvent(QFocusEvent *event) override;
   void leaveEvent(QEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
+  void wheelEvent(QWheelEvent *event) override;
 
 private slots:
   void set_scale_now(double scale);


### PR DESCRIPTION
Support the following gestures:

* Mouse wheel/touchpad scroll gesture: scroll the map
* Shift+wheel/touchpad: scroll the map with x and y inverted
* Ctrl+wheel/touchpad: zoom

This is consistent with the gestures widely used in browsers and other software.