### PR TITLE
Fix build with NLS disabled and GCC 11

### DIFF
--- a/docs/Getting/compile.rst
+++ b/docs/Getting/compile.rst
@@ -270,10 +270,7 @@ Once the command line directives are determined, the appropriate command looks l
 .. code-block:: sh
 
   $ cmake . -B build -G Ninja \
-     -DFREECIV_ENABLE_TOOLS=OFF \
-     -DFREECIV_ENABLE_SERVER=ON \
      -DCMAKE_BUILD_TYPE=Release \
-     -DFREECIV_ENABLE_NLS=OFF \
      -DCMAKE_INSTALL_PREFIX=$HOME/Install/Freeciv21
 
 

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -2174,15 +2174,16 @@ void make_contact(struct player *pplayer1, struct player *pplayer2,
       /* Non-default relation after contact, so send a message
        * Could just modify to send message in any case. */
       /* TRANS: ... the Poles ... Polish territory */
-      char *msg = PL_("You are in armistice with the %s. In %d turn, "
-                      "it will become a peace treaty. Move your "
-                      "military units out of %s territory to avoid them "
-                      "being disbanded.",
-                      "You are in armistice with the %s. In %d turns, "
-                      "it will become a peace treaty. Move any "
-                      "military units out of %s territory to avoid them "
-                      "being disbanded.",
-                      ds_plr1plr2->turns_left);
+      const char *msg =
+          PL_("You are in armistice with the %s. In %d turn, "
+              "it will become a peace treaty. Move your "
+              "military units out of %s territory to avoid them "
+              "being disbanded.",
+              "You are in armistice with the %s. In %d turns, "
+              "it will become a peace treaty. Move any "
+              "military units out of %s territory to avoid them "
+              "being disbanded.",
+              ds_plr1plr2->turns_left);
       notify_player(pplayer1, NULL, E_TREATY_PEACE, ftc_server, msg,
                     nation_plural_for_player(pplayer2),
                     ds_plr1plr2->turns_left,

--- a/utility/fcintl.h
+++ b/utility/fcintl.h
@@ -64,12 +64,6 @@
 #define R__(String) (String)
 #define RQ_(String) skip_intl_qualifier_prefix(String)
 
-#undef textdomain
-#undef bindtextdomain
-
-#define textdomain(Domain)
-#define bindtextdomain(Package, Directory)
-
 #endif // FREECIV_ENABLE_NLS
 
 /* This provides an untranslated version of Q_ that allows the caller to


### PR DESCRIPTION
This fixes the build failures recently reported on Arch and Gentoo when NLS is disabled. The documentation is also modified to stop recommending less tested non-default settings and build tools (including the modpack installer).