### PR TITLE
Fix black-on-black unit actions for Classic

### DIFF
--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -827,20 +827,15 @@ hud_action::hud_action(QWidget *parent, const QIcon &icon,
  */
 void hud_action::paintEvent(QPaintEvent *event)
 {
-  QRect rx, rz;
   QPainter p;
 
-  rx = QRect(0, 0, width(), height());
-  rz = QRect(0, 2, width(), height() - 6);
   p.begin(this);
   p.setCompositionMode(QPainter::CompositionMode_Source);
   p.setRenderHint(QPainter::SmoothPixmapTransform);
-  icon.paint(&p, rx);
-  p.setPen(QColor(palette().color(QPalette::Text)));
-  p.drawRect(rz);
+  icon.paint(&p, rect());
   if (focus) {
     p.setCompositionMode(QPainter::CompositionMode_DestinationOver);
-    p.fillRect(rx, QColor(palette().color(QPalette::Highlight)));
+    p.fillRect(rect(), QColor(palette().color(QPalette::Highlight)));
   }
   p.end();
 }

--- a/client/icons.cpp
+++ b/client/icons.cpp
@@ -16,6 +16,8 @@
 #include <QPainter>
 #include <QPalette>
 #include <QSvgRenderer>
+#include <QWidget>
+
 // utility
 #include "shared.h"
 
@@ -73,6 +75,9 @@ public:
     }
 
     auto col = QApplication::palette().color(QPalette::ButtonText);
+    if (auto widget = dynamic_cast<QWidget *>(painter->device()); widget) {
+      col = widget->palette().color(QPalette::ButtonText);
+    }
     QString key = path + "-" + QString::number(rect.width()) + "-"
                   + QString::number(rect.height()) + "-" + col.name();
     QPixmap pix;

--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -887,14 +887,13 @@ unit_hud_selector {
   border: 2px solid #a5a5a5;
 }
 
-
 hud_action {
-  selection-background-color:  rgba(221, 204, 161, 220);
-  color: rgb(5,5,185);
+  selection-background-color: rgba(75, 75, 75, 165);
+  color: white;
 }
 
 hud_units {
-  background: rgba(40, 10, 30, 200);
+  background: rgba(0, 0, 0, 200);
 }
 
 hud_units QLabel {

--- a/data/themes/gui-qt/NightStalker/resource.qss
+++ b/data/themes/gui-qt/NightStalker/resource.qss
@@ -968,8 +968,8 @@ gold_widget[current_warning="2"] {
 }
 
 hud_action {
-  selection-background-color: rgba(25,75,125, 150);
-  color: rgb(5,5,185);
+  selection-background-color: rgba(75, 75, 75, 165);
+  color: white;
 }
 
 hud_units {


### PR DESCRIPTION
Make sure to paint unit action icons in white, since the background is black.

Reported by Mu [on Discord](https://discord.com/channels/378908274113904641/912500712833974322/1043590889827745832):
![image](https://user-images.githubusercontent.com/22327575/202869477-01851d69-d0fa-4e6c-96ce-f3bd0d47faef.png)
