### PR TITLE
Fix opening load saved game or start scenario game on start menu

### DIFF
--- a/client/messagewin_common.cpp
+++ b/client/messagewin_common.cpp
@@ -44,7 +44,7 @@ static void meswin_dialog_update()
   if (!can_client_change_view()) {
     return;
   }
-  update_queue::uq()->add(real_meswin_dialog_update);
+  update_queue::uq()->add(real_meswin_dialog_update, nullptr);
 }
 
 /**

--- a/client/update_queue.cpp
+++ b/client/update_queue.cpp
@@ -205,9 +205,9 @@ void update_queue::push(uq_callback_t callback,
 
 // Add a callback to the update queue. NB: you can only set a callback
 // once. Setting a callback twice will overwrite the previous.
-void update_queue::add(uq_callback_t callback)
+void update_queue::add(uq_callback_t callback, void *data)
 {
-  push(callback, data_new(nullptr, nullptr));
+  push(callback, data_new(data, nullptr));
 }
 
 // Returns whether this callback is listed in the update queue.
@@ -216,6 +216,27 @@ bool update_queue::has_callback(uq_callback_t callback)
   for (auto pair : qAsConst(queue)) {
     if (pair.first == callback)
       return true;
+  }
+  return false;
+}
+
+bool update_queue::has_callback_full(uq_callback_t callback,
+                                     const void **data,
+                                     uq_free_fn_t *free_data_func)
+{
+  struct update_queue_data *uq_data = nullptr;
+  for (auto p : qAsConst(queue)) {
+    if (p.first == callback)
+      uq_data = p.second;
+  }
+  if (uq_data) {
+    if (nullptr != data) {
+      *data = uq_data->data;
+    }
+    if (nullptr != free_data_func) {
+      *free_data_func = uq_data->free_data_func;
+    }
+    return true;
   }
   return false;
 }
@@ -276,7 +297,7 @@ void set_client_page(enum client_pages page)
   log_debug("Requested page: %s.", client_pages_name(page));
 
   next_client_page = page;
-  update_queue::uq()->add(set_client_page_callback);
+  update_queue::uq()->add(set_client_page_callback, nullptr);
 }
 
 // Start server and then, set the client page.
@@ -311,10 +332,12 @@ bool update_queue_is_switching_page(void)
 // Request the menus to be initialized and updated.
 void menus_init(void)
 {
-  update_queue::uq()->add([](void *) {
-    real_menus_init();
-    real_menus_update();
-  });
+  update_queue::uq()->add(
+      [](void *) {
+        real_menus_init();
+        real_menus_update();
+      },
+      nullptr);
 }
 
 // Update the menus.
@@ -324,14 +347,14 @@ static void menus_update_callback(void *) { real_menus_update(); }
 void menus_update(void)
 {
   if (!update_queue::uq()->has_callback(menus_update_callback)) {
-    update_queue::uq()->add(menus_update_callback);
+    update_queue::uq()->add(menus_update_callback, nullptr);
   }
 }
 
 // Update multipliers/policy dialog.
 void multipliers_dialog_update(void)
 {
-  update_queue::uq()->add(real_multipliers_dialog_update);
+  update_queue::uq()->add(real_multipliers_dialog_update, nullptr);
 }
 
 // Update cities gui.
@@ -383,7 +406,7 @@ void popup_city_dialog(struct city *pcity)
   pcity->client.need_updates =
       static_cast<city_updates>(static_cast<int>(pcity->client.need_updates)
                                 | static_cast<int>(CU_POPUP_DIALOG));
-  update_queue::uq()->add(cities_update_callback);
+  update_queue::uq()->add(cities_update_callback, nullptr);
 }
 
 // Request the city dialog to be updated for the city.
@@ -392,7 +415,7 @@ void refresh_city_dialog(struct city *pcity)
   pcity->client.need_updates =
       static_cast<city_updates>(static_cast<int>(pcity->client.need_updates)
                                 | static_cast<int>(CU_UPDATE_DIALOG));
-  update_queue::uq()->add(cities_update_callback);
+  update_queue::uq()->add(cities_update_callback, nullptr);
 }
 
 // Request the city to be updated in the city report.
@@ -401,47 +424,47 @@ void city_report_dialog_update_city(struct city *pcity)
   pcity->client.need_updates =
       static_cast<city_updates>(static_cast<int>(pcity->client.need_updates)
                                 | static_cast<int>(CU_UPDATE_REPORT));
-  update_queue::uq()->add(cities_update_callback);
+  update_queue::uq()->add(cities_update_callback, nullptr);
 }
 
 // Update the connection list in the start page.
 void conn_list_dialog_update(void)
 {
-  update_queue::uq()->add(real_conn_list_dialog_update);
+  update_queue::uq()->add(real_conn_list_dialog_update, nullptr);
 }
 
 // Update the nation report.
 void players_dialog_update(void)
 {
-  update_queue::uq()->add(real_players_dialog_update);
+  update_queue::uq()->add(real_players_dialog_update, nullptr);
 }
 
 // Update the city report.
 void city_report_dialog_update(void)
 {
-  update_queue::uq()->add(real_city_report_dialog_update);
+  update_queue::uq()->add(real_city_report_dialog_update, nullptr);
 }
 
 // Update the science report.
 void science_report_dialog_update(void)
 {
-  update_queue::uq()->add(real_science_report_dialog_update);
+  update_queue::uq()->add(real_science_report_dialog_update, nullptr);
 }
 
 // Update the economy report.
 void economy_report_dialog_update(void)
 {
-  update_queue::uq()->add(real_economy_report_dialog_update);
+  update_queue::uq()->add(real_economy_report_dialog_update, nullptr);
 }
 
 // Update the units report.
 void units_report_dialog_update(void)
 {
-  update_queue::uq()->add(real_units_report_dialog_update);
+  update_queue::uq()->add(real_units_report_dialog_update, nullptr);
 }
 
 // Update the units report.
 void unit_select_dialog_update(void)
 {
-  update_queue::uq()->add(unit_select_dialog_update_real);
+  update_queue::uq()->add(unit_select_dialog_update_real, nullptr);
 }

--- a/client/update_queue.cpp
+++ b/client/update_queue.cpp
@@ -60,17 +60,17 @@ void update_queue::drop()
 }
 
 // Moves the instances waiting to the request_id to the callback queue.
-void update_queue::wq_run_requests(int request_id)
+void update_queue::wq_run_requests(waitingQueue &hash, int request_id)
 {
-  if (!wq_processing_finished.contains(request_id)) {
+  if (!hash.contains(request_id)) {
     return;
   }
 
-  auto list = wq_processing_finished.value(request_id);
+  auto list = hash.value(request_id);
   for (const auto &wq_data : qAsConst(list)) {
     queue.push_back(wq_data);
   }
-  wq_processing_finished.remove(request_id);
+  hash.remove(request_id);
 }
 
 // Free a waiting queue data.
@@ -85,11 +85,11 @@ void update_queue::wq_data_destroy(waiting_queue_data &wq_data)
 }
 
 // Connects the callback to a network event.
-void update_queue::wq_add_request(int request_id, uq_callback_t callback,
-                                  void *data, uq_free_fn_t free_data_func)
+void update_queue::wq_add_request(waitingQueue &hash, int request_id,
+                                  uq_callback_t callback, void *data,
+                                  uq_free_fn_t free_data_func)
 {
-  wq_processing_finished[request_id].append(
-      {callback, data, free_data_func});
+  hash[request_id].append({callback, data, free_data_func});
 }
 
 // clears content
@@ -113,7 +113,7 @@ update_queue::~update_queue() { init(); }
 // Moves the instances waiting to the request_id to the callback queue.
 void update_queue::processing_finished(int request_id)
 {
-  wq_run_requests(request_id);
+  wq_run_requests(wq_processing_finished, request_id);
 }
 
 // Unqueue all updates.
@@ -162,7 +162,8 @@ void update_queue::connect_processing_finished(int request_id,
                                                uq_callback_t callback,
                                                void *data)
 {
-  wq_add_request(request_id, callback, data, nullptr);
+  wq_add_request(wq_processing_finished, request_id, callback, data,
+                 nullptr);
 }
 
 /**
@@ -181,7 +182,8 @@ void update_queue::connect_processing_finished_unique(int request_id,
       }
     }
   }
-  wq_add_request(request_id, callback, data, nullptr);
+  wq_add_request(wq_processing_finished, request_id, callback, data,
+                 nullptr);
 }
 
 // Connects the callback to the end of the processing (in server side) of
@@ -190,7 +192,8 @@ void update_queue::connect_processing_finished_full(
     int request_id, uq_callback_t callback, void *data,
     uq_free_fn_t free_data_func)
 {
-  wq_add_request(request_id, callback, data, free_data_func);
+  wq_add_request(wq_processing_finished, request_id, callback, data,
+                 free_data_func);
 }
 
 namespace {

--- a/client/update_queue.h
+++ b/client/update_queue.h
@@ -47,7 +47,7 @@ public:
   static void drop();
   ~update_queue();
   void init();
-  void add(uq_callback_t callback);
+  void add(uq_callback_t callback, void *data);
   void processing_finished(int request_id);
   bool has_callback(uq_callback_t callback);
   bool has_callback_full(uq_callback_t cb, const void **data,

--- a/client/update_queue.h
+++ b/client/update_queue.h
@@ -19,26 +19,26 @@
 typedef void (*uq_callback_t)(void *data);
 typedef void (*uq_free_fn_t)(void *data);
 
+// Data type in 'update_queue'.
+struct update_queue_data {
+  void *data;
+  uq_free_fn_t free_data_func;
+};
+
 // Type of data listed in 'wq_processing_started' and
 // 'wq_processing_finished.'
 struct waiting_queue_data {
   uq_callback_t callback;
-  void *data;
-  uq_free_fn_t free_data_func;
-
-  bool operator==(const waiting_queue_data &other) const
-  {
-    return callback == other.callback && data == other.data
-           && free_data_func == other.free_data_func;
-  }
+  struct update_queue_data *uq_data;
 };
 
-typedef QList<waiting_queue_data> waitq_list;
-typedef QHash<int, waitq_list> waitingQueue;
+typedef QList<struct waiting_queue_data *> waitq_list;
+typedef QPair<uq_callback_t, struct update_queue_data *> updatePair;
+typedef QHash<int, waitq_list *> waitingQueue;
 
 class update_queue {
   static update_queue *m_instance;
-  QQueue<waiting_queue_data> queue;
+  QQueue<updatePair> queue;
   waitingQueue wq_processing_finished;
   bool has_idle_cb = {false};
 
@@ -61,10 +61,16 @@ public:
 
 private:
   update_queue() = default;
+  struct update_queue_data *data_new(void *data, uq_free_fn_t free_fn);
+  void data_destroy(struct update_queue_data *dt);
   void update_unqueue();
-  void push(const waiting_queue_data &wq);
+  void push(uq_callback_t cb, struct update_queue_data *dt);
+  struct update_queue_data *
+  wq_data_extract(struct waiting_queue_data *wq_data);
   void wq_run_requests(waitingQueue &hash, int request_id);
-  void wq_data_destroy(waiting_queue_data &wq_data);
+  void wq_data_destroy(struct waiting_queue_data *wq_data);
+  struct waiting_queue_data *wq_data_new(uq_callback_t callback, void *data,
+                                         uq_free_fn_t free_fn);
   void wq_add_request(waitingQueue &hash, int request_id, uq_callback_t cb,
                       void *data, uq_free_fn_t free_fn);
 };

--- a/client/update_queue.h
+++ b/client/update_queue.h
@@ -63,10 +63,10 @@ private:
   update_queue() = default;
   void update_unqueue();
   void push(const waiting_queue_data &wq);
-  void wq_run_requests(int request_id);
+  void wq_run_requests(waitingQueue &hash, int request_id);
   void wq_data_destroy(waiting_queue_data &wq_data);
-  void wq_add_request(int request_id, uq_callback_t cb, void *data,
-                      uq_free_fn_t free_fn);
+  void wq_add_request(waitingQueue &hash, int request_id, uq_callback_t cb,
+                      void *data, uq_free_fn_t free_fn);
 };
 
 bool update_queue_is_switching_page(void);


### PR DESCRIPTION
Reverts commits touching `update_queue.{h,cpp}` as needed to undo the culprit for #1485.

Closes #1485.