### PR TITLE
Clear closing reason for connection object when a client connects

### DIFF
--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -315,6 +315,7 @@ int server_make_connection(QTcpSocket *new_sock, const QString &client_addr)
     if (!pconn->used) {
       connection_common_init(pconn);
       pconn->sock = new_sock;
+      pconn->closing_reason.clear();
       pconn->observer = false;
       pconn->playing = nullptr;
       pconn->capability[0] = '\0';


### PR DESCRIPTION
The closing reason would otherwise persist from the previous client disconnecting and would appear when listing connected clients via the `/list connections` command.

Part of #1517