### PR TITLE
Add a CMakePreset with the flags used in major distros and enable in …

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,37 @@ jobs:
             build/Linux-x86_64/freeciv21_*_amd64.deb
             build/Linux-x86_64/freeciv21_*_amd64.deb.sha256
 
+  flagstest:
+    name: "Additional compile flags in Ubuntu"
+    needs: clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install GCC
+        run: |
+          sudo apt-get install g++
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            cmake \
+            ninja-build \
+            python3 \
+            gettext \
+            qtbase5-dev \
+            libqt5svg5-dev \
+            libkf5archive-dev \
+            liblua5.3-dev \
+            libsqlite3-dev \
+            libsdl2-mixer-dev
+      - name: Configure
+        run: |
+            cmake . -B build -G Ninja --preset "DistroRelease"
+      - name: Build
+        run: |
+          cmake --build build
   windows:
     name: "Windows MSYS2 (gcc)"
     runs-on: windows-latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,6 +58,21 @@
       }
     },
     {
+      "name": "DistroRelease",
+      "displayName": "Build Everything with default flags in major distros ",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "None",
+        "CMAKE_CXX_FLAGS": "-O2 -g -Wp,-DGLIBCXX_ASSERTIONS -O2 -g -Wformat -Wall -Wextra -Werror=format-security -Werror=return-type -fcf-protection -U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -flto=auto -DNDEBUG -Wno-sign-compare -Warray-bounds -Wdelete-incomplete -Wint-in-bool-context -Wreturn-type -Wsequence-point -Wswitch -Wunused-value -Wmaybe-uninitialized -Wstringop-truncation -fPIC -march=x86-64 -mtune=generic -pipe -fno-plt -fexceptions -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto",
+        "CMAKE_C_FLAGS": "-O2 -g -O2 -g -Wformat -Wall -Wextra -Werror=format-security -Werror=return-type -fcf-protection -U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -flto=auto -DNDEBUG -Wno-sign-compare -Warray-bounds -Wdelete-incomplete -Wint-in-bool-context -Wreturn-type -Wsequence-point -Wswitch -Wunused-value -Wmaybe-uninitialized -Wstringop-truncation -fPIC -march=x86-64 -mtune=generic -pipe -fno-plt -fexceptions -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto",
+        "FREECIV_ENABLE_TOOLS": "ON",
+        "FREECIV_ENABLE_SERVER": "ON",
+        "FREECIV_ENABLE_CLIENT": "ON",
+        "FREECIV_ENABLE_NLS": "ON"
+      }
+    },
+    {
       "name": "clazy",
       "displayName": "Check for clazy warnings",
       "generator": "Unix Makefiles",

--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -994,7 +994,7 @@ void popup_notify_dialog(const char *caption, const char *headline,
   if (strcmp(caption, "Traveler's Report:") == 0) {
     currentdemographics = false;
   }
-  fc_snprintf(inputcompare, sizeof(inputcompare),
+  fc_snprintf(inputcompare, sizeof(inputcompare), "%s",
               currentdemographics ? caption : headline);
 
   nd_list = queen()->game_tab_widget->findChildren<notify_dialog *>();
@@ -1002,7 +1002,7 @@ void popup_notify_dialog(const char *caption, const char *headline,
     loopnd = nd_list[i];
     loopcompare = currentdemographics ? loopnd->qcaption : loopnd->qheadline;
     loopcomparestr = loopcompare.toStdString();
-    fc_snprintf(loopcomparechar, sizeof(loopcomparechar),
+    fc_snprintf(loopcomparechar, sizeof(loopcomparechar), "%s",
                 loopcomparestr.c_str());
 
     if (strcmp(loopcomparechar, inputcompare) == 0) {


### PR DESCRIPTION
…actions

Fixes #1530

This enables linker flags too so fixes #172

Also fix a issue which pops up from enabling -Werror=format-security and have more secure format strings.