### PR TITLE
Bump jidicula/clang-format-action to 4.9.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -414,7 +414,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run clang-format style check for C/C++
-      uses: jidicula/clang-format-action@v4.4.0
+      uses: jidicula/clang-format-action@v4.9.0
       with:
         clang-format-version: '11'
         exclude-regex: 'dependencies'


### PR DESCRIPTION
4.4.0 started failing today for clang-format-11. Since 4.5.0, the action supports use even older versions so 11 should be fine.

Closes #1503.