### PR TITLE
Improve contrast in the chat

### DIFF
--- a/data/themes/gui-qt/Classic/theme.conf
+++ b/data/themes/gui-qt/Classic/theme.conf
@@ -22,3 +22,20 @@ PlaceholderText = #232627
 Foreground = #232627
 WindowText = #232627
 Background = #EFF0F1
+
+[color_mapping]
+; Colors used in the chat. Chosen to have a contrast ratio > 5 on black, as
+; defined in the Web Content Accessibility Guidelines (WCAG) 2.1
+
+7F7F7F = #7F7F7F ; log
+8B0000 = #FF0000 ; server, vote failed
+;EF7F00 = #EF7F00 ; client
+0000FF = #00FFFF ; editor
+00008B = #0099FF ; public chat
+551166 = #ff00ff ; ally chat
+A020F0 = #b340ff ; private chat
+;2B008B = ; lua console input
+;FF0000 = ; lua console error
+;CF2020 = ; lua console warning
+;006400 = ; lua console normal
+;B8B8B8 = ; lua console verbose

--- a/data/themes/gui-qt/NightStalker/theme.conf
+++ b/data/themes/gui-qt/NightStalker/theme.conf
@@ -22,3 +22,20 @@ ToolTipText = #fcfcfc
 PlaceholderText = #fcfcfc
 Foreground = #fcfcfc
 Background = #2a2e32
+
+[color_mapping]
+; Colors used in the chat. Chosen to have a contrast ratio > 5 on black, as
+; defined in the Web Content Accessibility Guidelines (WCAG) 2.1
+
+7F7F7F = #7F7F7F ; log
+8B0000 = #FF0000 ; server, vote failed
+;EF7F00 = #EF7F00 ; client
+0000FF = #00FFFF ; editor
+00008B = #0099FF ; public chat
+551166 = #ff00ff ; ally chat
+A020F0 = #b340ff ; private chat
+;2B008B = ; lua console input
+;FF0000 = ; lua console error
+;CF2020 = ; lua console warning
+;006400 = ; lua console normal
+;B8B8B8 = ; lua console verbose


### PR DESCRIPTION
Contrast was too low for some of the colors used by the server. Use the color replacement feature to make them stand out on the black background.

Closes #1510.