### PR TITLE
Sort rows in the city dialog detailed output

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1099,10 +1099,11 @@ void city_info::update_labels(struct city *pcity)
   m_plague_label->setVisible(game.info.illness_on);
   m_plague->setVisible(game.info.illness_on);
 
-  if (pcity->steal) {
-    m_stolen->setText(QString::asprintf(_("%d times"), pcity->steal));
+  if (pcity->steal > 0) {
+    m_stolen->setText(QString::asprintf(
+        PL_("%3d time", "%3d times", pcity->steal), pcity->steal));
   } else {
-    m_stolen->setText(QString::asprintf(_("Not stolen")));
+    m_stolen->setText(_("Not stolen"));
   }
 
   m_airlift->setText(get_city_dialog_airlift_value(pcity));

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -2286,7 +2286,7 @@ void city_dialog::update_units()
 
   ui.supported_units->set_units(units);
   n = unit_list_size(units);
-  fc_snprintf(buf, sizeof(buf), _("Supported units %d"), n);
+  fc_snprintf(buf, sizeof(buf), _("Supported units: %d"), n);
   ui.supp_units->setText(QString(buf));
 
   if (nullptr != client.conn.playing
@@ -2536,7 +2536,7 @@ void city_dialog::update_improvements()
   ui.city_buildings->setUpdatesEnabled(true);
   ui.city_buildings->setUpdatesEnabled(true);
 
-  ui.curr_impr->setText(QString(_("Improvements - upkeep %1")).arg(upkeep));
+  ui.curr_impr->setText(QString(_("Improvements: upkeep %1")).arg(upkeep));
 }
 
 /**

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -19,6 +19,7 @@
 #include <QScreen>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QSpacerItem>
 #include <QSplitter>
 #include <QVBoxLayout>
 #include <QWidgetAction>
@@ -984,8 +985,10 @@ void city_label::set_city(city *pciti) { pcity = pciti; }
 city_info::city_info(QWidget *parent) : QWidget(parent)
 {
   QGridLayout *info_grid_layout = new QGridLayout();
-  info_grid_layout->setSpacing(0);
+  info_grid_layout->setHorizontalSpacing(6);
+  info_grid_layout->setVerticalSpacing(0);
   info_grid_layout->setContentsMargins(0, 0, 0, 0);
+  info_grid_layout->setColumnStretch(1, 100);
   setLayout(info_grid_layout);
 
   auto small_font = fcFont::instance()->getFont(fonts::notify_label);
@@ -1007,17 +1010,29 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
   };
 
   QLabel *dummy;
-  std::tie(dummy, m_size) = create_labels(_("Citizens:"));
-  std::tie(dummy, m_food) = create_labels(_("Food:"));
-  std::tie(dummy, m_production) = create_labels(_("Prod:"));
-  std::tie(dummy, m_trade) = create_labels(_("Trade:"));
-  std::tie(dummy, m_gold) = create_labels(_("Gold:"));
-  std::tie(dummy, m_luxury) = create_labels(_("Luxury:"));
-  std::tie(dummy, m_science) = create_labels(_("Science:"));
+  std::tie(dummy, m_food) = create_labels(_("<B>Food:</B>"));
   std::tie(dummy, m_granary) = create_labels(_("Granary:"));
+  std::tie(dummy, m_size) = create_labels(_("Citizens:"));
   std::tie(dummy, m_growth) = create_labels(_("Change in:"));
-  std::tie(dummy, m_corruption) = create_labels(_("Corruption:"));
+
+  info_grid_layout->addItem(new QSpacerItem(0, 9),
+                            info_grid_layout->rowCount(), 0);
+
+  std::tie(dummy, m_production) = create_labels(_("<B>Production:</B>"));
   std::tie(dummy, m_waste) = create_labels(_("Waste:"));
+
+  info_grid_layout->addItem(new QSpacerItem(0, 9),
+                            info_grid_layout->rowCount(), 0);
+
+  std::tie(dummy, m_trade) = create_labels(_("<B>Trade:</B>"));
+  std::tie(dummy, m_corruption) = create_labels(_("Corruption:"));
+  std::tie(dummy, m_gold) = create_labels(_("Gold:"));
+  std::tie(dummy, m_science) = create_labels(_("Science:"));
+  std::tie(dummy, m_luxury) = create_labels(_("Luxury:"));
+
+  info_grid_layout->addItem(new QSpacerItem(0, 9),
+                            info_grid_layout->rowCount(), 0);
+
   std::tie(dummy, m_culture) = create_labels(_("Culture:"));
   std::tie(dummy, m_pollution) = create_labels(_("Pollution:"));
   std::tie(m_plague_label, m_plague) = create_labels(_("Plague risk:"));
@@ -1030,16 +1045,19 @@ void city_info::update_labels(struct city *pcity)
   m_size->setText(QString::asprintf("%3d", pcity->size));
   m_size->setToolTip(get_city_dialog_size_text(pcity));
 
-  m_food->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_FOOD],
-                                    pcity->surplus[O_FOOD]));
+  m_food->setText(
+      QString::asprintf("<B style=\"white-space:pre\">%3d (%+4d)</B>",
+                        pcity->prod[O_FOOD], pcity->surplus[O_FOOD]));
   m_food->setToolTip(get_city_dialog_output_text(pcity, O_FOOD));
 
-  m_production->setText(QString::asprintf(
-      "%3d (%+4d)", pcity->prod[O_SHIELD], pcity->surplus[O_SHIELD]));
+  m_production->setText(
+      QString::asprintf("<B style=\"white-space:pre\">%3d (%+4d)</B>",
+                        pcity->prod[O_SHIELD], pcity->surplus[O_SHIELD]));
   m_production->setToolTip(get_city_dialog_output_text(pcity, O_SHIELD));
 
-  m_trade->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_TRADE],
-                                     pcity->surplus[O_TRADE]));
+  m_trade->setText(
+      QString::asprintf("<B style=\"white-space:pre\">%3d (%+4d)</B>",
+                        pcity->prod[O_TRADE], pcity->surplus[O_TRADE]));
   m_trade->setToolTip(get_city_dialog_output_text(pcity, O_TRADE));
 
   m_gold->setText(QString::asprintf("%3d (%+4d)", pcity->prod[O_GOLD],
@@ -1055,19 +1073,19 @@ void city_info::update_labels(struct city *pcity)
   m_science->setToolTip(get_city_dialog_output_text(pcity, O_SCIENCE));
 
   m_granary->setText(
-      QString::asprintf("%4d/%-4d", pcity->food_stock,
+      QString::asprintf("%3d/%-4d", pcity->food_stock,
                         city_granary_size(city_size_get(pcity))));
 
   m_growth->setText(get_city_dialog_growth_value(pcity));
 
-  m_corruption->setText(QString::asprintf("%4d", pcity->waste[O_TRADE]));
+  m_corruption->setText(QString::asprintf("%3d", pcity->waste[O_TRADE]));
 
-  m_waste->setText(QString::asprintf("%4d", pcity->waste[O_SHIELD]));
+  m_waste->setText(QString::asprintf("%3d", pcity->waste[O_SHIELD]));
 
-  m_culture->setText(QString::asprintf("%4d", pcity->client.culture));
+  m_culture->setText(QString::asprintf("%3d", pcity->client.culture));
   m_culture->setToolTip(get_city_dialog_culture_text(pcity));
 
-  m_pollution->setText(QString::asprintf("%4d", pcity->pollution));
+  m_pollution->setText(QString::asprintf("%3d", pcity->pollution));
   m_pollution->setToolTip(get_city_dialog_pollution_text(pcity));
 
   if (game.info.illness_on) {
@@ -1075,7 +1093,7 @@ void city_info::update_labels(struct city *pcity)
         city_illness_calc(pcity, nullptr, nullptr, nullptr, nullptr);
     // illness is in tenth of percent
     m_plague->setText(
-        QString::asprintf("%4.1f%%", static_cast<float>(illness) / 10.0));
+        QString::asprintf("%3.1f%%", static_cast<float>(illness) / 10.0));
     m_plague->setToolTip(get_city_dialog_illness_text(pcity));
   }
   m_plague_label->setVisible(game.info.illness_on);

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -867,7 +867,7 @@ QString get_city_dialog_airlift_value(const struct city *pcity)
     /* TRANS: airlift. Possible take offs text. String is a symbol that
      * indicates that terms and conditions apply when landings are limited
      * and empty when they aren't limited. */
-    fc_snprintf(src, sizeof(src), _("∞%s"),
+    fc_snprintf(src, sizeof(src), _(" ∞%s"),
                 game.info.airlifting_style & AIRLIFTING_UNLIMITED_DEST
                     /* TRANS: airlift unlimited take offs may be spent symbol
                      * used above. */
@@ -876,7 +876,7 @@ QString get_city_dialog_airlift_value(const struct city *pcity)
   } else {
     /* TRANS: airlift. Possible take offs text. Number is
      * airlift capacity. */
-    fc_snprintf(src, sizeof(src), _("%d"), pcity->airlift);
+    fc_snprintf(src, sizeof(src), _("%2d"), pcity->airlift);
   }
 
   if (game.info.airlifting_style & AIRLIFTING_UNLIMITED_DEST) {
@@ -886,25 +886,25 @@ QString get_city_dialog_airlift_value(const struct city *pcity)
     unlimited++;
 
     // TRANS: airlift. Possible landings text.
-    fc_snprintf(dest, sizeof(dest), _("∞"));
+    fc_snprintf(dest, sizeof(dest), _(" ∞"));
   } else {
     // TRANS: airlift. Possible landings text.
-    fc_snprintf(dest, sizeof(dest), _("%d"), pcity->airlift);
+    fc_snprintf(dest, sizeof(dest), _("%2d"), pcity->airlift);
   }
 
   switch (unlimited) {
   case 2:
     // TRANS: unlimited airlift take offs and landings
-    return _("∞");
+    return _(" ∞");
     break;
   case 1:
     /* TRANS: airlift take offs and landings. One is unlimited. The first
      * string is the take offs text. The 2nd string is the landings text. */
-    return QString::asprintf(_("s: %s d: %s"), src, dest);
+    return QString::asprintf(_(" s: %s d: %s"), src, dest);
     break;
   default:
     // TRANS: airlift take offs or landings, no unlimited
-    return QString::asprintf(_("%s"), src);
+    return QString::asprintf(_(" %s"), src);
     break;
   }
 }

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -843,7 +843,7 @@ QString get_city_dialog_growth_value(const struct city *pcity)
     return _("never");
   } else {
     // TRANS: city growth turns.  Keep short.
-    return QString::asprintf(PL_("%d turn", "%d turns", abs(granaryturns)),
+    return QString::asprintf(PL_("%3d turn", "%3d turns", abs(granaryturns)),
                              abs(granaryturns));
   }
 }


### PR DESCRIPTION
Sort and categorize the table showing the detailed output of cities. The four main categories are Food, Production, and Trade, in the order they are shown on the map. Further details are shown under each category:

- Under Food: everything related to growth
- Under Production: only waste (the difference between waste and corruption is hard to learn, maybe this will help...)
- Under Trade: corruption and the three outputs taxed from it, in the order they are shown in the national budget.

This is only a first pass: in the future we'll want to add icons, make this more colorful, and get rid of the monospace font.

Closes #1491.