### PR TITLE
Close the tile info popup when another button is pressed

### DIFF
--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -376,13 +376,11 @@ void map_view::shortcut_released(Qt::MouseButton bt)
   auto md = QApplication::keyboardModifiers();
   auto pos = mapFromGlobal(QCursor::pos()) / scale();
 
-  auto sc = fc_shortcuts::sc()->get_shortcut(SC_POPUP_INFO);
-  if (bt == sc.buttons && md == sc.modifiers) {
+  if (info_tile::shown()) {
     popdown_tile_info();
-    return;
   }
 
-  sc = fc_shortcuts::sc()->get_shortcut(SC_SELECT_BUTTON);
+  auto sc = fc_shortcuts::sc()->get_shortcut(SC_SELECT_BUTTON);
   if (bt == sc.buttons && md == sc.modifiers) {
     if (king()->trade_gen.hover_city || king()->rallies.hover_city) {
       king()->trade_gen.hover_city = false;

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -758,6 +758,11 @@ void info_tile::drop()
 }
 
 /**
+ * Check if the info tile is currently shown.
+ */
+bool info_tile::shown() { return m_instance && m_instance->isVisible(); }
+
+/**
    Returns given instance
  */
 info_tile *info_tile::i(struct tile *p)

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -122,6 +122,8 @@ class info_tile : public QLabel {
 public:
   static info_tile *i(struct tile *p = nullptr);
   static void drop();
+  static bool shown();
+
   struct tile *itile;
 
 protected:


### PR DESCRIPTION
...and not only when releasing the middle mouse button.

Closes #1120.