### PR TITLE
Initialize options after creating the QApplication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,6 +165,12 @@ jobs:
           files: |
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe.sha256
+      - name: Upload a build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Windows-exe
+          path: build/Windows-x86_64/Freeciv21-*.exe
+
   windows_clang_msvc:
     name: "Windows Clang"
     runs-on: windows-latest
@@ -196,12 +202,7 @@ jobs:
          -DCMAKE_TOOLCHAIN_FILE="${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake" -A x64 -T ClangCL
       - name: Building
         run: cmake --build build --config Debug
-      - name: Upload a build
-        uses: actions/upload-artifact@v3
-        with:
-          name: Client (MSVC_Clang x64)
-          path: ${{github.workspace}}/build/Debug/freeciv21-client.exe
-          if-no-files-found: error
+
   os_x:
     name: "macOS"
     runs-on: macos-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.repository }}-${{ github.head_ref || github.run_id }}-{{ github.action }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -8,7 +8,7 @@ on:
   pull_request_target: {}
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.repository }}-${{ github.head_ref || github.run_id }}-{{ github.action }}
   cancel-in-progress: true
 
 jobs:

--- a/client/audio.cpp
+++ b/client/audio.cpp
@@ -173,7 +173,7 @@ bool audio_select_plugin(const QString &name)
   qDebug("Plugin '%s' is now selected",
          qUtf8Printable(plugins[selected_plugin].name));
 
-  plugins[selected_plugin].set_volume(gui_options.sound_effects_volume
+  plugins[selected_plugin].set_volume(gui_options->sound_effects_volume
                                       / 100.0);
 
   return true;
@@ -384,10 +384,10 @@ static void music_finished_callback()
   bool usage_enabled = true;
   switch (current_usage) {
   case MU_MENU:
-    usage_enabled = gui_options.sound_enable_menu_music;
+    usage_enabled = gui_options->sound_enable_menu_music;
     break;
   case MU_INGAME:
-    usage_enabled = gui_options.sound_enable_game_music;
+    usage_enabled = gui_options->sound_enable_game_music;
     break;
   }
 
@@ -509,7 +509,7 @@ void audio_play_sound(const QString &tag, const QString &alt_tag)
   const QString pretty_alt_tag =
       alt_tag.isEmpty() ? QStringLiteral("(null)") : alt_tag;
 
-  if (gui_options.sound_enable_effects) {
+  if (gui_options->sound_enable_effects) {
     fc_assert_ret(tag != nullptr);
 
     log_debug("audio_play_sound('%s', '%s')", qUtf8Printable(tag),

--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -253,7 +253,7 @@ void chat_listener::send_chat_message(const QString &message)
    * Option to send to allies by default
    */
   if (!message.isEmpty()) {
-    if (client_state() >= C_S_RUNNING && gui_options.gui_qt_allied_chat_only
+    if (client_state() >= C_S_RUNNING && gui_options->gui_qt_allied_chat_only
         && is_plain_public_message(message)) {
       send_chat((QString(CHAT_ALLIES_PREFIX) + " " + message).toLocal8Bit());
     } else {
@@ -424,7 +424,7 @@ chat_widget::chat_widget(QWidget *parent)
     QString icon_name =
         priv ? QLatin1String("public") : QLatin1String("private");
     cb->setIcon(fcIcons::instance()->getIcon(icon_name));
-    gui_options.gui_qt_allied_chat_only = priv;
+    gui_options->gui_qt_allied_chat_only = priv;
   });
   connect(chat_output, &QTextBrowser::anchorClicked, this,
           &chat_widget::anchor_clicked);

--- a/client/citybar.cpp
+++ b/client/citybar.cpp
@@ -297,7 +297,7 @@ void citybar_painter::option_changed(option *opt)
 citybar_painter *citybar_painter::current()
 {
   if (!s_current) {
-    set_current(gui_options.default_city_bar_style_name);
+    set_current(gui_options->default_city_bar_style_name);
   }
   return s_current.get();
 }
@@ -363,7 +363,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
   second.set_text_shadow_brush(dark_color);
 
   // First line
-  if (gui_options.draw_city_names) {
+  if (gui_options->draw_city_names) {
     // City name
     format.setFont(get_font(FONT_CITY_NAME));
     format.setForeground(get_color(tileset, COLOR_MAPVIEW_CITYTEXT));
@@ -372,7 +372,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
     static const QString en_space = QStringLiteral(" ");
 
     // Growth string (eg "5")
-    if (gui_options.draw_city_growth && can_see_inside) {
+    if (gui_options->draw_city_growth && can_see_inside) {
       // Separator (assuming the em space is wider for the city name)
       first.add_text(en_space, format);
 
@@ -383,7 +383,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
     }
 
     // Trade routes (eg "3/4")
-    if (gui_options.draw_city_trade_routes && can_see_inside) {
+    if (gui_options->draw_city_trade_routes && can_see_inside) {
       // Separator (can still be the city name format)
       first.add_text(en_space, format);
 
@@ -401,7 +401,7 @@ QRect simple_citybar_painter::paint(QPainter &painter,
   }
 
   // Second line
-  if (gui_options.draw_city_productions && can_see_inside) {
+  if (gui_options->draw_city_productions && can_see_inside) {
     // Get text
     char prod[512];
     get_city_mapview_production(pcity, prod, sizeof(prod));
@@ -447,16 +447,16 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
   const bool can_see_inside =
       (client_is_global_observer() || city_owner(pcity) == client_player());
   const bool should_draw_productions =
-      can_see_inside && gui_options.draw_city_productions;
+      can_see_inside && gui_options->draw_city_productions;
   const bool should_draw_growth =
-      can_see_inside && gui_options.draw_city_growth;
+      can_see_inside && gui_options->draw_city_growth;
   const bool should_draw_trade_routes =
-      can_see_inside && gui_options.draw_city_trade_routes;
+      can_see_inside && gui_options->draw_city_trade_routes;
   const bool should_draw_lower_bar = should_draw_productions
                                      || should_draw_growth
                                      || should_draw_trade_routes;
 
-  if (!gui_options.draw_city_names && !should_draw_lower_bar) {
+  if (!gui_options->draw_city_names && !should_draw_lower_bar) {
     // Nothing to draw.
     return QRect();
   }
@@ -482,7 +482,7 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
   line_of_text first, second;
 
   // First line
-  if (gui_options.draw_city_names) {
+  if (gui_options->draw_city_names) {
     // Flag
     first.add_icon(get_city_flag_sprite(t, pcity));
 
@@ -586,7 +586,7 @@ QRect traditional_citybar_painter::paint(QPainter &painter,
   painter.drawTiledPixmap(bounds, *citybar->background);
   painter.setPen(owner_color);
   painter.drawRect(bounds);
-  if (gui_options.draw_city_names && should_draw_lower_bar) {
+  if (gui_options->draw_city_names && should_draw_lower_bar) {
     painter.drawLine(bounds.topLeft() + QPointF(0, first.height() + 1),
                      bounds.topRight() + QPointF(0, first.height() + 1));
   }
@@ -614,11 +614,11 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   const bool can_see_inside =
       (client_is_global_observer() || city_owner(pcity) == client_player());
   const bool should_draw_productions =
-      can_see_inside && gui_options.draw_city_productions;
+      can_see_inside && gui_options->draw_city_productions;
   const bool should_draw_growth =
-      can_see_inside && gui_options.draw_city_growth;
+      can_see_inside && gui_options->draw_city_growth;
   const bool should_draw_trade_routes =
-      can_see_inside && gui_options.draw_city_trade_routes;
+      can_see_inside && gui_options->draw_city_trade_routes;
 
   // Get the tileset to grab stuff from
   const auto t = get_tileset();
@@ -731,7 +731,7 @@ QRect polished_citybar_painter::paint(QPainter &painter,
   }
 
   // Name
-  if (gui_options.draw_city_names) {
+  if (gui_options->draw_city_names) {
     format.setFont(get_font(FONT_CITY_NAME));
     format.setForeground(text_color);
     line.add_text(name, format, false, text_margins);

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -146,7 +146,7 @@ void get_city_dialog_production(struct city *pcity, char *buffer,
   cost_str = city_production_cost_str(pcity);
 
   if (turns < FC_INFINITY) {
-    if (gui_options.concise_city_production) {
+    if (gui_options->concise_city_production) {
       fc_snprintf(time_str, sizeof(time_str), "%3d", turns);
     } else {
       fc_snprintf(time_str, sizeof(time_str),
@@ -154,10 +154,10 @@ void get_city_dialog_production(struct city *pcity, char *buffer,
     }
   } else {
     fc_snprintf(time_str, sizeof(time_str), "%s",
-                gui_options.concise_city_production ? "-" : _("never"));
+                gui_options->concise_city_production ? "-" : _("never"));
   }
 
-  if (gui_options.concise_city_production) {
+  if (gui_options->concise_city_production) {
     fc_snprintf(buffer, buffer_len, _("%3d/%s:%s"), stock, cost_str,
                 time_str);
   } else {

--- a/client/cityrep.cpp
+++ b/client/cityrep.cpp
@@ -412,7 +412,7 @@ void city_widget::city_view()
   pcity = selected_cities[0];
 
   Q_ASSERT(pcity != nullptr);
-  if (gui_options.center_when_popup_city) {
+  if (gui_options->center_when_popup_city) {
     queen()->mapview_wdg->center_on_tile(pcity->tile);
   }
   real_city_dialog_popup(pcity);

--- a/client/cityrepdata.cpp
+++ b/client/cityrepdata.cpp
@@ -560,7 +560,7 @@ static const char *cr_entry_building(const struct city *pcity,
 {
   static char buf[192];
   const char *from_worklist = worklist_is_empty(&pcity->worklist) ? ""
-                              : gui_options.concise_city_production
+                              : gui_options->concise_city_production
                                   ? "+"
                                   : _("(worklist)");
 

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -306,6 +306,10 @@ static void client_game_reset()
 int client_main(int argc, char *argv[])
 {
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QApplication::setHighDpiScaleFactorRoundingPolicy(
+      Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
   QApplication app(argc, argv);
   QCoreApplication::setApplicationVersion(VERSION_STRING);
 

--- a/client/climisc.cpp
+++ b/client/climisc.cpp
@@ -862,7 +862,7 @@ void handle_event(const char *featured_text, struct tile *ptile,
   /* Maybe highlight our player and user names if someone is talking
    * about us. */
   if (-1 != conn_id && client.conn.id != conn_id
-      && ft_color_requested(gui_options.highlight_our_names)) {
+      && ft_color_requested(gui_options->highlight_our_names)) {
     const char *username = client.conn.username;
     size_t userlen = qstrlen(username);
     const char *playername = ((client_player() && !client_is_observer())
@@ -883,7 +883,7 @@ void handle_event(const char *featured_text, struct tile *ptile,
       if (nullptr != username && 0 == fc_strncasecmp(p, username, userlen)) {
         struct text_tag *ptag =
             text_tag_new(TTT_COLOR, p - plain_text, p - plain_text + userlen,
-                         gui_options.highlight_our_names);
+                         gui_options->highlight_our_names);
 
         fc_assert(ptag != nullptr);
 
@@ -895,7 +895,7 @@ void handle_event(const char *featured_text, struct tile *ptile,
                  && 0 == fc_strncasecmp(p, playername, playerlen)) {
         struct text_tag *ptag = text_tag_new(
             TTT_COLOR, p - plain_text, p - plain_text + playerlen,
-            gui_options.highlight_our_names);
+            gui_options->highlight_our_names);
 
         fc_assert(ptag != nullptr);
 
@@ -1147,24 +1147,24 @@ bool mapimg_client_define()
 
   // Map image definition: zoom, turns
   fc_snprintf(str, sizeof(str), "zoom=%d:turns=0:format=%s",
-              gui_options.mapimg_zoom, gui_options.mapimg_format);
+              gui_options->mapimg_zoom, gui_options->mapimg_format);
 
   // Map image definition: show
   if (client_is_global_observer()) {
     cat_snprintf(str, sizeof(str), ":show=all");
     // use all available knowledge
-    gui_options.mapimg_layer[MAPIMG_LAYER_KNOWLEDGE] = false;
+    gui_options->mapimg_layer[MAPIMG_LAYER_KNOWLEDGE] = false;
   } else {
     cat_snprintf(str, sizeof(str), ":show=plrid:plrid=%d",
                  player_index(client.conn.playing));
     // use only player knowledge
-    gui_options.mapimg_layer[MAPIMG_LAYER_KNOWLEDGE] = true;
+    gui_options->mapimg_layer[MAPIMG_LAYER_KNOWLEDGE] = true;
   }
 
   // Map image definition: map
   for (layer = mapimg_layer_begin(); layer != mapimg_layer_end();
        layer = mapimg_layer_next(layer)) {
-    if (gui_options.mapimg_layer[layer]) {
+    if (gui_options->mapimg_layer[layer]) {
       mi_map[map_pos++] = mapimg_layer_name(layer)[0];
     }
   }

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -157,9 +157,9 @@ int connect_to_server(const QUrl &url, char *errbuf, int errbufsize)
     return -1;
   }
 
-  if (gui_options.use_prev_server) {
-    sz_strlcpy(gui_options.default_server_host, qUtf8Printable(url.host()));
-    gui_options.default_server_port = url.port(DEFAULT_SOCK_PORT);
+  if (gui_options->use_prev_server) {
+    sz_strlcpy(gui_options->default_server_host, qUtf8Printable(url.host()));
+    gui_options->default_server_port = url.port(DEFAULT_SOCK_PORT);
   }
 
   return 0;
@@ -218,7 +218,7 @@ void disconnect_from_server()
   }
   output_window_append(ftc_client, _("Disconnected from server."));
 
-  if (gui_options.save_options_on_exit) {
+  if (gui_options->save_options_on_exit) {
     options_save(nullptr);
   }
 }

--- a/client/control.cpp
+++ b/client/control.cpp
@@ -327,7 +327,7 @@ bool should_ask_server_for_actions(const struct unit *punit)
           /* The player is interested in getting a pop up for a mere
            * arrival. */
           || (punit->action_decision_want == ACT_DEC_PASSIVE
-              && gui_options.popup_actor_arrival));
+              && gui_options->popup_actor_arrival));
 }
 
 /**
@@ -420,7 +420,7 @@ void auto_center_on_focus_unit()
 {
   struct tile *ptile = find_a_focus_unit_tile_to_center_on();
 
-  if (ptile && gui_options.auto_center_on_unit
+  if (ptile && gui_options->auto_center_on_unit
       && !tile_visible_and_not_on_border_mapcanvas(ptile)) {
     queen()->mapview_wdg->center_on_tile(ptile);
   }
@@ -440,7 +440,7 @@ static void current_focus_append(struct unit *punit)
     ask_server_for_actions(punit);
   }
 
-  if (gui_options.unit_selection_clears_orders) {
+  if (gui_options->unit_selection_clears_orders) {
     clear_unit_orders(punit);
   }
 }
@@ -700,7 +700,7 @@ void unit_focus_advance()
    * non-AI unit this turn which was focused, then fake a Turn Done
    * keypress.
    */
-  if (gui_options.auto_turn_done && num_units_in_old_focus > 0
+  if (gui_options->auto_turn_done && num_units_in_old_focus > 0
       && get_num_units_in_focus() == 0 && non_ai_unit_focus) {
     key_end_turn();
   }
@@ -1126,7 +1126,7 @@ void control_mouse_cursor(struct tile *ptile)
   const auto &active_units = get_units_in_focus();
   enum cursor_type mouse_cursor_type = CURSOR_DEFAULT;
 
-  if (!gui_options.enable_cursor_changes) {
+  if (!gui_options->enable_cursor_changes) {
     return;
   }
 
@@ -1465,7 +1465,7 @@ void request_units_return()
   for (const auto unit : get_units_in_focus()) {
     // Find a path to the closest city
     auto finder = freeciv::path_finder(unit);
-    if (!gui_options.goto_into_unknown) {
+    if (!gui_options->goto_into_unknown) {
       finder.set_constraint(
           std::make_unique<freeciv::tile_known_constraint>(client_player()));
     }
@@ -1750,8 +1750,8 @@ void request_move_unit_direction(struct unit *punit, int dir)
 
   p.length = 1;
   p.orders[0].order =
-      (gui_options.popup_last_move_to_allied ? ORDER_ACTION_MOVE
-                                             : ORDER_MOVE);
+      (gui_options->popup_last_move_to_allied ? ORDER_ACTION_MOVE
+                                              : ORDER_MOVE);
   p.orders[0].dir = static_cast<direction8>(dir);
   p.orders[0].activity = ACTIVITY_LAST;
   p.orders[0].target = NO_TARGET;
@@ -2184,7 +2184,7 @@ void request_toggle_city_outlines()
     return;
   }
 
-  gui_options.draw_city_outlines = !gui_options.draw_city_outlines;
+  gui_options->draw_city_outlines = !gui_options->draw_city_outlines;
   update_map_canvas_visible();
 }
 
@@ -2197,7 +2197,7 @@ void request_toggle_city_output()
     return;
   }
 
-  gui_options.draw_city_output = !gui_options.draw_city_output;
+  gui_options->draw_city_output = !gui_options->draw_city_output;
   update_map_canvas_visible();
 }
 
@@ -2210,7 +2210,7 @@ void request_toggle_map_grid()
     return;
   }
 
-  gui_options.draw_map_grid ^= 1;
+  gui_options->draw_map_grid ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2223,7 +2223,7 @@ void request_toggle_map_borders()
     return;
   }
 
-  gui_options.draw_borders ^= 1;
+  gui_options->draw_borders ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2236,7 +2236,7 @@ void request_toggle_map_native()
     return;
   }
 
-  gui_options.draw_native ^= 1;
+  gui_options->draw_native ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2249,7 +2249,7 @@ void request_toggle_city_names()
     return;
   }
 
-  gui_options.draw_city_names ^= 1;
+  gui_options->draw_city_names ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2262,7 +2262,7 @@ void request_toggle_city_growth()
     return;
   }
 
-  gui_options.draw_city_growth ^= 1;
+  gui_options->draw_city_growth ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2275,7 +2275,7 @@ void request_toggle_city_productions()
     return;
   }
 
-  gui_options.draw_city_productions ^= 1;
+  gui_options->draw_city_productions ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2288,7 +2288,7 @@ void request_toggle_city_buycost()
     return;
   }
 
-  gui_options.draw_city_buycost ^= 1;
+  gui_options->draw_city_buycost ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2301,7 +2301,7 @@ void request_toggle_city_trade_routes()
     return;
   }
 
-  gui_options.draw_city_trade_routes ^= 1;
+  gui_options->draw_city_trade_routes ^= 1;
   update_map_canvas_visible();
 }
 
@@ -2365,7 +2365,7 @@ void do_move_unit(struct unit *punit, struct unit *target_unit)
   bool in_focus = unit_is_in_focus(punit);
 
   was_teleported = !is_tiles_adjacent(src_tile, dst_tile);
-  do_animation = (!was_teleported && gui_options.smooth_move_unit_msec > 0);
+  do_animation = (!was_teleported && gui_options->smooth_move_unit_msec > 0);
 
   if (!was_teleported && punit->activity != ACTIVITY_SENTRY
       && !unit_transported(punit)) {
@@ -2374,10 +2374,10 @@ void do_move_unit(struct unit *punit, struct unit *target_unit)
   }
 
   if (unit_owner(punit) == client.conn.playing
-      && gui_options.auto_center_on_unit && !unit_has_orders(punit)
+      && gui_options->auto_center_on_unit && !unit_has_orders(punit)
       && punit->activity != ACTIVITY_GOTO
       && punit->activity != ACTIVITY_SENTRY
-      && ((gui_options.auto_center_on_automated
+      && ((gui_options->auto_center_on_automated
            && punit->ssa_controller != SSA_NONE)
           || (punit->ssa_controller == SSA_NONE))
       && !tile_visible_and_not_on_border_mapcanvas(dst_tile)) {
@@ -2402,7 +2402,7 @@ void do_move_unit(struct unit *punit, struct unit *target_unit)
      * the tile without the unit (because it was unlinked above). */
     refresh_unit_mapcanvas(punit, src_tile, true);
 
-    if (!gui_options.auto_center_on_automated
+    if (!gui_options->auto_center_on_automated
         && punit->ssa_controller != SSA_NONE) {
       // Dont animate automatic units
     } else if (do_animation) {
@@ -2532,7 +2532,7 @@ void do_map_click(struct tile *ptile, enum quickselect_type qtype)
 
     if (qunit) {
       unit_focus_set_and_select(qunit);
-      maybe_goto = gui_options.keyboardless_goto;
+      maybe_goto = gui_options->keyboardless_goto;
     }
   } else if (nullptr != pcity
              && can_player_see_city_internals(client.conn.playing, pcity)) {
@@ -2540,14 +2540,14 @@ void do_map_click(struct tile *ptile, enum quickselect_type qtype)
     popup_city_dialog(pcity);
   } else if (!near_pcity && unit_list_size(ptile->units) == 0
              && nullptr == pcity && get_num_units_in_focus() > 0) {
-    maybe_goto = gui_options.keyboardless_goto;
+    maybe_goto = gui_options->keyboardless_goto;
   } else if (!near_pcity && unit_list_size(ptile->units) == 1
              && !get_transporter_occupancy(unit_list_get(ptile->units, 0))) {
     struct unit *punit = unit_list_get(ptile->units, 0);
 
     if (unit_owner(punit) == client.conn.playing) {
       if (can_unit_do_activity(punit, ACTIVITY_IDLE)) {
-        maybe_goto = gui_options.keyboardless_goto;
+        maybe_goto = gui_options->keyboardless_goto;
         if (qtype == SELECT_APPEND) {
           unit_focus_add(punit);
         } else {

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -76,7 +76,7 @@ fc_client::fc_client() : QMainWindow(), current_file(QLatin1String(""))
 
   menu_bar = new mr_menu();
   corner_wid = new fc_corner(this);
-  if (!gui_options.gui_qt_show_titlebar) {
+  if (!gui_options->gui_qt_show_titlebar) {
     menu_bar->setCornerWidget(corner_wid);
   }
   setMenuBar(menu_bar);
@@ -93,7 +93,7 @@ fc_client::fc_client() : QMainWindow(), current_file(QLatin1String(""))
   pages[PAGE_LOAD] = new page_load(central_wdg, this);
   pages[PAGE_NETWORK] = new page_network(central_wdg, this);
   pages[PAGE_NETWORK]->setVisible(false);
-  gui_options.gui_qt_allied_chat_only = true;
+  gui_options->gui_qt_allied_chat_only = true;
   path = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
   if (!path.isEmpty()) {
     QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, path);
@@ -211,7 +211,7 @@ void fc_client::switch_page(int new_pg)
     break;
   case PAGE_GAME:
     tileset_changed();
-    if (!gui_options.gui_qt_show_titlebar) {
+    if (!gui_options->gui_qt_show_titlebar) {
       setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
     }
     showMaximized();
@@ -222,7 +222,7 @@ void fc_client::switch_page(int new_pg)
     showMaximized();
     queen()->chat->update_widgets();
     status_bar->setVisible(false);
-    if (gui_options.gui_qt_fullscreen) {
+    if (gui_options->gui_qt_fullscreen) {
       king()->showFullScreen();
       queen()->game_tab_widget->showFullScreen();
     }

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -62,7 +62,7 @@ QFont fcFont::getFont(const QString &name, double zoom) const
 
   if (font_map.contains(name)) {
     auto font = font_map.value(name);
-    if (gui_options.zoom_scale_fonts) {
+    if (gui_options->zoom_scale_fonts) {
       font.setPointSizeF(font.pointSizeF() * zoom);
     }
     return font;

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -158,7 +158,7 @@ static enum tile_behavior get_TB_aggr(const struct tile *ptile,
                                       const struct pf_parameter *param)
 {
   if (known == TILE_UNKNOWN) {
-    if (!gui_options.goto_into_unknown) {
+    if (!gui_options->goto_into_unknown) {
       return TB_IGNORE;
     }
   } else if (is_non_allied_unit_tile(ptile, param->owner)
@@ -178,7 +178,7 @@ static enum tile_behavior get_TB_caravan(const struct tile *ptile,
                                          const struct pf_parameter *param)
 {
   if (known == TILE_UNKNOWN) {
-    if (!gui_options.goto_into_unknown) {
+    if (!gui_options->goto_into_unknown) {
       return TB_IGNORE;
     }
   } else if (is_non_allied_city_tile(ptile, param->owner)) {
@@ -203,7 +203,7 @@ static enum tile_behavior
 no_fights_or_unknown_goto(const struct tile *ptile, enum known_type known,
                           const struct pf_parameter *p)
 {
-  if (known == TILE_UNKNOWN && gui_options.goto_into_unknown) {
+  if (known == TILE_UNKNOWN && gui_options->goto_into_unknown) {
     // Special case allowing goto into the unknown.
     return TB_NORMAL;
   }
@@ -253,7 +253,7 @@ void enter_goto_state(const std::vector<unit *> &units)
     // This calls path_finder::path_finder(punit) behind the scenes
     // Need to do this because path_finder isn't copy-assignable
     auto [it, _] = goto_finders.emplace(punit->id, punit);
-    if (!gui_options.goto_into_unknown) {
+    if (!gui_options->goto_into_unknown) {
       it->second.set_constraint(
           std::make_unique<freeciv::tile_known_constraint>(client_player()));
     }

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -72,14 +72,14 @@ void ui_main()
     tileset_init(tileset);
     tileset_load_tiles(tileset);
     qApp->setWindowIcon(QIcon(*get_icon_sprite(tileset)));
-    if (gui_options.first_boot) {
+    if (gui_options->first_boot) {
       configure_fonts();
     }
     if (!isFontInstalled(QStringLiteral("Libertinus Sans"))
         && !isFontInstalled(QStringLiteral("Linux Libertine"))) {
       load_fonts();
     }
-    if (!load_theme(gui_options.gui_qt_default_theme_name)) {
+    if (!load_theme(gui_options->gui_qt_default_theme_name)) {
       gui_clear_theme();
     }
     freeciv_qt = new fc_client();
@@ -312,8 +312,8 @@ void gui_update_font(const QString &font_name, const QFont &font)
 
 void gui_update_allfonts()
 {
-  fcFont::instance()->setSizeAll(gui_options.gui_qt_increase_fonts);
-  gui_options.gui_qt_increase_fonts = 0;
+  fcFont::instance()->setSizeAll(gui_options->gui_qt_increase_fonts);
+  gui_options->gui_qt_increase_fonts = 0;
 }
 
 /**

--- a/client/layer.cpp
+++ b/client/layer.cpp
@@ -54,9 +54,9 @@ bool layer::do_draw_unit(const tile *ptile, const unit *punit) const
   }
 
   // Handle options to turn off drawing units.
-  if (gui_options.draw_units) {
+  if (gui_options->draw_units) {
     return true;
-  } else if (gui_options.draw_focus_unit && unit_is_in_focus(punit)) {
+  } else if (gui_options->draw_focus_unit && unit_is_in_focus(punit)) {
     return true;
   } else {
     return false;
@@ -80,12 +80,12 @@ bool layer::do_draw_unit(const tile *ptile, const unit *punit) const
 bool layer::solid_background(const tile *ptile, const unit *punit,
                              const city *pcity) const
 {
-  if (!gui_options.solid_color_behind_units) {
+  if (!gui_options->solid_color_behind_units) {
     // Solid background turned off (the default).
     return false;
   }
 
-  return do_draw_unit(ptile, punit) || (gui_options.draw_cities && pcity);
+  return do_draw_unit(ptile, punit) || (gui_options->draw_cities && pcity);
 }
 
 } // namespace freeciv

--- a/client/layer_background.cpp
+++ b/client/layer_background.cpp
@@ -34,16 +34,16 @@ std::vector<drawn_sprite> layer_background::fill_sprite_array(
 
   // Set up background color.
   player *owner = nullptr;
-  if (gui_options.solid_color_behind_units) {
+  if (gui_options->solid_color_behind_units) {
     /* Unit drawing is disabled when the view options are turned off,
      * but only where we're drawing on the mapview. */
     bool do_draw_unit =
         (punit
-         && (gui_options.draw_units || !ptile
-             || (gui_options.draw_focus_unit && unit_is_in_focus(punit))));
+         && (gui_options->draw_units || !ptile
+             || (gui_options->draw_focus_unit && unit_is_in_focus(punit))));
     if (do_draw_unit) {
       owner = unit_owner(punit);
-    } else if (pcity && gui_options.draw_cities) {
+    } else if (pcity && gui_options->draw_cities) {
       owner = city_owner(pcity);
     }
   }

--- a/client/map_updates_handler.cpp
+++ b/client/map_updates_handler.cpp
@@ -42,7 +42,7 @@ void map_updates_handler::update(const city *city, bool full)
 {
   if (!m_full_update) {
     const auto tile = city_tile(city);
-    if (full && (gui_options.draw_map_grid || gui_options.draw_borders)) {
+    if (full && (gui_options->draw_map_grid || gui_options->draw_borders)) {
       m_updates[tile] |= update_type::city_map;
     } else {
       // Assumption: city sprites are as big as unit sprites
@@ -74,7 +74,7 @@ void map_updates_handler::update(const unit *unit, bool full)
 {
   if (!m_full_update) {
     const auto tile = unit_tile(unit);
-    if (full && gui_options.draw_native) {
+    if (full && gui_options->draw_native) {
       update_all();
     } else if (full && unit_drawn_with_city_outline(unit, true)) {
       m_updates[tile] |= update_type::city_map;

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -262,8 +262,8 @@ void map_view::shortcut_pressed(shortcut_id id)
     }
 
     if (!goto_is_active()) {
-      stored_autocenter = gui_options.auto_center_on_unit;
-      gui_options.auto_center_on_unit = false;
+      stored_autocenter = gui_options->auto_center_on_unit;
+      gui_options->auto_center_on_unit = false;
       action_button_pressed(pos.x(), pos.y(), SELECT_FOCUS);
       return;
     }
@@ -301,7 +301,7 @@ void map_view::shortcut_pressed(shortcut_id id)
     break;
 
   case SC_RELOAD_THEME:
-    load_theme(gui_options.gui_qt_default_theme_name);
+    load_theme(gui_options->gui_qt_default_theme_name);
     break;
 
   case SC_RELOAD_TILESET:
@@ -393,7 +393,7 @@ void map_view::shortcut_released(Qt::MouseButton bt)
     }
     if (!keyboardless_goto_active || goto_is_active()) {
       action_button_pressed(pos.x(), pos.y(), SELECT_POPUP);
-      gui_options.auto_center_on_unit = stored_autocenter;
+      gui_options->auto_center_on_unit = stored_autocenter;
     }
     release_goto_button(pos.x(), pos.y());
     return;

--- a/client/mapctrl_common.cpp
+++ b/client/mapctrl_common.cpp
@@ -230,7 +230,7 @@ bool get_turn_done_button_state()
 {
   return can_end_turn()
          && (is_human(client.conn.playing)
-             || gui_options.ai_manual_turn_done);
+             || gui_options->ai_manual_turn_done);
 }
 
 /**

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -78,7 +78,7 @@ void draw_calculated_trade_routes(QPainter *painter)
   }
   auto color = get_color(tileset, COLOR_MAPVIEW_TRADE_ROUTES_NO_BUILT);
   // Draw calculated trade routes
-  if (gui_options.draw_city_trade_routes) {
+  if (gui_options->draw_city_trade_routes) {
     for (auto qgilles : qAsConst(king()->trade_gen.lines)) {
       base_map_distance_vector(&dx, &dy, TILE_XY(qgilles.t1),
                                TILE_XY(qgilles.t2));
@@ -148,7 +148,7 @@ map_view::map_view()
   timer->start(200);
   resize(0, 0);
   setMouseTracking(true);
-  stored_autocenter = gui_options.auto_center_on_unit;
+  stored_autocenter = gui_options->auto_center_on_unit;
   setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
 }
 
@@ -214,7 +214,7 @@ void map_view::center_on_tile(tile *tile, bool animate)
 
   m_origin_animation->stop();
   if (animate) {
-    m_origin_animation->setDuration(gui_options.smooth_center_slide_msec);
+    m_origin_animation->setDuration(gui_options->smooth_center_slide_msec);
     m_origin_animation->setCurrentTime(0);
 
     const auto start = QPointF(mapview.gui_x0, mapview.gui_y0);
@@ -259,7 +259,7 @@ double map_view::scale() const { return m_renderer->scale(); }
 void map_view::set_scale(double scale)
 {
   m_scale_animation->stop();
-  m_scale_animation->setDuration(gui_options.smooth_center_slide_msec);
+  m_scale_animation->setDuration(gui_options->smooth_center_slide_msec);
   m_scale_animation->setEndValue(scale);
   m_scale_animation->setCurrentTime(0);
   m_scale_animation->start();

--- a/client/mapview_common.cpp
+++ b/client/mapview_common.cpp
@@ -826,7 +826,7 @@ void put_one_element(QPixmap *pcanvas,
   bool city_unit = false;
   int dummy_x, dummy_y;
   auto sprites = layer->fill_sprite_array(ptile, pedge, pcorner, punit);
-  bool fog = (ptile && gui_options.draw_fog_of_war
+  bool fog = (ptile && gui_options->draw_fog_of_war
               && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile));
   if (ptile) {
     struct city *xcity = is_any_city_dialog_open();
@@ -1105,7 +1105,7 @@ static void draw_trade_routes_for_city(const struct city *pcity_src)
  */
 static void draw_trade_routes()
 {
-  if (!gui_options.draw_city_trade_routes) {
+  if (!gui_options->draw_city_trade_routes) {
     return;
   }
 
@@ -1519,7 +1519,7 @@ void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
     }
 
     unqueue_mapview_updates();
-    anim_delay(gui_options.smooth_combat_step_msec);
+    anim_delay(gui_options->smooth_combat_step_msec);
   }
 
   if (num_tiles_explode_unit > 0
@@ -1550,7 +1550,7 @@ void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
                  tileset_tile_height(tileset));
 
       flush_dirty();
-      anim_delay(gui_options.smooth_combat_step_msec);
+      anim_delay(gui_options->smooth_combat_step_msec);
     }
   }
 
@@ -1592,7 +1592,7 @@ void move_unit_map_canvas(struct unit *punit, struct tile *src_tile, int dx,
     float start_x, start_y;
     float canvas_dx, canvas_dy;
 
-    fc_assert(gui_options.smooth_move_unit_msec > 0);
+    fc_assert(gui_options->smooth_move_unit_msec > 0);
 
     map_to_gui_vector(tileset, &canvas_dx, &canvas_dy, dx, dy);
 
@@ -1612,7 +1612,7 @@ void move_unit_map_canvas(struct unit *punit, struct tile *src_tile, int dx,
     // Start the timer (AFTER the unqueue above).
     anim_timer->start();
 
-    const auto timing_ms = gui_options.smooth_move_unit_msec;
+    const auto timing_ms = gui_options->smooth_move_unit_msec;
     auto mytime = 0;
     do {
       mytime = MIN(anim_timer->elapsed(), timing_ms);
@@ -1772,7 +1772,7 @@ static void append_city_buycost_string(const struct city *pcity,
     return;
   }
 
-  if (!gui_options.draw_city_buycost || !city_can_buy(pcity)) {
+  if (!gui_options->draw_city_buycost || !city_can_buy(pcity)) {
     return;
   }
 

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -583,7 +583,7 @@ void mr_menu::setup_menus()
   connect(act, &QAction::triggered, this, &mr_menu::save_options_now);
   act = menu->addAction(_("Save Options on Exit"));
   act->setCheckable(true);
-  act->setChecked(gui_options.save_options_on_exit);
+  act->setChecked(gui_options->save_options_on_exit);
   menu->addSeparator();
 
   act = menu->addAction(_("Leave Game"));
@@ -602,7 +602,7 @@ void mr_menu::setup_menus()
   act = menu->addAction(_("Fullscreen"));
   shortcuts->link_action(SC_FULLSCREEN, act);
   act->setCheckable(true);
-  act->setChecked(gui_options.gui_qt_fullscreen);
+  act->setChecked(gui_options->gui_qt_fullscreen);
   connect(act, &QAction::triggered, this, &mr_menu::slot_fullscreen);
   menu->addSeparator();
   minimap_status = menu->addAction(_("Minimap"));
@@ -652,7 +652,7 @@ void mr_menu::setup_menus()
     act->setCheckable(true);
     act->setData(a);
     action_citybar->addAction(act);
-    if (a == QString(gui_options.default_city_bar_style_name)) {
+    if (a == QString(gui_options->default_city_bar_style_name)) {
       act->setChecked(true);
     }
     connect(act, &QAction::triggered, this, &mr_menu::slot_set_citybar);
@@ -660,57 +660,57 @@ void mr_menu::setup_menus()
 
   act = menu->addAction(_("City Outlines"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_outlines);
+  act->setChecked(gui_options->draw_city_outlines);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_outlines);
   act = menu->addAction(_("City Output"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_output);
+  act->setChecked(gui_options->draw_city_output);
   shortcuts->link_action(SC_CITY_OUTPUT, act);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_output);
   act = menu->addAction(_("Map Grid"));
   shortcuts->link_action(SC_MAP_GRID, act);
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_map_grid);
+  act->setChecked(gui_options->draw_map_grid);
   connect(act, &QAction::triggered, this, &mr_menu::slot_map_grid);
   act = menu->addAction(_("National Borders"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_borders);
+  act->setChecked(gui_options->draw_borders);
   shortcuts->link_action(SC_NAT_BORDERS, act);
   connect(act, &QAction::triggered, this, &mr_menu::slot_borders);
   act = menu->addAction(_("Units"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_units);
+  act->setChecked(gui_options->draw_units);
   connect(act, &QAction::toggled, this, [](bool checked) {
-    gui_options.draw_units = checked;
+    gui_options->draw_units = checked;
     update_map_canvas_visible();
   });
   act = menu->addAction(_("Native Tiles"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_native);
+  act->setChecked(gui_options->draw_native);
   act->setShortcut(QKeySequence(tr("ctrl+shift+n")));
   connect(act, &QAction::triggered, this, &mr_menu::slot_native_tiles);
   act = menu->addAction(_("City Names"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_names);
+  act->setChecked(gui_options->draw_city_names);
   shortcuts->link_action(SC_CITY_NAMES, act);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_names);
   act = menu->addAction(_("City Growth"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_growth);
+  act->setChecked(gui_options->draw_city_growth);
   act->setShortcut(QKeySequence(tr("ctrl+o")));
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_growth);
   act = menu->addAction(_("City Production Levels"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_productions);
+  act->setChecked(gui_options->draw_city_productions);
   shortcuts->link_action(SC_CITY_PROD, act);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_production);
   act = menu->addAction(_("City Buy Cost"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_buycost);
+  act->setChecked(gui_options->draw_city_buycost);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_buycost);
   act = menu->addAction(_("City Traderoutes"));
   act->setCheckable(true);
-  act->setChecked(gui_options.draw_city_trade_routes);
+  act->setChecked(gui_options->draw_city_trade_routes);
   shortcuts->link_action(SC_TRADE_ROUTES, act);
   connect(act, &QAction::triggered, this, &mr_menu::slot_city_traderoutes);
 
@@ -2463,8 +2463,8 @@ void enable_interface(bool enable)
  */
 void mr_menu::slot_fullscreen()
 {
-  gui_options.gui_qt_fullscreen = !gui_options.gui_qt_fullscreen;
-  if (gui_options.gui_qt_fullscreen) {
+  gui_options->gui_qt_fullscreen = !gui_options->gui_qt_fullscreen;
+  if (gui_options->gui_qt_fullscreen) {
     king()->setWindowState(king()->windowState() | Qt::WindowFullScreen);
   } else {
     king()->setWindowState(king()->windowState() & ~Qt::WindowFullScreen);
@@ -2512,7 +2512,7 @@ void mr_menu::slot_city_growth() { key_city_growth_toggle(); }
  */
 void mr_menu::zoom_scale_fonts()
 {
-  gui_options.zoom_scale_fonts = scale_fonts_status->isChecked();
+  gui_options->zoom_scale_fonts = scale_fonts_status->isChecked();
   update_map_canvas_visible();
 }
 
@@ -2533,9 +2533,9 @@ void mr_menu::slot_set_citybar()
 {
   for (auto *a : action_citybar->actions()) {
     if (a->isChecked()) {
-      fc_strlcpy(gui_options.default_city_bar_style_name,
+      fc_strlcpy(gui_options->default_city_bar_style_name,
                  qUtf8Printable(a->data().toString()),
-                 sizeof(gui_options.default_city_bar_style_name));
+                 sizeof(gui_options->default_city_bar_style_name));
       options_iterate(client_optset, poption)
       {
         if (QString(option_name(poption))

--- a/client/messagewin_common.cpp
+++ b/client/messagewin_common.cpp
@@ -55,7 +55,7 @@ void meswin_clear_older(int turn, int phase)
   int i;
   int j = 0;
 
-  if (!gui_options.show_previous_turn_messages) {
+  if (!gui_options->show_previous_turn_messages) {
     turn = MESWIN_CLEAR_ALL;
   }
 
@@ -178,7 +178,7 @@ void meswin_popup_city(int message_index)
     struct tile *ptile = messages[message_index]->tile;
     struct city *pcity = tile_city(ptile);
 
-    if (gui_options.center_when_popup_city) {
+    if (gui_options->center_when_popup_city) {
       queen()->mapview_wdg->center_on_tile(ptile);
     }
 

--- a/client/minimap.cpp
+++ b/client/minimap.cpp
@@ -99,10 +99,10 @@ void overview_pos_nowrap(const struct tileset *t, int *ovr_x, int *ovr_y,
   gui_to_natural_pos(t, &ntl_x, &ntl_y, gui_x, gui_y);
 
   // Now convert straight to overview coordinates.
-  *ovr_x =
-      std::round((ntl_x - gui_options.overview.map_x0) * OVERVIEW_TILE_SIZE);
-  *ovr_y =
-      std::round((ntl_y - gui_options.overview.map_y0) * OVERVIEW_TILE_SIZE);
+  *ovr_x = std::round((ntl_x - gui_options->overview.map_x0)
+                      * OVERVIEW_TILE_SIZE);
+  *ovr_y = std::round((ntl_y - gui_options->overview.map_y0)
+                      * OVERVIEW_TILE_SIZE);
 }
 
 } // namespace
@@ -114,7 +114,7 @@ void minimap_view::draw_viewport(QPainter *painter)
 {
   int x[4], y[4];
 
-  if (!gui_options.overview.map) {
+  if (!gui_options->overview.map) {
     return;
   }
 
@@ -192,7 +192,7 @@ void minimap_view::update_image()
  */
 int minimap_view::heightForWidth(int width) const
 {
-  const auto size = gui_options.overview.map->size();
+  const auto size = gui_options->overview.map->size();
   if (tileset_is_isometric(tileset)) {
     // Traditional iso tilesets have more or less this aspect ratio
     return size.height() * width / size.width() / 2;
@@ -207,7 +207,7 @@ int minimap_view::heightForWidth(int width) const
 QSize minimap_view::sizeHint() const
 {
   // The default size is a bit too small...
-  return 5 * gui_options.overview.map->size();
+  return 5 * gui_options->overview.map->size();
 }
 
 /**
@@ -216,7 +216,7 @@ QSize minimap_view::sizeHint() const
 void minimap_view::paint(QPainter *painter, QPaintEvent *event)
 {
   painter->drawPixmap(1, 1, width() - 1, height() - 1,
-                      *gui_options.overview.map);
+                      *gui_options->overview.map);
 
   painter->setPen(QColor(palette().color(QPalette::HighlightedText)));
   painter->drawRect(0, 0, width() - 1, height() - 1);
@@ -241,8 +241,8 @@ void minimap_view::resizeEvent(QResizeEvent *event)
 
   if (C_S_RUNNING <= client_state() && size.width() > 0
       && size.height() > 0) {
-    w_ratio = static_cast<float>(width()) / gui_options.overview.width;
-    h_ratio = static_cast<float>(height()) / gui_options.overview.height;
+    w_ratio = static_cast<float>(width()) / gui_options->overview.width;
+    h_ratio = static_cast<float>(height()) / gui_options->overview.height;
     king()->qt_settings.minimap_width =
         static_cast<float>(size.width()) / mapview.width;
     king()->qt_settings.minimap_height =
@@ -267,8 +267,8 @@ void minimap_view::mousePressEvent(QMouseEvent *event)
     fy = qRound(fy / h_ratio);
     fx = qMax(fx, 1);
     fy = qMax(fy, 1);
-    fx = qMin(fx, gui_options.overview.width - 1);
-    fy = qMin(fy, gui_options.overview.height - 1);
+    fx = qMin(fx, gui_options->overview.width - 1);
+    fy = qMin(fy, gui_options->overview.height - 1);
     int x, y;
     overview_to_map_pos(&x, &y, fx, fy);
     auto *ptile = map_pos_to_tile(&(wld.map), x, y);

--- a/client/music.cpp
+++ b/client/music.cpp
@@ -37,7 +37,7 @@ void start_style_music()
     return;
   }
 
-  if (gui_options.sound_enable_game_music) {
+  if (gui_options->sound_enable_game_music) {
     struct music_style *pms;
 
     stop_style_music();
@@ -77,7 +77,7 @@ void stop_style_music() { audio_stop_usage(); }
  */
 void start_menu_music(const QString &tag, const QString &alt_tag)
 {
-  if (gui_options.sound_enable_menu_music) {
+  if (gui_options->sound_enable_menu_music) {
     audio_play_music(tag, alt_tag, MU_MENU);
   }
 }

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -67,137 +67,8 @@
 
 typedef QHash<QString, QString> optionsHash;
 typedef QHash<QString, intptr_t> dialOptionsHash;
-struct client_options gui_options = {
-    /** Defaults for options normally on command line **/
-    "\0",                      // default_user_name
-    "localhost",               //.default_server_host =
-    DEFAULT_SOCK_PORT,         //.default_server_port =
-    false,                     //.use_prev_server =
-    false,                     //.heartbeat_enabled =
-    DEFAULT_METASERVER_OPTION, //.default_metaserver =
-    "\0",                      // .default_tileset_square_name =
-    "\0",                      //.default_tileset_hex_name =
-    "\0",                      //.default_tileset_isohex_name =
-    "Simple",                  //.default_city_bar_style_name =
-    "stdsounds",               //.default_sound_set_name =
-    "stdmusic",                //.default_music_set_name =
-    "\0",                      //.default_sound_plugin_name =
-    GUI_DEFAULT_CHAT_LOGFILE,  //.default_chat_logfile =
 
-    true, //.save_options_on_exit =
-
-    /** Migrations **/
-    true, //.first_boot =
-    "\0", //.default_tileset_overhead_name =
-    "\0", //.default_tileset_iso_name =
-
-    false, //.migrate_fullscreen =
-
-    /** Local Options: **/
-
-    false,                          //.solid_color_behind_units =
-    false,                          //.sound_bell_at_new_turn =
-    30,                             //.smooth_move_unit_msec =
-    200,                            //.smooth_center_slide_msec =
-    10,                             //.smooth_combat_step_msec =
-    true,                           //.ai_manual_turn_done =
-    true,                           //.auto_center_on_unit =
-    true,                           //.auto_center_on_automated =
-    false,                          //.auto_center_on_combat =
-    true,                           //.auto_center_each_turn =
-    true,                           //.wakeup_focus =
-    true,                           //.goto_into_unknown =
-    true,                           //.center_when_popup_city =
-    true,                           //.show_previous_turn_messages =
-    false,                          //.concise_city_production =
-    false,                          //.auto_turn_done =
-    true,                           //.ask_city_name =
-    true,                           //.popup_new_cities =
-    true,                           //.popup_actor_arrival =
-    true,                           //.popup_attack_actions =
-    true,                           //.popup_last_move_to_allied =
-    true,                           //.keyboardless_goto =
-    true,                           //.enable_cursor_changes =
-    false,                          //.separate_unit_selection =
-    true,                           //.unit_selection_clears_orders =
-    FT_COLOR("#000000", "#FFFF00"), //.highlight_our_names =
-
-    true,  //.voteinfo_bar_use =
-    false, //.voteinfo_bar_always_show =
-    false, //.voteinfo_bar_hide_when_not_player =
-    false, //.voteinfo_bar_new_at_front =
-
-    false, //.autoaccept_tileset_suggestion =
-    false, //.autoaccept_soundset_suggestion =
-    false, //.autoaccept_musicset_suggestion =
-
-    true, //.sound_enable_effects =
-    true, //.sound_enable_menu_music =
-    true, //.sound_enable_game_music =
-
-    // This option is currently set by the client - not by the user.
-
-    true,  //.draw_city_outlines =
-    false, //.draw_city_output =
-    false, //.draw_map_grid =
-    true,  //.draw_city_names =
-    true,  //.draw_city_growth =
-    true,  //.draw_city_productions =
-    false, //.draw_city_buycost =
-    false, //.draw_city_trade_routes =
-    false, //.draw_coastline =
-    true,  //.draw_roads_rails =
-    true,  //.draw_irrigation =
-    true,  //.draw_mines =
-    true,  //.draw_fortress_airbase =
-    true,  //.draw_specials =
-    true,  //.draw_huts =
-    true,  //.draw_pollution =
-    true,  //.draw_cities =
-    true,  //.draw_units =
-    false, //.draw_focus_unit =
-    true,  //.draw_fog_of_war =
-    true,  //.draw_borders =
-    false, //.draw_native =
-    true,  //.draw_unit_shields =
-    true,  //.zoom_scale_fonts =
-    true,  //.player_dlg_show_dead_players =
-    true,  //.reqtree_show_icons =
-    false, //.reqtree_curved_lines =
-    false, // SOMETHING ?
-
-    // sveinung - this wasnt here
-    "png", //  .mapimg_format,
-    // options for map images
-    2, //.mapimg_zoom =
-    {
-        //.mapimg_layer =
-        false, // a - MAPIMG_LAYER_AREA
-        true,  // b - MAPIMG_LAYER_BORDERS
-        true,  // c - MAPIMG_LAYER_CITIES
-        true,  // f - MAPIMG_LAYER_FOGOFWAR
-        true,  // k - MAPIMG_LAYER_KNOWLEDGE
-        true,  // t - MAPIMG_LAYER_TERRAIN
-        true   // u - MAPIMG_LAYER_UNITS
-    },
-    "mapimage filename",
-
-    // gui-qt client specific options.
-    true, //.gui_qt_fullscreen =
-    true, //.gui_qt_show_preview =
-    true, //.gui_qt_allied_chat_only =
-    0,    // font_increase
-    FC_QT_DEFAULT_THEME_NAME,
-    QFont(), //.gui_qt_font_default =
-    QFont(), //.gui_qt_font_notify_label =
-    QFont(), //.gui_qt_font_help_label =
-    QFont(), //.gui_qt_font_help_text =
-    QFont(), //.gui_qt_font_chatline =
-    QFont(), //.gui_qt_font_city_names =
-    QFont(), //.gui_qt_font_city_productions =
-    QFont(), //.gui_qt_font_reqtree_text =
-    true,    //.gui_qt_show_titlebar
-    {}};
+client_options *gui_options = nullptr;
 
 /* Set to TRUE after the first call to options_init(), to avoid the usage
  * of non-initialized datas when calling the changed callback. */
@@ -1094,49 +965,49 @@ struct client_option {
   struct {
     // OT_BOOLEAN type option.
     struct {
-      bool *const pvalue;
-      const bool def;
+      bool *pvalue;
+      bool def;
     } boolean;
     // OT_INTEGER type option.
     struct {
-      int *const pvalue;
-      const int def, min, max;
+      int *pvalue;
+      int def, min, max;
     } integer;
     // OT_STRING type option.
     struct {
-      char *const pvalue;
-      const size_t size;
-      const char *const def;
+      char *pvalue;
+      size_t size;
+      const char *def;
       /*
        * A function to return a string vector of possible string values,
        * or nullptr for none.
        */
-      const QVector<QString> *(*const val_accessor)(const struct option *);
+      const QVector<QString> *(*val_accessor)(const struct option *);
     } string;
     // OT_ENUM type option.
     struct {
-      int *const pvalue;
-      const int def;
+      int *pvalue;
+      int def;
       QVector<QString> *support_names, *pretty_names; // untranslated
-      const struct copt_val_name *(*const name_accessor)(int value);
+      const struct copt_val_name *(*name_accessor)(int value);
     } enumerator;
     // OT_BITWISE type option.
     struct {
-      unsigned *const pvalue;
-      const unsigned def;
+      unsigned *pvalue;
+      unsigned def;
       QVector<QString> *support_names, *pretty_names; // untranslated
-      const struct copt_val_name *(*const name_accessor)(int value);
+      const struct copt_val_name *(*name_accessor)(int value);
     } bitwise;
     // OT_FONT type option.
     struct {
-      QFont value;
+      QFont *value;
       QFont def;
       QString target;
     } font;
     // OT_COLOR type option.
     struct {
-      struct ft_color *const pvalue;
-      const struct ft_color def;
+      struct ft_color *pvalue;
+      struct ft_color def;
     } color;
   } u;
 };
@@ -1160,6 +1031,7 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_BOOL_OPTION(oname, odesc, ohelp, ocat, odef, ocb)               \
+  client_option                                                             \
   {                                                                         \
     .base_option = OPTION_BOOL_INIT(&client_optset_static,                  \
                                     client_option_common_vtable,            \
@@ -1168,7 +1040,7 @@ struct client_option {
     .category = ocat,                                                       \
     .u =                                                                    \
     {.boolean = {                                                           \
-         .pvalue = &gui_options.oname,                                      \
+         .pvalue = &gui_options->oname,                                     \
          .def = odef,                                                       \
      } }                                                                    \
   }
@@ -1190,13 +1062,14 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_INT_OPTION(oname, odesc, ohelp, ocat, odef, omin, omax, ocb)    \
+  client_option                                                             \
   {                                                                         \
     .base_option =                                                          \
         OPTION_INT_INIT(&client_optset_static, client_option_common_vtable, \
                         client_option_int_vtable, ocb),                     \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .integer = {.pvalue = &gui_options.oname,                             \
+      .integer = {.pvalue = &gui_options->oname,                            \
                   .def = odef,                                              \
                   .min = omin,                                              \
                   .max = omax}                                              \
@@ -1220,14 +1093,15 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_STR_OPTION(oname, odesc, ohelp, ocat, odef, ocb, cbd)           \
+  client_option                                                             \
   {                                                                         \
     .base_option =                                                          \
         OPTION_STR_INIT(&client_optset_static, client_option_common_vtable, \
                         client_option_str_vtable, ocb, cbd),                \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .string = {.pvalue = gui_options.oname,                               \
-                 .size = sizeof(gui_options.oname),                         \
+      .string = {.pvalue = gui_options->oname,                              \
+                 .size = sizeof(gui_options->oname),                        \
                  .def = odef,                                               \
                  .val_accessor = nullptr}                                   \
     }                                                                       \
@@ -1254,14 +1128,15 @@ struct client_option {
  */
 #define GEN_STR_LIST_OPTION(oname, odesc, ohelp, ocat, odef, oacc, ocb,     \
                             cbd)                                            \
+  client_option                                                             \
   {                                                                         \
     .base_option =                                                          \
         OPTION_STR_INIT(&client_optset_static, client_option_common_vtable, \
                         client_option_str_vtable, ocb, cbd),                \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .string = {.pvalue = gui_options.oname,                               \
-                 .size = sizeof(gui_options.oname),                         \
+      .string = {.pvalue = gui_options->oname,                              \
+                 .size = sizeof(gui_options->oname),                        \
                  .def = odef,                                               \
                  .val_accessor = oacc}                                      \
     }                                                                       \
@@ -1283,13 +1158,14 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_ENUM_OPTION(oname, odesc, ohelp, ocat, odef, oacc, ocb)         \
+  client_option                                                             \
   {                                                                         \
     .base_option = OPTION_ENUM_INIT(&client_optset_static,                  \
                                     client_option_common_vtable,            \
                                     client_option_enum_vtable, ocb),        \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .enumerator = {.pvalue = (int *) &gui_options.oname,                  \
+      .enumerator = {.pvalue = (int *) &gui_options->oname,                 \
                      .def = odef,                                           \
                      .support_names = nullptr, /* Set in options_init(). */ \
                      .pretty_names = nullptr,                               \
@@ -1313,13 +1189,14 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_BITWISE_OPTION(oname, odesc, ohelp, ocat, odef, oacc, ocb)      \
+  client_option                                                             \
   {                                                                         \
     .base_option = OPTION_BITWISE_INIT(&client_optset_static,               \
                                        client_option_common_vtable,         \
                                        client_option_bitwise_vtable, ocb),  \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .bitwise = {.pvalue = &gui_options.oname,                             \
+      .bitwise = {.pvalue = &gui_options->oname,                            \
                   .def = odef,                                              \
                   .support_names = nullptr, /* Set in options_init(). */    \
                   .pretty_names = nullptr,                                  \
@@ -1344,6 +1221,7 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_FONT_OPTION(oname, otgt, odesc, ohelp, ocat, ocb)               \
+  client_option                                                             \
   {                                                                         \
     .base_option = OPTION_FONT_INIT(&client_optset_static,                  \
                                     client_option_common_vtable,            \
@@ -1352,7 +1230,7 @@ struct client_option {
     .category = ocat,                                                       \
     .u =                                                                    \
     {.font = {                                                              \
-         .value = gui_options.oname,                                        \
+         .value = &gui_options->oname,                                      \
          .def = QFont(),                                                    \
          .target = otgt,                                                    \
      } }                                                                    \
@@ -1373,13 +1251,14 @@ struct client_option {
  *        the option changed.
  */
 #define GEN_COLOR_OPTION(oname, odesc, ohelp, ocat, odef_fg, odef_bg, ocb)  \
+  client_option                                                             \
   {                                                                         \
     .base_option = OPTION_COLOR_INIT(&client_optset_static,                 \
                                      client_option_common_vtable,           \
                                      client_option_color_vtable, ocb),      \
     .name = #oname, .description = odesc, .help_text = ohelp,               \
     .category = ocat, .u = {                                                \
-      .color = {.pvalue = &gui_options.oname,                               \
+      .color = {.pvalue = &gui_options->oname,                              \
                 .def = FT_COLOR(odef_fg, odef_bg)}                          \
     }                                                                       \
   }
@@ -1400,611 +1279,621 @@ static void game_music_enable_callback(struct option *poption);
 static void menu_music_enable_callback(struct option *poption);
 static void sound_volume_callback(struct option *poption);
 
-static struct client_option client_options[] = {
-    GEN_STR_OPTION(
-        default_user_name, N_("Login name"),
-        N_("This is the default login username that will be used "
-           "in the connection dialogs or with the -a command-line "
-           "parameter."),
-        COC_NETWORK, nullptr, nullptr, 0),
-    GEN_BOOL_OPTION(use_prev_server, N_("Default to previously used server"),
-                    N_("Automatically update \"Server\" and \"Server port\" "
-                       "options to match your latest connection, so by "
-                       "default you connect to the same server you used "
-                       "on the previous run. You should enable "
-                       "saving options on exit too, so that the automatic "
-                       "updates to the options get saved too."),
-                    COC_NETWORK, false, nullptr),
-    GEN_STR_OPTION(
-        default_server_host, N_("Server"),
-        N_("This is the default server hostname that will be used "
-           "in the connection dialogs or with the -a command-line "
-           "parameter."),
-        COC_NETWORK, "localhost", nullptr, 0),
-    GEN_INT_OPTION(
-        default_server_port, N_("Server port"),
-        N_("This is the default server port that will be used "
-           "in the connection dialogs or with the -a command-line "
-           "parameter."),
-        COC_NETWORK, DEFAULT_SOCK_PORT, 0, 65535, nullptr),
-    GEN_STR_OPTION(default_metaserver, N_("Metaserver"),
-                   N_("The metaserver is a host that the client contacts to "
-                      "find out about games on the internet.  Don't change "
-                      "this from its default value unless you know what "
-                      "you're doing."),
-                   COC_NETWORK, DEFAULT_METASERVER_OPTION, nullptr, 0),
-    GEN_BOOL_OPTION(
-        heartbeat_enabled, N_("Send heartbeat messages to server"),
-        N_("Periodically send an empty heartbeat message to the "
-           "server to probe whether the connection is still up. "
-           "This can help to make it obvious when the server has "
-           "cut the connection due to a connectivity outage, if "
-           "the client would otherwise sit idle for a long period."),
-        COC_NETWORK, true, nullptr),
-    GEN_STR_LIST_OPTION(
-        default_sound_set_name, N_("Soundset"),
-        N_("This is the soundset that will be used.  Changing "
-           "this is the same as using the -S command-line "
-           "parameter."),
-        COC_SOUND, "stdsounds", get_soundset_list, nullptr, 0),
-    GEN_STR_LIST_OPTION(
-        default_music_set_name, N_("Musicset"),
-        N_("This is the musicset that will be used.  Changing "
-           "this is the same as using the -m command-line "
-           "parameter."),
-        COC_SOUND, "stdmusic", get_musicset_list, musicspec_reread_callback,
-        0),
-    GEN_STR_LIST_OPTION(
-        default_sound_plugin_name, N_("Sound plugin"),
-        N_("If you have a problem with sound, try changing "
-           "the sound plugin.  The new plugin won't take "
-           "effect until you restart Freeciv21.  Changing this "
-           "is the same as using the -P command-line option."),
-        COC_SOUND, "", get_soundplugin_list, nullptr, 0),
-    GEN_STR_OPTION(default_chat_logfile, N_("The chat log file"),
-                   N_("The name of the chat log file."), COC_INTERFACE,
-                   GUI_DEFAULT_CHAT_LOGFILE, nullptr, 0),
-    GEN_STR_LIST_OPTION(gui_qt_default_theme_name, N_("Theme"),
-                        N_("By changing this option you change the "
-                           "active theme."),
-                        COC_GRAPHICS, FC_QT_DEFAULT_THEME_NAME,
-                        get_themes_list, theme_reread_callback, 0),
+static std::vector<client_option> client_options;
+static void init_client_options()
+{
+  client_options = {
+      GEN_STR_OPTION(
+          default_user_name, N_("Login name"),
+          N_("This is the default login username that will be used "
+             "in the connection dialogs or with the -a command-line "
+             "parameter."),
+          COC_NETWORK, nullptr, nullptr, 0),
+      GEN_BOOL_OPTION(
+          use_prev_server, N_("Default to previously used server"),
+          N_("Automatically update \"Server\" and \"Server port\" "
+             "options to match your latest connection, so by "
+             "default you connect to the same server you used "
+             "on the previous run. You should enable "
+             "saving options on exit too, so that the automatic "
+             "updates to the options get saved too."),
+          COC_NETWORK, false, nullptr),
+      GEN_STR_OPTION(
+          default_server_host, N_("Server"),
+          N_("This is the default server hostname that will be used "
+             "in the connection dialogs or with the -a command-line "
+             "parameter."),
+          COC_NETWORK, "localhost", nullptr, 0),
+      GEN_INT_OPTION(
+          default_server_port, N_("Server port"),
+          N_("This is the default server port that will be used "
+             "in the connection dialogs or with the -a command-line "
+             "parameter."),
+          COC_NETWORK, DEFAULT_SOCK_PORT, 0, 65535, nullptr),
+      GEN_STR_OPTION(
+          default_metaserver, N_("Metaserver"),
+          N_("The metaserver is a host that the client contacts to "
+             "find out about games on the internet.  Don't change "
+             "this from its default value unless you know what "
+             "you're doing."),
+          COC_NETWORK, DEFAULT_METASERVER_OPTION, nullptr, 0),
+      GEN_BOOL_OPTION(
+          heartbeat_enabled, N_("Send heartbeat messages to server"),
+          N_("Periodically send an empty heartbeat message to the "
+             "server to probe whether the connection is still up. "
+             "This can help to make it obvious when the server has "
+             "cut the connection due to a connectivity outage, if "
+             "the client would otherwise sit idle for a long period."),
+          COC_NETWORK, true, nullptr),
+      GEN_STR_LIST_OPTION(
+          default_sound_set_name, N_("Soundset"),
+          N_("This is the soundset that will be used.  Changing "
+             "this is the same as using the -S command-line "
+             "parameter."),
+          COC_SOUND, "stdsounds", get_soundset_list, nullptr, 0),
+      GEN_STR_LIST_OPTION(
+          default_music_set_name, N_("Musicset"),
+          N_("This is the musicset that will be used.  Changing "
+             "this is the same as using the -m command-line "
+             "parameter."),
+          COC_SOUND, "stdmusic", get_musicset_list,
+          musicspec_reread_callback, 0),
+      GEN_STR_LIST_OPTION(
+          default_sound_plugin_name, N_("Sound plugin"),
+          N_("If you have a problem with sound, try changing "
+             "the sound plugin.  The new plugin won't take "
+             "effect until you restart Freeciv21.  Changing this "
+             "is the same as using the -P command-line option."),
+          COC_SOUND, "", get_soundplugin_list, nullptr, 0),
+      GEN_STR_OPTION(default_chat_logfile, N_("The chat log file"),
+                     N_("The name of the chat log file."), COC_INTERFACE,
+                     "freeciv-chat.log", nullptr, 0),
+      GEN_STR_LIST_OPTION(gui_qt_default_theme_name, N_("Theme"),
+                          N_("By changing this option you change the "
+                             "active theme."),
+                          COC_GRAPHICS, FC_QT_DEFAULT_THEME_NAME,
+                          get_themes_list, theme_reread_callback, 0),
 
-    /* It's important to give empty string instead of nullptr as as default
-     * value. For nullptr value it would default to assigning first value
-     * from the tileset list returned by get_tileset_list() as default
-     * tileset. We don't want default tileset assigned at all here, but
-     * leave it to tilespec code that can handle tileset priority. */
-    GEN_STR_LIST_OPTION(
-        default_tileset_square_name, N_("Tileset (Square)"),
-        N_("Select the tileset used with Square based maps. "
-           "This may change the currently active tileset, if "
-           "you are playing on such a map, in which "
-           "case this is the same as using the -t "
-           "command-line parameter."),
-        COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback, 0),
-    GEN_STR_LIST_OPTION(
-        default_tileset_hex_name, N_("Tileset (Hex)"),
-        N_("Select the tileset used with Hex maps. "
-           "This may change the currently active tileset, if "
-           "you are playing on such a map, in which "
-           "case this is the same as using the -t "
-           "command-line parameter."),
-        COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback,
-        TF_HEX),
-    GEN_STR_LIST_OPTION(
-        default_tileset_isohex_name, N_("Tileset (Iso-Hex)"),
-        N_("Select the tileset used with Iso-Hex maps. "
-           "This may change the currently active tileset, if "
-           "you are playing on such a map, in which "
-           "case this is the same as using the -t "
-           "command-line parameter."),
-        COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback,
-        TF_ISO | TF_HEX),
+      /* It's important to give empty string instead of nullptr as as default
+       * value. For nullptr value it would default to assigning first value
+       * from the tileset list returned by get_tileset_list() as default
+       * tileset. We don't want default tileset assigned at all here, but
+       * leave it to tilespec code that can handle tileset priority. */
+      GEN_STR_LIST_OPTION(
+          default_tileset_square_name, N_("Tileset (Square)"),
+          N_("Select the tileset used with Square based maps. "
+             "This may change the currently active tileset, if "
+             "you are playing on such a map, in which "
+             "case this is the same as using the -t "
+             "command-line parameter."),
+          COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback, 0),
+      GEN_STR_LIST_OPTION(
+          default_tileset_hex_name, N_("Tileset (Hex)"),
+          N_("Select the tileset used with Hex maps. "
+             "This may change the currently active tileset, if "
+             "you are playing on such a map, in which "
+             "case this is the same as using the -t "
+             "command-line parameter."),
+          COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback,
+          TF_HEX),
+      GEN_STR_LIST_OPTION(
+          default_tileset_isohex_name, N_("Tileset (Iso-Hex)"),
+          N_("Select the tileset used with Iso-Hex maps. "
+             "This may change the currently active tileset, if "
+             "you are playing on such a map, in which "
+             "case this is the same as using the -t "
+             "command-line parameter."),
+          COC_GRAPHICS, "", get_tileset_list, tilespec_reread_callback,
+          TF_ISO | TF_HEX),
 
-    GEN_STR_LIST_OPTION(default_city_bar_style_name, N_("City bar style"),
-                        N_("Selects the style of the city bar."),
-                        COC_GRAPHICS, "Polished",
-                        citybar_painter::available_vector,
-                        citybar_painter::option_changed, 0),
+      GEN_STR_LIST_OPTION(default_city_bar_style_name, N_("City bar style"),
+                          N_("Selects the style of the city bar."),
+                          COC_GRAPHICS, "Polished",
+                          citybar_painter::available_vector,
+                          citybar_painter::option_changed, 0),
 
-    GEN_BOOL_OPTION(draw_city_outlines, N_("Draw city outlines"),
-                    N_("Setting this option will draw a line at the city "
-                       "workable limit."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_city_output, N_("Draw city output"),
-                    N_("Setting this option will draw city output for every "
-                       "citizen."),
-                    COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_map_grid, N_("Draw the map grid"),
-                    N_("Setting this option will draw a grid over the map."),
-                    COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_city_names, N_("Draw the city names"),
-        N_("Setting this option will draw the names of the cities "
-           "on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_city_growth, N_("Draw the city growth"),
-                    N_("Setting this option will draw in how many turns the "
-                       "cities will grow or shrink."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_city_productions, N_("Draw the city productions"),
-                    N_("Setting this option will draw what the cities are "
-                       "currently building on the map."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_city_buycost, N_("Draw the city buy costs"),
-                    N_("Setting this option will draw how much gold is "
-                       "needed to buy the production of the cities."),
-                    COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_city_trade_routes, N_("Draw the city trade routes"),
-                    N_("Setting this option will draw trade route lines "
-                       "between cities which have trade routes."),
-                    COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_coastline, N_("Draw the coast line"),
-        N_("Setting this option will draw a line to separate the "
-           "land from the ocean."),
-        COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_roads_rails, N_("Draw the roads and the railroads"),
-                    N_("Setting this option will draw the roads and the "
-                       "railroads on the map."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_irrigation, N_("Draw the irrigation"),
-        N_("Setting this option will draw the irrigation systems "
-           "on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_mines, N_("Draw the mines"),
-        N_("Setting this option will draw the mines on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_fortress_airbase, N_("Draw the bases"),
-        N_("Setting this option will draw the bases on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_specials, N_("Draw the resources"),
-                    N_("Setting this option will draw the resources on the "
-                       "map."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_huts, N_("Draw the huts"),
-                    N_("Setting this option will draw the huts on the "
-                       "map."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_pollution, N_("Draw the pollution/nuclear fallout"),
-                    N_("Setting this option will draw pollution and "
-                       "nuclear fallout on the map."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_cities, N_("Draw the cities"),
-        N_("Setting this option will draw the cities on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_units, N_("Draw the units"),
-        N_("Setting this option will draw the units on the map."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(solid_color_behind_units,
-                    N_("Solid unit background color"),
-                    N_("Setting this option will cause units on the map "
-                       "view to be drawn with a solid background color "
-                       "instead of the flag backdrop."),
-                    COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_unit_shields, N_("Draw shield graphics for units"),
-        N_("Setting this option will draw a shield icon "
-           "as the flags on units.  If unset, the full flag will "
-           "be drawn."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_focus_unit, N_("Draw the units in focus"),
-        N_("Setting this option will cause the currently focused "
-           "unit(s) to always be drawn, even if units are not "
-           "otherwise being drawn (for instance if 'Draw the units' "
-           "is unset)."),
-        COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(draw_fog_of_war, N_("Draw the fog of war"),
-                    N_("Setting this option will draw the fog of war."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_borders, N_("Draw the borders"),
-        N_("Setting this option will draw the national borders."),
-        COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        draw_native,
-        N_("Draw whether tiles are native to "
-           "selected unit"),
-        N_("Setting this option will highlight tiles that the "
-           "currently selected unit cannot enter unaided due to "
-           "non-native terrain. (If multiple units are selected, "
-           "only tiles that all of them can enter are indicated.)"),
-        COC_GRAPHICS, false, view_option_changed_callback),
-    GEN_BOOL_OPTION(player_dlg_show_dead_players,
-                    N_("Show dead players in Nations report"),
-                    N_("This option controls whether defeated nations are "
-                       "shown on the Nations report page."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(zoom_scale_fonts, N_("Scale fonts when zooming"),
-                    N_("When this option is set, the fonts and city "
-                       "descriptions will be "
-                       "scaled when the map is zoomed."),
-                    COC_GRAPHICS, true, view_option_changed_callback),
-    GEN_BOOL_OPTION(
-        sound_bell_at_new_turn, N_("Sound bell at new turn"),
-        N_("Set this option to have a \"bell\" event be generated "
-           "at the start of a new turn.  You can control the "
-           "behavior of the \"bell\" event by editing the message "
-           "options."),
-        COC_SOUND, false, nullptr),
-    GEN_INT_OPTION(
-        smooth_move_unit_msec,
-        N_("Unit movement animation time (milliseconds)"),
-        N_("This option controls how long unit \"animation\" takes "
-           "when a unit moves on the map view.  Set it to 0 to "
-           "disable animation entirely."),
-        COC_GRAPHICS, 30, 0, 2000, nullptr),
-    GEN_INT_OPTION(
-        smooth_center_slide_msec,
-        N_("Mapview recentering time (milliseconds)"),
-        N_("When the map view is recentered, it will slide "
-           "smoothly over the map to its new position.  This "
-           "option controls how long this slide lasts.  Set it to "
-           "0 to disable mapview sliding entirely."),
-        COC_GRAPHICS, 200, 0, 5000, nullptr),
-    GEN_INT_OPTION(
-        smooth_combat_step_msec,
-        N_("Combat animation step time (milliseconds)"),
-        N_("This option controls the speed of combat animation "
-           "between units on the mapview.  Set it to 0 to disable "
-           "animation entirely."),
-        COC_GRAPHICS, 10, 0, 100, nullptr),
-    GEN_BOOL_OPTION(reqtree_show_icons,
-                    N_("Show icons in the technology tree"),
-                    N_("Setting this option will display icons "
-                       "on the technology tree diagram. Turning "
-                       "this option off makes the technology tree "
-                       "more compact."),
-                    COC_GRAPHICS, true, reqtree_show_icons_callback),
-    GEN_BOOL_OPTION(reqtree_curved_lines,
-                    N_("Use curved lines in the technology tree"),
-                    N_("Setting this option make the technology tree "
-                       "diagram use curved lines to show technology "
-                       "relations. Turning this option off causes "
-                       "the lines to be drawn straight."),
-                    COC_GRAPHICS, false, reqtree_show_icons_callback),
-    GEN_COLOR_OPTION(
-        highlight_our_names, N_("Color to highlight your player/user name"),
-        N_("If set, your player and user name in the new chat "
-           "messages will be highlighted using this color as "
-           "background.  If not set, it will just not highlight "
-           "anything."),
-        COC_GRAPHICS, "#000000", "#FFFF00", nullptr),
-    GEN_BOOL_OPTION(ai_manual_turn_done, N_("Manual Turn Done in AI mode"),
-                    N_("Disable this option if you do not want to "
-                       "press the Turn Done button manually when watching "
-                       "an AI player."),
-                    COC_INTERFACE, true, manual_turn_done_callback),
-    GEN_BOOL_OPTION(auto_center_on_unit, N_("Auto center on units"),
-                    N_("Set this option to have the active unit centered "
-                       "automatically when the unit focus changes."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(auto_center_on_automated, N_("Show automated units"),
-                    N_("Disable this option if you do not want to see "
-                       "automated units autocentered and animated."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        auto_center_on_combat, N_("Auto center on combat"),
-        N_("Set this option to have any combat be centered "
-           "automatically.  Disabling this will speed up the time "
-           "between turns but may cause you to miss combat "
-           "entirely."),
-        COC_INTERFACE, false, nullptr),
-    GEN_BOOL_OPTION(auto_center_each_turn, N_("Auto center on new turn"),
-                    N_("Set this option to have the client automatically "
-                       "recenter the map on a suitable location at the "
-                       "start of each turn."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(wakeup_focus, N_("Focus on awakened units"),
-                    N_("Set this option to have newly awoken units be "
-                       "focused automatically."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(keyboardless_goto, N_("Keyboardless goto"),
-                    N_("If this option is set then a goto may be initiated "
-                       "by left-clicking and then holding down the mouse "
-                       "button while dragging the mouse onto a different "
-                       "tile."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        goto_into_unknown, N_("Allow goto into the unknown"),
-        N_("Setting this option will make the game consider "
-           "moving into unknown tiles.  If not, then goto routes "
-           "will detour around or be blocked by unknown tiles."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(center_when_popup_city, N_("Center map when popup city"),
-                    N_("Setting this option makes the mapview center on a "
-                       "city when its city dialog is popped up."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        show_previous_turn_messages, N_("Show messages from previous turn"),
-        N_("Message Window shows messages also from previous turn. "
-           "This makes sure you don't miss messages received in the end of "
-           "the turn, just before the window gets cleared."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        concise_city_production, N_("Concise city production"),
-        N_("Set this option to make the city production (as shown "
-           "in the city dialog) to be more compact."),
-        COC_INTERFACE, false, nullptr),
-    GEN_BOOL_OPTION(
-        auto_turn_done, N_("End turn when done moving"),
-        N_("Setting this option makes your turn end automatically "
-           "when all your units are done moving."),
-        COC_INTERFACE, false, nullptr),
-    GEN_BOOL_OPTION(
-        ask_city_name, N_("Prompt for city names"),
-        N_("Disabling this option will make the names of newly "
-           "founded cities be chosen automatically by the server."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(popup_new_cities,
-                    N_("Pop up city dialog for new cities"),
-                    N_("Setting this option will pop up a newly-founded "
-                       "city's city dialog automatically."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        popup_actor_arrival, N_("Pop up caravan and spy actions"),
-        N_("If this option is enabled, when a unit arrives at "
-           "a city where it can perform an action like "
-           "establishing a trade route, helping build a wonder, or "
-           "establishing an embassy, a window will pop up asking "
-           "which action should be performed. "
-           "Disabling this option means you will have to do the "
-           "action manually by pressing either 'r' (for a trade "
-           "route), 'b' (for building a wonder) or 'd' (for a "
-           "spy action) when the unit is in the city."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        popup_attack_actions, N_("Pop up attack questions"),
-        N_("If this option is enabled, when a unit arrives at a "
-           "target it can attack, a window will pop up asking "
-           "which action should be performed even if an attack "
-           "action is legal and no other interesting action are. "
-           "This allows you to change your mind or to select an "
-           "uninteresting action."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        popup_last_move_to_allied, N_("Pop up actions last move to allied"),
-        N_("If this option is enabled the final move in a unit's"
-           " orders to a tile with allied units or cities it can"
-           " perform an action to is interpreted as an attempted"
-           " action. This makes the action selection dialog pop up"
-           " while the unit is at the adjacent tile."
-           " This can, in cases where the action requires that"
-           " the actor unit has moves left, save a turn."
-           " The down side is that the unit remains adjacent to"
-           " rather than inside the protection of an allied city"
-           " or unit stack."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(enable_cursor_changes, N_("Enable cursor changing"),
-                    N_("This option controls whether the client should "
-                       "try to change the mouse cursor depending on what "
-                       "is being pointed at, as well as to indicate "
-                       "changes in the client or server state."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(separate_unit_selection,
-                    N_("Select cities before units"),
-                    N_("If this option is enabled, when both cities and "
-                       "units are present in the selection rectangle, only "
-                       "cities will be selected. See the help on Controls."),
-                    COC_INTERFACE, false, nullptr),
-    GEN_BOOL_OPTION(
-        unit_selection_clears_orders, N_("Clear unit orders on selection"),
-        N_("Enabling this option will cause unit orders to be "
-           "cleared as soon as one or more units are selected. If "
-           "this option is disabled, busy units will not stop "
-           "their current activity when selected. Giving them "
-           "new orders will clear their current ones; pressing "
-           "<space> once will clear their orders and leave them "
-           "selected, and pressing <space> a second time will "
-           "dismiss them."),
-        COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(voteinfo_bar_use, N_("Enable vote bar"),
-                    N_("If this option is turned on, the vote bar will be "
-                       "displayed to show vote information."),
-                    COC_GRAPHICS, true, voteinfo_bar_callback),
-    GEN_BOOL_OPTION(
-        voteinfo_bar_always_show, N_("Always display the vote bar"),
-        N_("If this option is turned on, the vote bar will never "
-           "be hidden, even if there is no running vote."),
-        COC_GRAPHICS, false, voteinfo_bar_callback),
-    GEN_BOOL_OPTION(
-        voteinfo_bar_hide_when_not_player,
-        N_("Do not show vote bar if not a player"),
-        N_("If this option is enabled, the client won't show the "
-           "vote bar if you are not a player."),
-        COC_GRAPHICS, false, voteinfo_bar_callback),
-    GEN_BOOL_OPTION(voteinfo_bar_new_at_front, N_("Set new votes at front"),
-                    N_("If this option is enabled, then new votes will go "
-                       "to the front of the vote list."),
-                    COC_GRAPHICS, false, voteinfo_bar_callback),
-    GEN_BOOL_OPTION(autoaccept_tileset_suggestion,
-                    N_("Autoaccept tileset suggestions"),
-                    N_("If this option is enabled, any tileset suggested by "
-                       "the ruleset is automatically used; otherwise you "
-                       "are prompted to change tileset."),
-                    COC_GRAPHICS, false, nullptr),
+      GEN_BOOL_OPTION(draw_city_outlines, N_("Draw city outlines"),
+                      N_("Setting this option will draw a line at the city "
+                         "workable limit."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_city_output, N_("Draw city output"),
+          N_("Setting this option will draw city output for every "
+             "citizen."),
+          COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_map_grid, N_("Draw the map grid"),
+          N_("Setting this option will draw a grid over the map."),
+          COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_city_names, N_("Draw the city names"),
+          N_("Setting this option will draw the names of the cities "
+             "on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_city_growth, N_("Draw the city growth"),
+          N_("Setting this option will draw in how many turns the "
+             "cities will grow or shrink."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_city_productions, N_("Draw the city productions"),
+                      N_("Setting this option will draw what the cities are "
+                         "currently building on the map."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_city_buycost, N_("Draw the city buy costs"),
+                      N_("Setting this option will draw how much gold is "
+                         "needed to buy the production of the cities."),
+                      COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_city_trade_routes,
+                      N_("Draw the city trade routes"),
+                      N_("Setting this option will draw trade route lines "
+                         "between cities which have trade routes."),
+                      COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_coastline, N_("Draw the coast line"),
+          N_("Setting this option will draw a line to separate the "
+             "land from the ocean."),
+          COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_roads_rails,
+                      N_("Draw the roads and the railroads"),
+                      N_("Setting this option will draw the roads and the "
+                         "railroads on the map."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_irrigation, N_("Draw the irrigation"),
+          N_("Setting this option will draw the irrigation systems "
+             "on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_mines, N_("Draw the mines"),
+          N_("Setting this option will draw the mines on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_fortress_airbase, N_("Draw the bases"),
+          N_("Setting this option will draw the bases on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_specials, N_("Draw the resources"),
+          N_("Setting this option will draw the resources on the "
+             "map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_huts, N_("Draw the huts"),
+                      N_("Setting this option will draw the huts on the "
+                         "map."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_pollution,
+                      N_("Draw the pollution/nuclear fallout"),
+                      N_("Setting this option will draw pollution and "
+                         "nuclear fallout on the map."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_cities, N_("Draw the cities"),
+          N_("Setting this option will draw the cities on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_units, N_("Draw the units"),
+          N_("Setting this option will draw the units on the map."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(solid_color_behind_units,
+                      N_("Solid unit background color"),
+                      N_("Setting this option will cause units on the map "
+                         "view to be drawn with a solid background color "
+                         "instead of the flag backdrop."),
+                      COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_unit_shields, N_("Draw shield graphics for units"),
+          N_("Setting this option will draw a shield icon "
+             "as the flags on units.  If unset, the full flag will "
+             "be drawn."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_focus_unit, N_("Draw the units in focus"),
+          N_("Setting this option will cause the currently focused "
+             "unit(s) to always be drawn, even if units are not "
+             "otherwise being drawn (for instance if 'Draw the units' "
+             "is unset)."),
+          COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(draw_fog_of_war, N_("Draw the fog of war"),
+                      N_("Setting this option will draw the fog of war."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_borders, N_("Draw the borders"),
+          N_("Setting this option will draw the national borders."),
+          COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          draw_native,
+          N_("Draw whether tiles are native to "
+             "selected unit"),
+          N_("Setting this option will highlight tiles that the "
+             "currently selected unit cannot enter unaided due to "
+             "non-native terrain. (If multiple units are selected, "
+             "only tiles that all of them can enter are indicated.)"),
+          COC_GRAPHICS, false, view_option_changed_callback),
+      GEN_BOOL_OPTION(player_dlg_show_dead_players,
+                      N_("Show dead players in Nations report"),
+                      N_("This option controls whether defeated nations are "
+                         "shown on the Nations report page."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(zoom_scale_fonts, N_("Scale fonts when zooming"),
+                      N_("When this option is set, the fonts and city "
+                         "descriptions will be "
+                         "scaled when the map is zoomed."),
+                      COC_GRAPHICS, true, view_option_changed_callback),
+      GEN_BOOL_OPTION(
+          sound_bell_at_new_turn, N_("Sound bell at new turn"),
+          N_("Set this option to have a \"bell\" event be generated "
+             "at the start of a new turn.  You can control the "
+             "behavior of the \"bell\" event by editing the message "
+             "options."),
+          COC_SOUND, false, nullptr),
+      GEN_INT_OPTION(
+          smooth_move_unit_msec,
+          N_("Unit movement animation time (milliseconds)"),
+          N_("This option controls how long unit \"animation\" takes "
+             "when a unit moves on the map view.  Set it to 0 to "
+             "disable animation entirely."),
+          COC_GRAPHICS, 30, 0, 2000, nullptr),
+      GEN_INT_OPTION(
+          smooth_center_slide_msec,
+          N_("Mapview recentering time (milliseconds)"),
+          N_("When the map view is recentered, it will slide "
+             "smoothly over the map to its new position.  This "
+             "option controls how long this slide lasts.  Set it to "
+             "0 to disable mapview sliding entirely."),
+          COC_GRAPHICS, 200, 0, 5000, nullptr),
+      GEN_INT_OPTION(
+          smooth_combat_step_msec,
+          N_("Combat animation step time (milliseconds)"),
+          N_("This option controls the speed of combat animation "
+             "between units on the mapview.  Set it to 0 to disable "
+             "animation entirely."),
+          COC_GRAPHICS, 10, 0, 100, nullptr),
+      GEN_BOOL_OPTION(reqtree_show_icons,
+                      N_("Show icons in the technology tree"),
+                      N_("Setting this option will display icons "
+                         "on the technology tree diagram. Turning "
+                         "this option off makes the technology tree "
+                         "more compact."),
+                      COC_GRAPHICS, true, reqtree_show_icons_callback),
+      GEN_BOOL_OPTION(reqtree_curved_lines,
+                      N_("Use curved lines in the technology tree"),
+                      N_("Setting this option make the technology tree "
+                         "diagram use curved lines to show technology "
+                         "relations. Turning this option off causes "
+                         "the lines to be drawn straight."),
+                      COC_GRAPHICS, false, reqtree_show_icons_callback),
+      GEN_COLOR_OPTION(
+          highlight_our_names,
+          N_("Color to highlight your player/user name"),
+          N_("If set, your player and user name in the new chat "
+             "messages will be highlighted using this color as "
+             "background.  If not set, it will just not highlight "
+             "anything."),
+          COC_GRAPHICS, "#000000", "#FFFF00", nullptr),
+      GEN_BOOL_OPTION(ai_manual_turn_done, N_("Manual Turn Done in AI mode"),
+                      N_("Disable this option if you do not want to "
+                         "press the Turn Done button manually when watching "
+                         "an AI player."),
+                      COC_INTERFACE, true, manual_turn_done_callback),
+      GEN_BOOL_OPTION(auto_center_on_unit, N_("Auto center on units"),
+                      N_("Set this option to have the active unit centered "
+                         "automatically when the unit focus changes."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(auto_center_on_automated, N_("Show automated units"),
+                      N_("Disable this option if you do not want to see "
+                         "automated units autocentered and animated."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          auto_center_on_combat, N_("Auto center on combat"),
+          N_("Set this option to have any combat be centered "
+             "automatically.  Disabling this will speed up the time "
+             "between turns but may cause you to miss combat "
+             "entirely."),
+          COC_INTERFACE, false, nullptr),
+      GEN_BOOL_OPTION(auto_center_each_turn, N_("Auto center on new turn"),
+                      N_("Set this option to have the client automatically "
+                         "recenter the map on a suitable location at the "
+                         "start of each turn."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(wakeup_focus, N_("Focus on awakened units"),
+                      N_("Set this option to have newly awoken units be "
+                         "focused automatically."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          keyboardless_goto, N_("Keyboardless goto"),
+          N_("If this option is set then a goto may be initiated "
+             "by left-clicking and then holding down the mouse "
+             "button while dragging the mouse onto a different "
+             "tile."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          goto_into_unknown, N_("Allow goto into the unknown"),
+          N_("Setting this option will make the game consider "
+             "moving into unknown tiles.  If not, then goto routes "
+             "will detour around or be blocked by unknown tiles."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(center_when_popup_city,
+                      N_("Center map when popup city"),
+                      N_("Setting this option makes the mapview center on a "
+                         "city when its city dialog is popped up."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          show_previous_turn_messages,
+          N_("Show messages from previous turn"),
+          N_("Message Window shows messages also from previous turn. "
+             "This makes sure you don't miss messages received in the end "
+             "of "
+             "the turn, just before the window gets cleared."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          concise_city_production, N_("Concise city production"),
+          N_("Set this option to make the city production (as shown "
+             "in the city dialog) to be more compact."),
+          COC_INTERFACE, false, nullptr),
+      GEN_BOOL_OPTION(
+          auto_turn_done, N_("End turn when done moving"),
+          N_("Setting this option makes your turn end automatically "
+             "when all your units are done moving."),
+          COC_INTERFACE, false, nullptr),
+      GEN_BOOL_OPTION(
+          ask_city_name, N_("Prompt for city names"),
+          N_("Disabling this option will make the names of newly "
+             "founded cities be chosen automatically by the server."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(popup_new_cities,
+                      N_("Pop up city dialog for new cities"),
+                      N_("Setting this option will pop up a newly-founded "
+                         "city's city dialog automatically."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          popup_actor_arrival, N_("Pop up caravan and spy actions"),
+          N_("If this option is enabled, when a unit arrives at "
+             "a city where it can perform an action like "
+             "establishing a trade route, helping build a wonder, or "
+             "establishing an embassy, a window will pop up asking "
+             "which action should be performed. "
+             "Disabling this option means you will have to do the "
+             "action manually by pressing either 'r' (for a trade "
+             "route), 'b' (for building a wonder) or 'd' (for a "
+             "spy action) when the unit is in the city."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          popup_attack_actions, N_("Pop up attack questions"),
+          N_("If this option is enabled, when a unit arrives at a "
+             "target it can attack, a window will pop up asking "
+             "which action should be performed even if an attack "
+             "action is legal and no other interesting action are. "
+             "This allows you to change your mind or to select an "
+             "uninteresting action."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          popup_last_move_to_allied,
+          N_("Pop up actions last move to allied"),
+          N_("If this option is enabled the final move in a unit's"
+             " orders to a tile with allied units or cities it can"
+             " perform an action to is interpreted as an attempted"
+             " action. This makes the action selection dialog pop up"
+             " while the unit is at the adjacent tile."
+             " This can, in cases where the action requires that"
+             " the actor unit has moves left, save a turn."
+             " The down side is that the unit remains adjacent to"
+             " rather than inside the protection of an allied city"
+             " or unit stack."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(enable_cursor_changes, N_("Enable cursor changing"),
+                      N_("This option controls whether the client should "
+                         "try to change the mouse cursor depending on what "
+                         "is being pointed at, as well as to indicate "
+                         "changes in the client or server state."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          separate_unit_selection, N_("Select cities before units"),
+          N_("If this option is enabled, when both cities and "
+             "units are present in the selection rectangle, only "
+             "cities will be selected. See the help on Controls."),
+          COC_INTERFACE, false, nullptr),
+      GEN_BOOL_OPTION(
+          unit_selection_clears_orders, N_("Clear unit orders on selection"),
+          N_("Enabling this option will cause unit orders to be "
+             "cleared as soon as one or more units are selected. If "
+             "this option is disabled, busy units will not stop "
+             "their current activity when selected. Giving them "
+             "new orders will clear their current ones; pressing "
+             "<space> once will clear their orders and leave them "
+             "selected, and pressing <space> a second time will "
+             "dismiss them."),
+          COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(voteinfo_bar_use, N_("Enable vote bar"),
+                      N_("If this option is turned on, the vote bar will be "
+                         "displayed to show vote information."),
+                      COC_GRAPHICS, true, voteinfo_bar_callback),
+      GEN_BOOL_OPTION(
+          voteinfo_bar_always_show, N_("Always display the vote bar"),
+          N_("If this option is turned on, the vote bar will never "
+             "be hidden, even if there is no running vote."),
+          COC_GRAPHICS, false, voteinfo_bar_callback),
+      GEN_BOOL_OPTION(
+          voteinfo_bar_hide_when_not_player,
+          N_("Do not show vote bar if not a player"),
+          N_("If this option is enabled, the client won't show the "
+             "vote bar if you are not a player."),
+          COC_GRAPHICS, false, voteinfo_bar_callback),
+      GEN_BOOL_OPTION(voteinfo_bar_new_at_front,
+                      N_("Set new votes at front"),
+                      N_("If this option is enabled, then new votes will go "
+                         "to the front of the vote list."),
+                      COC_GRAPHICS, false, voteinfo_bar_callback),
+      GEN_BOOL_OPTION(
+          autoaccept_tileset_suggestion,
+          N_("Autoaccept tileset suggestions"),
+          N_("If this option is enabled, any tileset suggested by "
+             "the ruleset is automatically used; otherwise you "
+             "are prompted to change tileset."),
+          COC_GRAPHICS, false, nullptr),
 
-    GEN_BOOL_OPTION(sound_enable_effects, N_("Enable sound effects"),
-                    N_("Play sound effects, assuming there's suitable "
-                       "sound plugin and soundset with the sounds."),
-                    COC_SOUND, true, nullptr),
-    GEN_BOOL_OPTION(
-        sound_enable_game_music, N_("Enable in-game music"),
-        N_("Play music during the game, assuming there's suitable "
-           "sound plugin and musicset with in-game tracks."),
-        COC_SOUND, true, game_music_enable_callback),
-    GEN_BOOL_OPTION(sound_enable_menu_music, N_("Enable menu music"),
-                    N_("Play music while not in actual game, "
-                       "assuming there's suitable "
-                       "sound plugin and musicset with menu music tracks."),
-                    COC_SOUND, true, menu_music_enable_callback),
-    GEN_INT_OPTION(sound_effects_volume, N_("Sound volume"),
-                   N_("Volume scale from 0-100"), COC_SOUND, 100, 0, 100,
-                   sound_volume_callback),
+      GEN_BOOL_OPTION(sound_enable_effects, N_("Enable sound effects"),
+                      N_("Play sound effects, assuming there's suitable "
+                         "sound plugin and soundset with the sounds."),
+                      COC_SOUND, true, nullptr),
+      GEN_BOOL_OPTION(
+          sound_enable_game_music, N_("Enable in-game music"),
+          N_("Play music during the game, assuming there's suitable "
+             "sound plugin and musicset with in-game tracks."),
+          COC_SOUND, true, game_music_enable_callback),
+      GEN_BOOL_OPTION(
+          sound_enable_menu_music, N_("Enable menu music"),
+          N_("Play music while not in actual game, "
+             "assuming there's suitable "
+             "sound plugin and musicset with menu music tracks."),
+          COC_SOUND, true, menu_music_enable_callback),
+      GEN_INT_OPTION(sound_effects_volume, N_("Sound volume"),
+                     N_("Volume scale from 0-100"), COC_SOUND, 100, 0, 100,
+                     sound_volume_callback),
 
-    GEN_BOOL_OPTION(
-        autoaccept_soundset_suggestion,
-        N_("Autoaccept soundset suggestions"),
-        N_("If this option is enabled, any soundset suggested by "
-           "the ruleset is automatically used."),
-        COC_SOUND, false, nullptr),
-    GEN_BOOL_OPTION(
-        autoaccept_musicset_suggestion,
-        N_("Autoaccept musicset suggestions"),
-        N_("If this option is enabled, any musicset suggested by "
-           "the ruleset is automatically used."),
-        COC_SOUND, false, nullptr),
+      GEN_BOOL_OPTION(
+          autoaccept_soundset_suggestion,
+          N_("Autoaccept soundset suggestions"),
+          N_("If this option is enabled, any soundset suggested by "
+             "the ruleset is automatically used."),
+          COC_SOUND, false, nullptr),
+      GEN_BOOL_OPTION(
+          autoaccept_musicset_suggestion,
+          N_("Autoaccept musicset suggestions"),
+          N_("If this option is enabled, any musicset suggested by "
+             "the ruleset is automatically used."),
+          COC_SOUND, false, nullptr),
 
-    GEN_BOOL_OPTION(overview.layers[OLAYER_BACKGROUND],
-                    N_("Background layer"),
-                    N_("The background layer of the overview shows just "
-                       "ocean and land."),
-                    COC_OVERVIEW, true, nullptr),
-    GEN_BOOL_OPTION(overview.layers[OLAYER_RELIEF],
-                    N_("Terrain relief map layer"),
-                    N_("The relief layer shows all terrains on the map."),
-                    COC_OVERVIEW, true, overview_redraw_callback),
-    GEN_BOOL_OPTION(overview.layers[OLAYER_BORDERS], N_("Borders layer"),
-                    N_("The borders layer of the overview shows which tiles "
-                       "are owned by each player."),
-                    COC_OVERVIEW, false, overview_redraw_callback),
-    GEN_BOOL_OPTION(overview.layers[OLAYER_BORDERS_ON_OCEAN],
-                    N_("Borders layer on ocean tiles"),
-                    N_("The borders layer of the overview are drawn on "
-                       "ocean tiles as well (this may look ugly with many "
-                       "islands). This option is only of interest if you "
-                       "have set the option \"Borders layer\" already."),
-                    COC_OVERVIEW, true, overview_redraw_callback),
-    GEN_BOOL_OPTION(overview.layers[OLAYER_UNITS], N_("Units layer"),
-                    N_("Enabling this will draw units on the overview."),
-                    COC_OVERVIEW, true, overview_redraw_callback),
-    GEN_BOOL_OPTION(overview.layers[OLAYER_CITIES], N_("Cities layer"),
-                    N_("Enabling this will draw cities on the overview."),
-                    COC_OVERVIEW, true, overview_redraw_callback),
-    GEN_BOOL_OPTION(overview.fog, N_("Overview fog of war"),
-                    N_("Enabling this will show fog of war on the "
-                       "overview."),
-                    COC_OVERVIEW, true, overview_redraw_callback),
+      GEN_BOOL_OPTION(overview.layers[OLAYER_BACKGROUND],
+                      N_("Background layer"),
+                      N_("The background layer of the overview shows just "
+                         "ocean and land."),
+                      COC_OVERVIEW, true, nullptr),
+      GEN_BOOL_OPTION(overview.layers[OLAYER_RELIEF],
+                      N_("Terrain relief map layer"),
+                      N_("The relief layer shows all terrains on the map."),
+                      COC_OVERVIEW, true, overview_redraw_callback),
+      GEN_BOOL_OPTION(
+          overview.layers[OLAYER_BORDERS], N_("Borders layer"),
+          N_("The borders layer of the overview shows which tiles "
+             "are owned by each player."),
+          COC_OVERVIEW, false, overview_redraw_callback),
+      GEN_BOOL_OPTION(overview.layers[OLAYER_BORDERS_ON_OCEAN],
+                      N_("Borders layer on ocean tiles"),
+                      N_("The borders layer of the overview are drawn on "
+                         "ocean tiles as well (this may look ugly with many "
+                         "islands). This option is only of interest if you "
+                         "have set the option \"Borders layer\" already."),
+                      COC_OVERVIEW, true, overview_redraw_callback),
+      GEN_BOOL_OPTION(overview.layers[OLAYER_UNITS], N_("Units layer"),
+                      N_("Enabling this will draw units on the overview."),
+                      COC_OVERVIEW, true, overview_redraw_callback),
+      GEN_BOOL_OPTION(overview.layers[OLAYER_CITIES], N_("Cities layer"),
+                      N_("Enabling this will draw cities on the overview."),
+                      COC_OVERVIEW, true, overview_redraw_callback),
+      GEN_BOOL_OPTION(overview.fog, N_("Overview fog of war"),
+                      N_("Enabling this will show fog of war on the "
+                         "overview."),
+                      COC_OVERVIEW, true, overview_redraw_callback),
 
-    // options for map images
-    GEN_STR_LIST_OPTION(mapimg_format, N_("Image format"),
-                        N_("The image toolkit and file format used for "
-                           "map images."),
-                        COC_MAPIMG, nullptr, get_mapimg_format_list, nullptr,
-                        0),
-    GEN_INT_OPTION(mapimg_zoom, N_("Zoom factor for map images"),
-                   N_("The magnification used for map images."), COC_MAPIMG,
-                   2, 1, 5, mapimg_changed_callback),
-    GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_AREA],
-                    N_("Show area within borders"),
-                    N_("If set, the territory of each nation is shown "
-                       "on the saved image."),
-                    COC_MAPIMG, false, mapimg_changed_callback),
-    GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_BORDERS], N_("Show borders"),
-                    N_("If set, the border of each nation is shown on the "
-                       "saved image."),
-                    COC_MAPIMG, true, mapimg_changed_callback),
-    GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_CITIES], N_("Show cities"),
-                    N_("If set, cities are shown on the saved image."),
-                    COC_MAPIMG, true, mapimg_changed_callback),
-    GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_FOGOFWAR],
-                    N_("Show fog of war"),
-                    N_("If set, the extent of fog of war is shown on the "
-                       "saved image."),
-                    COC_MAPIMG, true, mapimg_changed_callback),
-    GEN_BOOL_OPTION(
-        mapimg_layer[MAPIMG_LAYER_TERRAIN], N_("Show full terrain"),
-        N_("If set, terrain relief is shown with different colors "
-           "in the saved image; otherwise, only land and water are "
-           "distinguished."),
-        COC_MAPIMG, true, mapimg_changed_callback),
-    GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_UNITS], N_("Show units"),
-                    N_("If set, units are shown in the saved image."),
-                    COC_MAPIMG, true, mapimg_changed_callback),
-    GEN_STR_OPTION(
-        mapimg_filename, N_("Map image file name"),
-        N_("The base part of the filename for saved map images. "
-           "A string identifying the game turn and map options will "
-           "be appended."),
-        COC_MAPIMG, GUI_DEFAULT_MAPIMG_FILENAME, nullptr, 0),
+      // options for map images
+      GEN_STR_LIST_OPTION(mapimg_format, N_("Image format"),
+                          N_("The image toolkit and file format used for "
+                             "map images."),
+                          COC_MAPIMG, nullptr, get_mapimg_format_list,
+                          nullptr, 0),
+      GEN_INT_OPTION(mapimg_zoom, N_("Zoom factor for map images"),
+                     N_("The magnification used for map images."),
+                     COC_MAPIMG, 2, 1, 5, mapimg_changed_callback),
+      GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_AREA],
+                      N_("Show area within borders"),
+                      N_("If set, the territory of each nation is shown "
+                         "on the saved image."),
+                      COC_MAPIMG, false, mapimg_changed_callback),
+      GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_BORDERS], N_("Show borders"),
+                      N_("If set, the border of each nation is shown on the "
+                         "saved image."),
+                      COC_MAPIMG, true, mapimg_changed_callback),
+      GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_CITIES], N_("Show cities"),
+                      N_("If set, cities are shown on the saved image."),
+                      COC_MAPIMG, true, mapimg_changed_callback),
+      GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_FOGOFWAR],
+                      N_("Show fog of war"),
+                      N_("If set, the extent of fog of war is shown on the "
+                         "saved image."),
+                      COC_MAPIMG, true, mapimg_changed_callback),
+      GEN_BOOL_OPTION(
+          mapimg_layer[MAPIMG_LAYER_TERRAIN], N_("Show full terrain"),
+          N_("If set, terrain relief is shown with different colors "
+             "in the saved image; otherwise, only land and water are "
+             "distinguished."),
+          COC_MAPIMG, true, mapimg_changed_callback),
+      GEN_BOOL_OPTION(mapimg_layer[MAPIMG_LAYER_UNITS], N_("Show units"),
+                      N_("If set, units are shown in the saved image."),
+                      COC_MAPIMG, true, mapimg_changed_callback),
+      GEN_STR_OPTION(
+          mapimg_filename, N_("Map image file name"),
+          N_("The base part of the filename for saved map images. "
+             "A string identifying the game turn and map options will "
+             "be appended."),
+          COC_MAPIMG, GUI_DEFAULT_MAPIMG_FILENAME, nullptr, 0),
 
-    GEN_BOOL_OPTION(gui_qt_fullscreen, N_("Fullscreen"),
-                    N_("If this option is set the client will use the "
-                       "whole screen area for drawing."),
-                    COC_INTERFACE, true, nullptr),
-    GEN_BOOL_OPTION(
-        gui_qt_show_titlebar, N_("Show titlebar"),
-        N_("If this option is set the client will show a titlebar. "
-           "If disabled, then no titlebar will be shown, and "
-           "minimize/maximize/etc buttons will be placed on the "
-           "menu bar."),
-        COC_INTERFACE, true, nullptr),
-    GEN_INT_OPTION(gui_qt_increase_fonts, N_("Change all fonts size"),
-                   N_("Change size of all fonts at once by given percent. "
-                      "This option cannot be saved. Hit the Apply button "
-                      "after changing this."),
-                   COC_FONT, 0, -100, 100, allfont_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_default, "default_font", N_("Default font"),
-                    N_("This is default font"), COC_FONT,
-                    font_changed_callback),
-    GEN_FONT_OPTION(
-        gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
-        N_("This font is used to display server reports such "
-           "as the demographic report or historian publications."),
-        COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_help_label, "help_label", N_("Help Label"),
-                    N_("This font is used to display the help labels in the "
-                       "help window."),
-                    COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_help_text, "help_text", N_("Help Text"),
-                    N_("This font is used to display the help body text in "
-                       "the help window."),
-                    COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
-                    N_("This font is used to display the text in the "
-                       "chatline area."),
-                    COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
-                    N_("This font is used to the display the city names "
-                       "on the map."),
-                    COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
-                    N_("City Productions"),
-                    N_("This font is used to display the city production "
-                       "on the map."),
-                    COC_FONT, font_changed_callback),
-    GEN_FONT_OPTION(
-        gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
-        N_("This font is used to the display the requirement tree "
-           "in the Research report."),
-        COC_FONT, font_changed_callback),
-    GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
-                    N_("If this option is set the client will show "
-                       "information and map preview of current savegame."),
-                    COC_GRAPHICS, true, nullptr),
-};
-static const int client_options_num = ARRAY_SIZE(client_options);
-
-// Iteration loop, including invalid options for the current gui type.
-#define client_options_iterate_all(poption)                                 \
-  {                                                                         \
-    const struct client_option *const poption##_max =                       \
-        client_options + client_options_num;                                \
-    struct client_option *client_##poption = client_options;                \
-    struct option *poption;                                                 \
-    for (; client_##poption < poption##_max; client_##poption++) {          \
-      poption = OPTION(client_##poption);
-
-#define client_options_iterate_all_end                                      \
-  }                                                                         \
-  }
+      GEN_BOOL_OPTION(gui_qt_fullscreen, N_("Fullscreen"),
+                      N_("If this option is set the client will use the "
+                         "whole screen area for drawing."),
+                      COC_INTERFACE, true, nullptr),
+      GEN_BOOL_OPTION(
+          gui_qt_show_titlebar, N_("Show titlebar"),
+          N_("If this option is set the client will show a titlebar. "
+             "If disabled, then no titlebar will be shown, and "
+             "minimize/maximize/etc buttons will be placed on the "
+             "menu bar."),
+          COC_INTERFACE, true, nullptr),
+      GEN_INT_OPTION(gui_qt_increase_fonts, N_("Change all fonts size"),
+                     N_("Change size of all fonts at once by given percent. "
+                        "This option cannot be saved. Hit the Apply button "
+                        "after changing this."),
+                     COC_FONT, 0, -100, 100, allfont_changed_callback),
+      GEN_FONT_OPTION(gui_qt_font_default, "default_font",
+                      N_("Default font"), N_("This is default font"),
+                      COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(
+          gui_qt_font_notify_label, "notify_label", N_("Notify Label"),
+          N_("This font is used to display server reports such "
+             "as the demographic report or historian publications."),
+          COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(
+          gui_qt_font_help_label, "help_label", N_("Help Label"),
+          N_("This font is used to display the help labels in the "
+             "help window."),
+          COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(
+          gui_qt_font_help_text, "help_text", N_("Help Text"),
+          N_("This font is used to display the help body text in "
+             "the help window."),
+          COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(gui_qt_font_chatline, "chatline", N_("Chatline Area"),
+                      N_("This font is used to display the text in the "
+                         "chatline area."),
+                      COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(gui_qt_font_city_names, "city_names", N_("City Names"),
+                      N_("This font is used to the display the city names "
+                         "on the map."),
+                      COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(gui_qt_font_city_productions, "city_productions",
+                      N_("City Productions"),
+                      N_("This font is used to display the city production "
+                         "on the map."),
+                      COC_FONT, font_changed_callback),
+      GEN_FONT_OPTION(
+          gui_qt_font_reqtree_text, "reqtree_text", N_("Requirement Tree"),
+          N_("This font is used to the display the requirement tree "
+             "in the Research report."),
+          COC_FONT, font_changed_callback),
+      GEN_BOOL_OPTION(gui_qt_show_preview, N_("Show savegame information"),
+                      N_("If this option is set the client will show "
+                         "information and map preview of current savegame."),
+                      COC_GRAPHICS, true, nullptr),
+  };
+}
 
 /**
    Returns the next valid option pointer for the current gui type.
@@ -2012,9 +1901,7 @@ static const int client_options_num = ARRAY_SIZE(client_options);
 static struct client_option *
 client_option_next_valid(struct client_option *poption)
 {
-  const struct client_option *const max =
-      client_options + client_options_num;
-  return (poption < max ? poption : nullptr);
+  return (poption < &client_options.back() ? poption : nullptr);
 }
 
 /**
@@ -2022,10 +1909,10 @@ client_option_next_valid(struct client_option *poption)
  */
 static struct option *client_optset_option_by_number(int id)
 {
-  if (0 > id || id > client_options_num) {
+  if (id < 0 || id >= client_options.size()) {
     return nullptr;
   }
-  return OPTION(client_options + id);
+  return OPTION(&client_options[id]);
 }
 
 /**
@@ -2033,7 +1920,7 @@ static struct option *client_optset_option_by_number(int id)
  */
 static struct option *client_optset_option_first()
 {
-  return OPTION(client_option_next_valid(client_options));
+  return OPTION(client_option_next_valid(&client_options.front()));
 }
 
 /**
@@ -2076,7 +1963,7 @@ static const char *client_optset_category_name(int category)
  */
 static int client_option_number(const struct option *poption)
 {
-  return CLIENT_OPTION(poption) - client_options;
+  return CLIENT_OPTION(poption) - &client_options.front();
 }
 
 /**
@@ -2289,7 +2176,7 @@ static const char *client_option_bitwise_secfile_str(secfile_data_t data,
  */
 static QFont client_option_font_get(const struct option *poption)
 {
-  return CLIENT_OPTION(poption)->u.font.value;
+  return *CLIENT_OPTION(poption)->u.font.value;
 }
 
 /**
@@ -2325,11 +2212,11 @@ static bool client_option_font_set(struct option *poption, const QFont &font)
 {
   struct client_option *pcoption = CLIENT_OPTION(poption);
 
-  if (pcoption->u.font.value == font) {
+  if (*pcoption->u.font.value == font) {
     return false;
   }
 
-  pcoption->u.font.value = font;
+  *pcoption->u.font.value = font;
   return true;
 }
 
@@ -4364,7 +4251,7 @@ void options_load()
     qInfo(_("Didn't find the option file. Creating a new one."));
     options_fully_initialized = true;
     create_default_cma_presets();
-    gui_options.first_boot = true;
+    gui_options->first_boot = true;
     return;
   }
   if (!(sf = secfile_load(name, true))) {
@@ -4374,7 +4261,7 @@ void options_load()
     secfile_insert_str(sf, VERSION_STRING, "client.version");
 
     create_default_cma_presets();
-    gui_options.first_boot = true;
+    gui_options->first_boot = true;
     save_cma_presets(sf);
 
     // FIXME: need better messages
@@ -4395,43 +4282,44 @@ void options_load()
         secfile_lookup_str_default(sf, "", "%s.password", prefix));
   }
 
-  gui_options.save_options_on_exit =
-      secfile_lookup_bool_default(sf, gui_options.save_options_on_exit,
+  gui_options->save_options_on_exit =
+      secfile_lookup_bool_default(sf, gui_options->save_options_on_exit,
                                   "%s.save_options_on_exit", prefix);
-  gui_options.migrate_fullscreen = secfile_lookup_bool_default(
-      sf, gui_options.migrate_fullscreen, "%s.fullscreen_mode", prefix);
+  gui_options->migrate_fullscreen = secfile_lookup_bool_default(
+      sf, gui_options->migrate_fullscreen, "%s.fullscreen_mode", prefix);
 
   str = secfile_lookup_str_default(sf, nullptr,
                                    "client.default_tileset_overhead_name");
   if (str != nullptr) {
-    sz_strlcpy(gui_options.default_tileset_overhead_name, str);
+    sz_strlcpy(gui_options->default_tileset_overhead_name, str);
   }
   str = secfile_lookup_str_default(sf, nullptr,
                                    "client.default_tileset_iso_name");
   if (str != nullptr) {
-    sz_strlcpy(gui_options.default_tileset_iso_name, str);
+    sz_strlcpy(gui_options->default_tileset_iso_name, str);
   }
 
   bool draw_full_citybar =
       secfile_lookup_bool_default(sf, true, "client.draw_full_citybar");
   if (draw_full_citybar) {
-    fc_strlcpy(gui_options.default_city_bar_style_name, "Polished",
-               sizeof(gui_options.default_city_bar_style_name));
+    fc_strlcpy(gui_options->default_city_bar_style_name, "Polished",
+               sizeof(gui_options->default_city_bar_style_name));
   } else {
-    fc_strlcpy(gui_options.default_city_bar_style_name, "Simple",
-               sizeof(gui_options.default_city_bar_style_name));
+    fc_strlcpy(gui_options->default_city_bar_style_name, "Simple",
+               sizeof(gui_options->default_city_bar_style_name));
   }
 
   /* Backwards compatibility for removed options replaced by entirely "new"
    * options. The equivalent "new" option will override these, if set. */
 
   // Renamed in 2.6
-  gui_options.popup_actor_arrival = secfile_lookup_bool_default(
+  gui_options->popup_actor_arrival = secfile_lookup_bool_default(
       sf, true, "%s.popup_caravan_arrival", prefix);
 
   // Load all the regular options
-  client_options_iterate_all(poption) { client_option_load(poption, sf); }
-  client_options_iterate_all_end;
+  for (auto &option : client_options) {
+    client_option_load(OPTION(&option), sf);
+  }
 
   /* More backwards compatibility, for removed options that had been
    * folded into then-existing options. Here, the backwards-compatibility
@@ -4440,7 +4328,7 @@ void options_load()
   // Removed in 2.4
   if (!secfile_lookup_bool_default(sf, true, "%s.do_combat_animation",
                                    prefix)) {
-    gui_options.smooth_combat_step_msec = 0;
+    gui_options->smooth_combat_step_msec = 0;
   }
 
   message_options_load(sf, prefix);
@@ -4496,15 +4384,16 @@ void options_save(option_save_log_callback log_cb)
   sf = secfile_new(true);
   secfile_insert_str(sf, VERSION_STRING, "client.version");
 
-  secfile_insert_bool(sf, gui_options.save_options_on_exit,
+  secfile_insert_bool(sf, gui_options->save_options_on_exit,
                       "client.save_options_on_exit");
-  secfile_insert_bool_comment(sf, gui_options.migrate_fullscreen,
+  secfile_insert_bool_comment(sf, gui_options->migrate_fullscreen,
                               "deprecated", "client.fullscreen_mode");
 
   // prevent saving that option
-  gui_options.gui_qt_increase_fonts = 0; // gui-enabled options
-  client_options_iterate_all(poption) { client_option_save(poption, sf); }
-  client_options_iterate_all_end;
+  gui_options->gui_qt_increase_fonts = 0; // gui-enabled options
+  for (const auto &option : client_options) {
+    client_option_save(OPTION(&option), sf);
+  }
 
   message_options_save(sf, "client");
   options_dialogs_save(sf);
@@ -4560,13 +4449,16 @@ static void options_init_names(const struct copt_val_name *(*acc)(int),
  */
 void options_init()
 {
+  gui_options = new struct client_options;
+  init_client_options();
+
   message_options_init();
   options_extra_init();
   global_worklists_init();
 
-  client_options_iterate_all(poption)
-  {
-    struct client_option *pcoption = CLIENT_OPTION(poption);
+  for (auto &option : client_options) {
+    auto *poption = OPTION(&option);
+    auto *pcoption = CLIENT_OPTION(&option);
 
     switch (option_type(poption)) {
     case OT_INTEGER:
@@ -4586,10 +4478,10 @@ void options_init()
       break;
 
     case OT_STRING:
-      if (gui_options.default_user_name == option_str_get(poption)) {
+      if (gui_options->default_user_name == option_str_get(poption)) {
         // Hack to get a default value.
         *(const_cast<const char **>(&(pcoption->u.string.def))) =
-            fc_strdup(gui_options.default_user_name);
+            fc_strdup(gui_options->default_user_name);
       }
 
       if (nullptr == option_str_def(poption)) {
@@ -4645,7 +4537,6 @@ void options_init()
     // Set to default.
     option_reset(poption);
   }
-  client_options_iterate_all_end;
 }
 
 /**
@@ -4653,9 +4544,9 @@ void options_init()
  */
 void options_free()
 {
-  client_options_iterate_all(poption)
-  {
-    struct client_option *pcoption = CLIENT_OPTION(poption);
+  for (auto option : client_options) {
+    auto *poption = OPTION(&option);
+    auto *pcoption = CLIENT_OPTION(&option);
 
     switch (option_type(poption)) {
     case OT_ENUM:
@@ -4686,13 +4577,14 @@ void options_free()
       break;
     }
   }
-  client_options_iterate_all_end;
 
   settable_options->clear();
   dialog_options->clear();
 
   message_options_free();
   global_worklists_free();
+
+  delete gui_options;
 }
 
 /**
@@ -4723,7 +4615,7 @@ static void manual_turn_done_callback(struct option *poption)
   Q_UNUSED(poption)
   update_turn_done_button_state();
 
-  if (!gui_options.ai_manual_turn_done) {
+  if (!gui_options->ai_manual_turn_done) {
     const player *pplayer = client_player();
     if (pplayer != nullptr && is_ai(pplayer) && can_end_turn()) {
       user_ended_turn();
@@ -4737,7 +4629,7 @@ static void manual_turn_done_callback(struct option *poption)
 static void sound_volume_callback(struct option *poption)
 {
   Q_UNUSED(poption)
-  audio_set_volume(gui_options.sound_effects_volume / 100.0);
+  audio_set_volume(gui_options->sound_effects_volume / 100.0);
 }
 
 /**
@@ -4797,7 +4689,7 @@ static void game_music_enable_callback(struct option *poption)
 {
   Q_UNUSED(poption)
   if (client_state() == C_S_RUNNING) {
-    if (gui_options.sound_enable_game_music) {
+    if (gui_options->sound_enable_game_music) {
       start_style_music();
     } else {
       stop_style_music();
@@ -4812,7 +4704,7 @@ static void menu_music_enable_callback(struct option *poption)
 {
   Q_UNUSED(poption)
   if (client_state() != C_S_RUNNING) {
-    if (gui_options.sound_enable_menu_music) {
+    if (gui_options->sound_enable_menu_music) {
       start_menu_music(QStringLiteral("music_menu"), nullptr);
     } else {
       stop_menu_music();
@@ -4840,13 +4732,13 @@ const char *tileset_name_for_topology(int topology_id)
   switch (topology_id & (TF_ISO | TF_HEX)) {
   case 0:
   case TF_ISO:
-    tsn = gui_options.default_tileset_square_name;
+    tsn = gui_options->default_tileset_square_name;
     break;
   case TF_HEX:
-    tsn = gui_options.default_tileset_hex_name;
+    tsn = gui_options->default_tileset_hex_name;
     break;
   case TF_ISO | TF_HEX:
-    tsn = gui_options.default_tileset_isohex_name;
+    tsn = gui_options->default_tileset_isohex_name;
     break;
   }
 
@@ -4915,14 +4807,14 @@ static bool is_ts_option_unset(const char *optname)
 void fill_topo_ts_default()
 {
   if (is_ts_option_unset("default_tileset_square_name")) {
-    if (gui_options.default_tileset_iso_name[0] != '\0') {
-      qstrncpy(gui_options.default_tileset_square_name,
-               gui_options.default_tileset_iso_name,
-               sizeof(gui_options.default_tileset_square_name));
-    } else if (gui_options.default_tileset_overhead_name[0] != '\0') {
-      qstrncpy(gui_options.default_tileset_square_name,
-               gui_options.default_tileset_overhead_name,
-               sizeof(gui_options.default_tileset_square_name));
+    if (gui_options->default_tileset_iso_name[0] != '\0') {
+      qstrncpy(gui_options->default_tileset_square_name,
+               gui_options->default_tileset_iso_name,
+               sizeof(gui_options->default_tileset_square_name));
+    } else if (gui_options->default_tileset_overhead_name[0] != '\0') {
+      qstrncpy(gui_options->default_tileset_square_name,
+               gui_options->default_tileset_overhead_name,
+               sizeof(gui_options->default_tileset_square_name));
     } else {
       log_debug("Setting tileset for square topologies.");
       tilespec_try_read(QString(), false, 0);

--- a/client/options.h
+++ b/client/options.h
@@ -46,117 +46,127 @@ struct overview {
 };
 
 struct client_options {
-  char default_user_name[512];
-  char default_server_host[512];
-  int default_server_port;
-  bool use_prev_server;
-  bool heartbeat_enabled;
-  char default_metaserver[512];
-  char default_tileset_square_name[512];
-  char default_tileset_hex_name[512];
-  char default_tileset_isohex_name[512];
-  char default_city_bar_style_name[512];
-  char default_sound_set_name[512];
-  char default_music_set_name[512];
-  char default_sound_plugin_name[512];
-  char default_chat_logfile[512];
+  char default_user_name[512] = "\0";
+  char default_server_host[512] = "localhost";
+  int default_server_port = DEFAULT_SOCK_PORT;
+  bool use_prev_server = false;
+  bool heartbeat_enabled = false;
+  char default_metaserver[512] = DEFAULT_METASERVER_OPTION;
+  char default_tileset_square_name[512] = "\0";
+  char default_tileset_hex_name[512] = "\0";
+  char default_tileset_isohex_name[512] = "\0";
+  char default_city_bar_style_name[512] = "Simple";
+  char default_sound_set_name[512] = "stdsounds";
+  char default_music_set_name[512] = "stdmusic";
+  char default_sound_plugin_name[512] = "\0";
+  char default_chat_logfile[512] = "freeciv-chat.log";
 
-  bool save_options_on_exit;
+  bool save_options_on_exit = true;
 
   /** Migrations **/
-  bool first_boot; /* There was no earlier options saved.
-                    * This affects some migrations, but not all. */
-  char default_tileset_overhead_name[512]; /* 2.6 had separate tilesets for
-                                              ... */
-  char default_tileset_iso_name[512];      // ...overhead and iso topologies.
+  bool first_boot = true; /* There was no earlier options saved.
+                           * This affects some migrations, but not all. */
+  char default_tileset_overhead_name[512] =
+      "\0"; /* 2.6 had separate tilesets for
+        ... */
+  char default_tileset_iso_name[512] =
+      "\0"; // ...overhead and iso topologies.
 
-  bool migrate_fullscreen;
+  bool migrate_fullscreen = false;
 
   /** Local Options: **/
 
-  bool solid_color_behind_units;
-  bool sound_bell_at_new_turn;
-  int smooth_move_unit_msec;
-  int smooth_center_slide_msec;
-  int smooth_combat_step_msec;
-  bool ai_manual_turn_done;
-  bool auto_center_on_unit;
-  bool auto_center_on_automated;
-  bool auto_center_on_combat;
-  bool auto_center_each_turn;
-  bool wakeup_focus;
-  bool goto_into_unknown;
-  bool center_when_popup_city;
-  bool show_previous_turn_messages;
-  bool concise_city_production;
-  bool auto_turn_done;
-  bool ask_city_name;
-  bool popup_new_cities;
-  bool popup_actor_arrival;
-  bool popup_attack_actions;
-  bool popup_last_move_to_allied;
-  bool keyboardless_goto;
-  bool enable_cursor_changes;
-  bool separate_unit_selection;
-  bool unit_selection_clears_orders;
-  struct ft_color highlight_our_names;
+  bool solid_color_behind_units = false;
+  bool sound_bell_at_new_turn = false;
+  int smooth_move_unit_msec = 30;
+  int smooth_center_slide_msec = 200;
+  int smooth_combat_step_msec = 10;
+  bool ai_manual_turn_done = true;
+  bool auto_center_on_unit = true;
+  bool auto_center_on_automated = true;
+  bool auto_center_on_combat = false;
+  bool auto_center_each_turn = true;
+  bool wakeup_focus = true;
+  bool goto_into_unknown = true;
+  bool center_when_popup_city = true;
+  bool show_previous_turn_messages = true;
+  bool concise_city_production = false;
+  bool auto_turn_done = false;
+  bool ask_city_name = true;
+  bool popup_new_cities = true;
+  bool popup_actor_arrival = true;
+  bool popup_attack_actions = true;
+  bool popup_last_move_to_allied = true;
+  bool keyboardless_goto = false;
+  bool enable_cursor_changes = true;
+  bool separate_unit_selection = false;
+  bool unit_selection_clears_orders = true;
+  struct ft_color highlight_our_names = FT_COLOR("#000000", "#FFFF00");
 
-  bool voteinfo_bar_use;
-  bool voteinfo_bar_always_show;
-  bool voteinfo_bar_hide_when_not_player;
-  bool voteinfo_bar_new_at_front;
+  bool voteinfo_bar_use = true;
+  bool voteinfo_bar_always_show = false;
+  bool voteinfo_bar_hide_when_not_player = false;
+  bool voteinfo_bar_new_at_front = false;
 
-  bool autoaccept_tileset_suggestion;
-  bool autoaccept_soundset_suggestion;
-  bool autoaccept_musicset_suggestion;
+  bool autoaccept_tileset_suggestion = false;
+  bool autoaccept_soundset_suggestion = false;
+  bool autoaccept_musicset_suggestion = false;
 
-  bool sound_enable_effects;
-  bool sound_enable_menu_music;
-  bool sound_enable_game_music;
-  int sound_effects_volume;
+  bool sound_enable_effects = true;
+  bool sound_enable_menu_music = true;
+  bool sound_enable_game_music = true;
+  int sound_effects_volume = 50;
 
-  bool draw_city_outlines;
-  bool draw_city_output;
-  bool draw_map_grid;
-  bool draw_city_names;
-  bool draw_city_growth;
-  bool draw_city_productions;
-  bool draw_city_buycost;
-  bool draw_city_trade_routes;
-  bool draw_coastline;
-  bool draw_roads_rails;
-  bool draw_irrigation;
-  bool draw_mines;
-  bool draw_fortress_airbase;
-  bool draw_specials;
-  bool draw_huts;
-  bool draw_pollution;
-  bool draw_cities;
-  bool draw_units;
-  bool draw_focus_unit;
-  bool draw_fog_of_war;
-  bool draw_borders;
-  bool draw_native;
-  bool draw_unit_shields;
-  bool zoom_scale_fonts;
+  bool draw_city_outlines = true;
+  bool draw_city_output = false;
+  bool draw_map_grid = false;
+  bool draw_city_names = true;
+  bool draw_city_growth = true;
+  bool draw_city_productions = true;
+  bool draw_city_buycost = false;
+  bool draw_city_trade_routes = false;
+  bool draw_coastline = false;
+  bool draw_roads_rails = true;
+  bool draw_irrigation = true;
+  bool draw_mines = true;
+  bool draw_fortress_airbase = true;
+  bool draw_specials = true;
+  bool draw_huts = true;
+  bool draw_pollution = true;
+  bool draw_cities = true;
+  bool draw_units = true;
+  bool draw_focus_unit = false;
+  bool draw_fog_of_war = true;
+  bool draw_borders = true;
+  bool draw_native = false;
+  bool draw_unit_shields = true;
+  bool zoom_scale_fonts = true;
 
-  bool player_dlg_show_dead_players;
-  bool reqtree_show_icons;
-  bool reqtree_curved_lines;
+  bool player_dlg_show_dead_players = true;
+  bool reqtree_show_icons = true;
+  bool reqtree_curved_lines = false;
 
   // options for map images
-  char mapimg_format[64];
-  int mapimg_zoom;
-  bool mapimg_layer[MAPIMG_LAYER_COUNT];
-  char mapimg_filename[512];
+  char mapimg_format[64] = "png";
+  int mapimg_zoom = 2;
+  bool mapimg_layer[MAPIMG_LAYER_COUNT] = {
+      false, // a - MAPIMG_LAYER_AREA
+      true,  // b - MAPIMG_LAYER_BORDERS
+      true,  // c - MAPIMG_LAYER_CITIES
+      true,  // f - MAPIMG_LAYER_FOGOFWAR
+      true,  // k - MAPIMG_LAYER_KNOWLEDGE
+      true,  // t - MAPIMG_LAYER_TERRAIN
+      true   // u - MAPIMG_LAYER_UNITS
+  };
+  char mapimg_filename[512] = "mapimage filename";
 
 // gui-qt client specific options.
 #define FC_QT_DEFAULT_THEME_NAME "NightStalker"
-  bool gui_qt_fullscreen;
-  bool gui_qt_show_preview;
-  bool gui_qt_allied_chat_only;
-  int gui_qt_increase_fonts;
-  char gui_qt_default_theme_name[512];
+  bool gui_qt_fullscreen = true;
+  bool gui_qt_show_preview = true;
+  bool gui_qt_allied_chat_only = true;
+  int gui_qt_increase_fonts = 0;
+  char gui_qt_default_theme_name[512] = "NightStalker";
   QFont gui_qt_font_default;
   QFont gui_qt_font_notify_label;
   QFont gui_qt_font_help_label;
@@ -165,12 +175,12 @@ struct client_options {
   QFont gui_qt_font_city_names;
   QFont gui_qt_font_city_productions;
   QFont gui_qt_font_reqtree_text;
-  bool gui_qt_show_titlebar;
+  bool gui_qt_show_titlebar = true;
 
-  struct overview overview;
+  struct overview overview = {};
 };
 
-extern struct client_options gui_options;
+extern client_options *gui_options;
 
 #define SPECENUM_NAME option_type
 #define SPECENUM_VALUE0 OT_BOOLEAN
@@ -307,7 +317,6 @@ extern int messages_where[]; // OR-ed MW_ values [E_COUNT]
 
 /** Client options **/
 
-#define GUI_DEFAULT_CHAT_LOGFILE "freeciv-chat.log"
 #define GUI_DEFAULT_MAPIMG_FILENAME "freeciv"
 
 struct tileset;

--- a/client/overview_common.cpp
+++ b/client/overview_common.cpp
@@ -96,8 +96,10 @@ void gui_to_overview_pos(const struct tileset *t, int *ovr_x, int *ovr_y,
   gui_to_natural_pos(t, &ntl_x, &ntl_y, gui_x, gui_y);
 
   // Now convert straight to overview coordinates.
-  *ovr_x = floor((ntl_x - gui_options.overview.map_x0) * OVERVIEW_TILE_SIZE);
-  *ovr_y = floor((ntl_y - gui_options.overview.map_y0) * OVERVIEW_TILE_SIZE);
+  *ovr_x =
+      floor((ntl_x - gui_options->overview.map_x0) * OVERVIEW_TILE_SIZE);
+  *ovr_y =
+      floor((ntl_y - gui_options->overview.map_y0) * OVERVIEW_TILE_SIZE);
 
   // Now do additional adjustments.
   if (current_topo_has_flag(TF_WRAPX)) {
@@ -122,7 +124,7 @@ void gui_to_overview_pos(const struct tileset *t, int *ovr_x, int *ovr_y,
  */
 static QColor overview_tile_color(const tile *ptile)
 {
-  if (gui_options.overview.layers[OLAYER_CITIES]) {
+  if (gui_options->overview.layers[OLAYER_CITIES]) {
     struct city *pcity = tile_city(ptile);
 
     if (pcity) {
@@ -137,7 +139,7 @@ static QColor overview_tile_color(const tile *ptile)
       }
     }
   }
-  if (gui_options.overview.layers[OLAYER_UNITS]) {
+  if (gui_options->overview.layers[OLAYER_UNITS]) {
     struct unit *punit = find_visible_unit(ptile);
 
     if (punit) {
@@ -152,22 +154,22 @@ static QColor overview_tile_color(const tile *ptile)
       }
     }
   }
-  if (gui_options.overview.layers[OLAYER_BORDERS]) {
+  if (gui_options->overview.layers[OLAYER_BORDERS]) {
     struct player *owner = tile_owner(ptile);
 
     if (owner) {
-      if (gui_options.overview.layers[OLAYER_BORDERS_ON_OCEAN]) {
+      if (gui_options->overview.layers[OLAYER_BORDERS_ON_OCEAN]) {
         return get_player_color(tileset, owner);
       } else if (!is_ocean_tile(ptile)) {
         return get_player_color(tileset, owner);
       }
     }
   }
-  if (gui_options.overview.layers[OLAYER_RELIEF]
+  if (gui_options->overview.layers[OLAYER_RELIEF]
       && tile_terrain(ptile) != T_UNKNOWN) {
     return get_terrain_color(tileset, tile_terrain(ptile));
   }
-  if (gui_options.overview.layers[OLAYER_BACKGROUND]
+  if (gui_options->overview.layers[OLAYER_BACKGROUND]
       && tile_terrain(ptile) != T_UNKNOWN) {
     if (terrain_has_flag(tile_terrain(ptile), TER_FROZEN)) {
       return get_color(tileset, COLOR_OVERVIEW_FROZEN);
@@ -191,17 +193,17 @@ static void redraw_overview()
 {
   int i, x[4], y[4];
 
-  if (!gui_options.overview.map) {
+  if (!gui_options->overview.map) {
     return;
   }
 
   {
-    QPixmap *src = gui_options.overview.map;
-    QPixmap *dst = gui_options.overview.window;
-    int x_left = gui_options.overview.map_x0 * OVERVIEW_TILE_SIZE;
-    int y_top = gui_options.overview.map_y0 * OVERVIEW_TILE_SIZE;
-    int ix = gui_options.overview.width - x_left;
-    int iy = gui_options.overview.height - y_top;
+    QPixmap *src = gui_options->overview.map;
+    QPixmap *dst = gui_options->overview.window;
+    int x_left = gui_options->overview.map_x0 * OVERVIEW_TILE_SIZE;
+    int y_top = gui_options->overview.map_y0 * OVERVIEW_TILE_SIZE;
+    int ix = gui_options->overview.width - x_left;
+    int iy = gui_options->overview.height - y_top;
 
     QPainter p(dst);
     p.drawPixmap(ix, iy, *src, 0, 0, x_left, y_top);
@@ -219,7 +221,7 @@ static void redraw_overview()
   gui_to_overview_pos(tileset, &x[3], &y[3], mapview.gui_x0,
                       mapview.gui_y0 + mapview.height);
 
-  QPainter p(gui_options.overview.window);
+  QPainter p(gui_options->overview.window);
   p.setPen(QPen(get_color(tileset, COLOR_OVERVIEW_VIEWRECT), 2));
   for (i = 0; i < 4; i++) {
     int src_x = x[i];
@@ -259,8 +261,8 @@ void flush_dirty_overview()
 void overview_to_map_pos(int *map_x, int *map_y, int overview_x,
                          int overview_y)
 {
-  int ntl_x = overview_x / OVERVIEW_TILE_SIZE + gui_options.overview.map_x0;
-  int ntl_y = overview_y / OVERVIEW_TILE_SIZE + gui_options.overview.map_y0;
+  int ntl_x = overview_x / OVERVIEW_TILE_SIZE + gui_options->overview.map_x0;
+  int ntl_y = overview_y / OVERVIEW_TILE_SIZE + gui_options->overview.map_y0;
 
   if (MAP_IS_ISOMETRIC && !current_topo_has_flag(TF_WRAPX)) {
     // Clip half tile left and right.
@@ -297,7 +299,7 @@ static void put_overview_tile_area(QPixmap *pcanvas, const tile *ptile,
 {
   QPainter p(pcanvas);
   p.fillRect(x, y, w, h, overview_tile_color(ptile));
-  if (gui_options.overview.fog
+  if (gui_options->overview.fog
       && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile)) {
     p.drawPixmap(x, y, w, h, *get_basic_fog_sprite(tileset));
   }
@@ -325,11 +327,11 @@ static void overview_update_tile(const tile *ptile)
 
     if (MAP_IS_ISOMETRIC) {
       if (current_topo_has_flag(TF_WRAPX)) {
-        if (overview_x > gui_options.overview.width - OVERVIEW_TILE_WIDTH) {
+        if (overview_x > gui_options->overview.width - OVERVIEW_TILE_WIDTH) {
           /* This tile is shown half on the left and half on the right
            * side of the overview.  So we have to draw it in two parts. */
-          put_overview_tile_area(gui_options.overview.map, ptile,
-                                 overview_x - gui_options.overview.width,
+          put_overview_tile_area(gui_options->overview.map, ptile,
+                                 overview_x - gui_options->overview.width,
                                  overview_y, OVERVIEW_TILE_WIDTH,
                                  OVERVIEW_TILE_HEIGHT);
         }
@@ -340,7 +342,7 @@ static void overview_update_tile(const tile *ptile)
       }
     }
 
-    put_overview_tile_area(gui_options.overview.map, ptile, overview_x,
+    put_overview_tile_area(gui_options->overview.map, ptile, overview_x,
                            overview_y, OVERVIEW_TILE_WIDTH,
                            OVERVIEW_TILE_HEIGHT);
 
@@ -386,19 +388,20 @@ void calculate_overview_dimensions()
   log_debug("Map size %d,%d - area size %d,%d - scale: %d", wld.map.xsize,
             wld.map.ysize, w, h, OVERVIEW_TILE_SIZE);
 
-  gui_options.overview.width =
+  gui_options->overview.width =
       OVERVIEW_TILE_WIDTH * wld.map.xsize + shift * OVERVIEW_TILE_SIZE;
-  gui_options.overview.height = OVERVIEW_TILE_HEIGHT * wld.map.ysize;
+  gui_options->overview.height = OVERVIEW_TILE_HEIGHT * wld.map.ysize;
 
-  if (gui_options.overview.map) {
-    delete gui_options.overview.map;
-    delete gui_options.overview.window;
+  if (gui_options->overview.map) {
+    delete gui_options->overview.map;
+    delete gui_options->overview.window;
   }
-  gui_options.overview.map =
-      new QPixmap(gui_options.overview.width, gui_options.overview.height);
-  gui_options.overview.window =
-      new QPixmap(gui_options.overview.width, gui_options.overview.height);
-  gui_options.overview.map->fill(get_color(tileset, COLOR_OVERVIEW_UNKNOWN));
+  gui_options->overview.map =
+      new QPixmap(gui_options->overview.width, gui_options->overview.height);
+  gui_options->overview.window =
+      new QPixmap(gui_options->overview.width, gui_options->overview.height);
+  gui_options->overview.map->fill(
+      get_color(tileset, COLOR_OVERVIEW_UNKNOWN));
 
   update_minimap();
   if (can_client_change_view()) {
@@ -441,11 +444,11 @@ void overview_init()
  */
 void overview_free()
 {
-  if (gui_options.overview.map) {
-    delete gui_options.overview.map;
-    delete gui_options.overview.window;
-    gui_options.overview.map = nullptr;
-    gui_options.overview.window = nullptr;
+  if (gui_options->overview.map) {
+    delete gui_options->overview.map;
+    delete gui_options->overview.window;
+    gui_options->overview.map = nullptr;
+    gui_options->overview.window = nullptr;
   }
   updates = nullptr;
 }

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -503,7 +503,7 @@ void handle_unit_combat_info(const struct packet_unit_combat_info *packet)
     if (tile_visible_mapcanvas(unit_tile(punit0))
         && tile_visible_mapcanvas(unit_tile(punit1))) {
       show_combat = true;
-    } else if (gui_options.auto_center_on_combat) {
+    } else if (gui_options->auto_center_on_combat) {
       if (unit_owner(punit0) == client.conn.playing) {
         queen()->mapview_wdg->center_on_tile(unit_tile(punit0));
       } else {
@@ -520,7 +520,7 @@ void handle_unit_combat_info(const struct packet_unit_combat_info *packet)
       audio_play_sound(unit_type_get(punit1)->sound_fight,
                        unit_type_get(punit1)->sound_fight_alt);
 
-      if (gui_options.smooth_combat_step_msec > 0) {
+      if (gui_options->smooth_combat_step_msec > 0) {
         decrease_unit_hp_smooth(punit0, hp0, punit1, hp1);
       } else {
         punit0->hp = hp0;
@@ -678,15 +678,15 @@ void handle_city_info(const struct packet_city_info *packet)
      * have changed, the time-to-grow is likely to
      * have changed as well. */
     update_descriptions =
-        (gui_options.draw_city_names && name_changed)
-        || (gui_options.draw_city_productions
+        (gui_options->draw_city_names && name_changed)
+        || (gui_options->draw_city_productions
             && (!are_universals_equal(&pcity->production, &product)
                 || pcity->surplus[O_SHIELD] != packet->surplus[O_SHIELD]
                 || pcity->shield_stock != packet->shield_stock))
-        || (gui_options.draw_city_growth
+        || (gui_options->draw_city_growth
             && (pcity->food_stock != packet->food_stock
                 || pcity->surplus[O_FOOD] != packet->surplus[O_FOOD]))
-        || (gui_options.draw_city_trade_routes && trade_routes_changed);
+        || (gui_options->draw_city_trade_routes && trade_routes_changed);
   }
 
   sz_strlcpy(pcity->name, packet->name);
@@ -860,7 +860,7 @@ void handle_city_info(const struct packet_city_info *packet)
   pcity->client.unhappy = city_unhappy(pcity);
 
   popup = (city_is_new && can_client_change_view()
-           && powner == client.conn.playing && gui_options.popup_new_cities)
+           && powner == client.conn.playing && gui_options->popup_new_cities)
           || packet->diplomat_investigate;
 
   city_packet_common(pcity, pcenter, powner, worked_tiles, city_is_new,
@@ -914,7 +914,7 @@ void handle_city_info(const struct packet_city_info *packet)
         action_selection_target_extra(), false);
   }
 
-  if (gui_options.draw_city_trade_routes
+  if (gui_options->draw_city_trade_routes
       && (trade_routes_changed
           || (city_is_new && 0 < city_num_trade_routes(pcity)))) {
     update_map_canvas_visible();
@@ -1053,7 +1053,7 @@ void handle_traderoute_info(const struct packet_traderoute_info *packet)
   proute->dir = packet->direction;
   proute->goods = goods_by_number(packet->goods);
 
-  if (gui_options.draw_city_trade_routes && city_changed) {
+  if (gui_options->draw_city_trade_routes && city_changed) {
     update_city_description(pcity);
     update_map_canvas_visible();
   }
@@ -1146,7 +1146,7 @@ void handle_city_short_info(const struct packet_city_short_info *packet)
         (0 != strncmp(packet->name, pcity->name, sizeof(pcity->name)));
 
     // Check if city descriptions should be updated
-    if (gui_options.draw_city_names && name_changed) {
+    if (gui_options->draw_city_names && name_changed) {
       update_descriptions = true;
     }
 
@@ -1292,7 +1292,7 @@ void handle_new_year(int year, int fragments, int turn)
   update_map_canvas_visible();
   link_marks_decrease_turn_counters();
 
-  if (gui_options.sound_bell_at_new_turn) {
+  if (gui_options->sound_bell_at_new_turn) {
     create_event(nullptr, E_TURN_BELL, ftc_client, _("Start of turn %d"),
                  game.info.turn);
   }
@@ -1352,7 +1352,7 @@ void handle_start_phase(int phase)
 
     update_turn_done_button_state();
 
-    if (is_ai(client.conn.playing) && !gui_options.ai_manual_turn_done) {
+    if (is_ai(client.conn.playing) && !gui_options->ai_manual_turn_done) {
       user_ended_turn();
     }
 
@@ -1640,7 +1640,7 @@ static bool handle_unit_packet_common(struct unit *packet_unit)
       repaint_unit = true;
 
       // Wakeup Focus
-      if (gui_options.wakeup_focus && nullptr != client.conn.playing
+      if (gui_options->wakeup_focus && nullptr != client.conn.playing
           && is_human(client.conn.playing)
           && unit_owner(punit) == client.conn.playing
           && punit->activity == ACTIVITY_SENTRY
@@ -2394,7 +2394,7 @@ void handle_player_info(const struct packet_player_info *pinfo)
     if (pplayer == my_player) {
       if (is_ai(my_player)) {
         output_window_append(ftc_client, _("AI mode is now ON."));
-        if (!gui_options.ai_manual_turn_done && !pplayer->phase_done) {
+        if (!gui_options->ai_manual_turn_done && !pplayer->phase_done) {
           // End turn immediately
           user_ended_turn();
         }
@@ -3242,7 +3242,7 @@ void handle_ruleset_control(const struct packet_ruleset_control *packet)
     // There is tileset suggestion
     if (strcmp(packet->preferred_tileset, tileset_basename(tileset))) {
       // It's not currently in use
-      if (gui_options.autoaccept_tileset_suggestion) {
+      if (gui_options->autoaccept_tileset_suggestion) {
         tilespec_reread(game.control.preferred_tileset, true);
       } else {
         popup_tileset_suggestion_dialog();
@@ -3254,7 +3254,7 @@ void handle_ruleset_control(const struct packet_ruleset_control *packet)
     // There is soundset suggestion
     if (QString(packet->preferred_soundset) != sound_set_name) {
       // It's not currently in use
-      if (gui_options.autoaccept_soundset_suggestion) {
+      if (gui_options->autoaccept_soundset_suggestion) {
         audio_restart(game.control.preferred_soundset, music_set_name);
       } else {
         popup_soundset_suggestion_dialog();
@@ -3266,7 +3266,7 @@ void handle_ruleset_control(const struct packet_ruleset_control *packet)
     // There is musicset suggestion
     if (QString(packet->preferred_musicset) != music_set_name) {
       // It's not currently in use
-      if (gui_options.autoaccept_musicset_suggestion) {
+      if (gui_options->autoaccept_musicset_suggestion) {
         audio_restart(sound_set_name, game.control.preferred_musicset);
       } else {
         popup_musicset_suggestion_dialog();
@@ -4616,7 +4616,7 @@ void handle_city_name_suggestion_info(int unit_id, const char *name)
   }
 
   if (punit) {
-    if (gui_options.ask_city_name) {
+    if (gui_options->ask_city_name) {
       bool other_asking = false;
 
       unit_list_iterate(unit_tile(punit)->units, other)
@@ -4912,7 +4912,7 @@ void handle_unit_actions(const struct packet_unit_actions *packet)
 
     action_id auto_action;
 
-    if (gui_options.popup_attack_actions) {
+    if (gui_options->popup_attack_actions) {
       // Pop up the action selection dialog no matter what.
       auto_action = ACTION_NONE;
     } else {

--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -60,7 +60,7 @@ page_load::page_load(QWidget *parent, fc_client *c) : QWidget(parent)
   ui.load_save_text->setText(QLatin1String(""));
   ui.load_save_text->setTextFormat(Qt::RichText);
   ui.load_save_text->setWordWrap(true);
-  ui.show_preview->setChecked(gui_options.gui_qt_show_preview);
+  ui.show_preview->setChecked(gui_options->gui_qt_show_preview);
   ui.saves_load->setRowCount(0);
   QStringList sav;
   sav << _("Choose Saved Game to Load") << _("Date");
@@ -100,7 +100,7 @@ void page_load::update_load_page()
   row = 0;
   ui.saves_load->clearContents();
   ui.saves_load->setRowCount(0);
-  ui.show_preview->setChecked(gui_options.gui_qt_show_preview);
+  ui.show_preview->setChecked(gui_options->gui_qt_show_preview);
 
   const auto files =
       find_files_in_path(get_save_dirs(), QStringLiteral("*.sav*"), false);
@@ -148,7 +148,7 @@ void page_load::browse_saves()
  */
 void page_load::state_preview()
 {
-  gui_options.gui_qt_show_preview =
+  gui_options->gui_qt_show_preview =
       ui.show_preview->checkState() != Qt::Unchecked;
   auto selection = ui.saves_load->selectionModel()->selection();
   ui.saves_load->selectionModel()->clearSelection();

--- a/client/reqtree.cpp
+++ b/client/reqtree.cpp
@@ -126,7 +126,7 @@ static void node_rectangle_minimum_size(struct tree_node *node, int *width,
     max_icon_height = 0;
     icons_width_sum = 5;
 
-    if (gui_options.reqtree_show_icons) {
+    if (gui_options->reqtree_show_icons) {
       // units
       unit_type_iterate(unit)
       {
@@ -1043,7 +1043,7 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
 
         icon_startx = startx + 5;
 
-        if (gui_options.reqtree_show_icons) {
+        if (gui_options->reqtree_show_icons) {
           unit_type_iterate(unit)
           {
             if (advance_number(unit->require_advance) != node->tech) {
@@ -1138,7 +1138,7 @@ QList<req_tooltip_help *> *draw_reqtree(struct reqtree *tree,
         // -1 for pen half-width
         endy = dest_node->node_y + dest_node->node_height / 2 - 1;
 
-        if (gui_options.reqtree_curved_lines) {
+        if (gui_options->reqtree_curved_lines) {
           QPainterPath path;
           path.moveTo(startx, starty);
           path.cubicTo((startx + endx) / 2., starty, startx,

--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -239,7 +239,7 @@ QStringList get_useable_themes_in_directory(QString &directory)
     theme_list << str;
   }
 
-  qtheme_name = gui_options.gui_qt_default_theme_name;
+  qtheme_name = gui_options->gui_qt_default_theme_name;
   // move current theme on first position
   if (theme_list.contains(qtheme_name)) {
     theme_list.removeAll(qtheme_name);

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -3471,7 +3471,7 @@ static QPixmap *get_unit_nation_flag_sprite(const struct tileset *t,
 {
   struct nation_type *pnation = nation_of_unit(punit);
 
-  if (gui_options.draw_unit_shields) {
+  if (gui_options->draw_unit_shields) {
     return t->sprites.nation_shield.p[nation_index(pnation)];
   } else {
     return t->sprites.nation_flag.p[nation_index(pnation)];
@@ -3600,7 +3600,7 @@ void fill_unit_sprite_array(const struct tileset *t,
 
   // Flag
   if (!ptile || !tile_city(ptile)) {
-    if (!gui_options.solid_color_behind_units) {
+    if (!gui_options->solid_color_behind_units) {
       sprs.emplace_back(t, get_unit_nation_flag_sprite(t, punit), true,
                         FULL_TILE_X_OFFSET + t->unit_flag_offset_x,
                         FULL_TILE_Y_OFFSET + t->unit_flag_offset_y);
@@ -3805,7 +3805,7 @@ static void fill_road_sprite_array(const struct tileset *t,
   }
   extra_type_list_iterate_end;
 
-  draw_single_road = road && (!pcity || !gui_options.draw_cities) && !hider;
+  draw_single_road = road && (!pcity || !gui_options->draw_cities) && !hider;
 
   for (dir = 0; dir < 8; dir++) {
     bool roads_exist;
@@ -4002,7 +4002,7 @@ static void fill_irrigation_sprite_array(const struct tileset *t,
 {
   /* We don't draw the irrigation if there's a city (it just gets overdrawn
    * anyway, and ends up looking bad). */
-  if (!(pcity && gui_options.draw_cities)) {
+  if (!(pcity && gui_options->draw_cities)) {
     extra_type_list_iterate(t->style_lists[ESTYLE_CARDINALS], pextra)
     {
       if (is_extra_drawing_enabled(pextra)) {
@@ -4077,7 +4077,7 @@ static void fill_city_overlays_sprite_array(const struct tileset *t,
         sprs.emplace_back(t, t->sprites.city.unworked_tile_overlay.p[idx]);
       }
     } else if (nullptr != pwork && pwork == pcity
-               && (citymode || gui_options.draw_city_output)) {
+               && (citymode || gui_options->draw_city_output)) {
       // Add on the tile output sprites.
       const int ox = t->type == TS_ISOMETRIC ? t->normal_tile_width / 3 : 0;
       const int oy =
@@ -4126,7 +4126,7 @@ static void fill_fog_sprite_array(const struct tileset *t,
                                   const struct tile_edge *pedge,
                                   const struct tile_corner *pcorner)
 {
-  if (t->fogstyle == FOG_SPRITE && gui_options.draw_fog_of_war
+  if (t->fogstyle == FOG_SPRITE && gui_options->draw_fog_of_war
       && nullptr != ptile
       && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile)) {
     // With FOG_AUTO, fog is done this way.
@@ -4134,7 +4134,7 @@ static void fill_fog_sprite_array(const struct tileset *t,
   }
 
   if (t->darkness_layer->style() == freeciv::DARKNESS_CORNER && pcorner
-      && gui_options.draw_fog_of_war) {
+      && gui_options->draw_fog_of_war) {
     int i, tileno = 0;
 
     for (i = 3; i >= 0; i--) {
@@ -4180,7 +4180,7 @@ bool unit_drawn_with_city_outline(const struct unit *punit, bool check_focus)
    * and on a tile where a city can be built.
    * But suppress the outline if the unit has orders (likely it is in
    * transit to somewhere else and this will just slow down redraws). */
-  return gui_options.draw_city_outlines && unit_is_cityfounder(punit)
+  return gui_options->draw_city_outlines && unit_is_cityfounder(punit)
          && !unit_has_orders(punit)
          && (client_tile_get_known(unit_tile(punit)) != TILE_UNKNOWN
              && city_can_be_built_here(unit_tile(punit), punit))
@@ -4251,7 +4251,7 @@ static void fill_grid_sprite_array(const struct tileset *t,
         || mapdeco_is_highlight_set(pedge->tile[1])) {
       sprs.emplace_back(t, t->sprites.grid.selected[pedge->type]);
     } else {
-      if (gui_options.draw_map_grid) {
+      if (gui_options->draw_map_grid) {
         if (worked[0] || worked[1]) {
           sprs.emplace_back(t, t->sprites.grid.worked[pedge->type]);
         } else if (city[0] || city[1]) {
@@ -4260,7 +4260,7 @@ static void fill_grid_sprite_array(const struct tileset *t,
           sprs.emplace_back(t, t->sprites.grid.main[pedge->type]);
         }
       }
-      if (gui_options.draw_city_outlines) {
+      if (gui_options->draw_city_outlines) {
         if (XOR(city[0], city[1])) {
           sprs.emplace_back(t, t->sprites.grid.city[pedge->type]);
         }
@@ -4270,7 +4270,7 @@ static void fill_grid_sprite_array(const struct tileset *t,
       }
     }
 
-    if (gui_options.draw_borders && BORDERS_DISABLED != game.info.borders
+    if (gui_options->draw_borders && BORDERS_DISABLED != game.info.borders
         && known[0] && known[1]) {
       struct player *owner0 = tile_owner(pedge->tile[0]);
       struct player *owner1 = tile_owner(pedge->tile[1]);
@@ -4299,7 +4299,7 @@ static void fill_grid_sprite_array(const struct tileset *t,
       sprs.emplace_back(t, t->sprites.grid.unavailable);
     }
 
-    if (gui_options.draw_native && citymode == nullptr) {
+    if (gui_options->draw_native && citymode == nullptr) {
       bool native = true;
       for (const auto pfocus : get_units_in_focus()) {
         if (!is_native_tile(unit_type_get(pfocus), ptile)) {
@@ -4392,44 +4392,44 @@ bool is_extra_drawing_enabled(struct extra_type *pextra)
   bool no_disable = true; // Draw if matches no cause
 
   if (is_extra_caused_by(pextra, EC_IRRIGATION)) {
-    if (gui_options.draw_irrigation) {
+    if (gui_options->draw_irrigation) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_caused_by(pextra, EC_POLLUTION)
       || is_extra_caused_by(pextra, EC_FALLOUT)) {
-    if (gui_options.draw_pollution) {
+    if (gui_options->draw_pollution) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_caused_by(pextra, EC_MINE)) {
-    if (gui_options.draw_mines) {
+    if (gui_options->draw_mines) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_caused_by(pextra, EC_RESOURCE)) {
-    if (gui_options.draw_specials) {
+    if (gui_options->draw_specials) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_removed_by(pextra, ERM_ENTER)) {
-    if (gui_options.draw_huts) {
+    if (gui_options->draw_huts) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_caused_by(pextra, EC_BASE)) {
-    if (gui_options.draw_fortress_airbase) {
+    if (gui_options->draw_fortress_airbase) {
       return true;
     }
     no_disable = false;
   }
   if (is_extra_caused_by(pextra, EC_ROAD)) {
-    if (gui_options.draw_roads_rails) {
+    if (gui_options->draw_roads_rails) {
       return true;
     }
     no_disable = false;
@@ -4469,10 +4469,10 @@ fill_sprite_array(struct tileset *t, enum mapview_layer layer,
    * but only where we're drawing on the mapview. */
   bool do_draw_unit =
       (punit
-       && (gui_options.draw_units || !ptile
-           || (gui_options.draw_focus_unit && unit_is_in_focus(punit))));
-  bool solid_bg = (gui_options.solid_color_behind_units
-                   && (do_draw_unit || (pcity && gui_options.draw_cities)));
+       && (gui_options->draw_units || !ptile
+           || (gui_options->draw_focus_unit && unit_is_in_focus(punit))));
+  bool solid_bg = (gui_options->solid_color_behind_units
+                   && (do_draw_unit || (pcity && gui_options->draw_cities)));
 
   const city *citymode = is_any_city_dialog_open();
 
@@ -4609,7 +4609,7 @@ fill_sprite_array(struct tileset *t, enum mapview_layer layer,
 
   case LAYER_CITY1:
     // City.  Some city sprites are drawn later.
-    if (pcity && gui_options.draw_cities) {
+    if (pcity && gui_options->draw_cities) {
       if (!citybar_painter::current()->has_flag()) {
         sprs.emplace_back(t, get_city_flag_sprite(t, pcity), true,
                           FULL_TILE_X_OFFSET + t->city_flag_offset_x,
@@ -4683,7 +4683,7 @@ fill_sprite_array(struct tileset *t, enum mapview_layer layer,
 
   case LAYER_CITY2:
     // City size.  Drawing this under fog makes it hard to read.
-    if (pcity && gui_options.draw_cities
+    if (pcity && gui_options->draw_cities
         && !citybar_painter::current()->has_size()) {
       bool warn = false;
       unsigned int size = city_size_get(pcity);

--- a/client/voteinfo.cpp
+++ b/client/voteinfo.cpp
@@ -130,7 +130,7 @@ void voteinfo_queue_add(int vote_no, const char *user, const char *desc,
   vi->percent_required = percent_required;
   vi->flags = flags;
 
-  if (gui_options.voteinfo_bar_new_at_front) {
+  if (gui_options->voteinfo_bar_new_at_front) {
     voteinfo_list_prepend(voteinfo_queue, vi);
     voteinfo_queue_current_index = 0;
   } else {


### PR DESCRIPTION
QFont can only be instantiated once we have the QApplication. Font options were instantiated statically instead, leading to an immediate crash on Mac and, likely, strange behaviour with HiDPI on Windows reported by some users.

Modify the code to initialize options dynamically on startup, after creating the QApplication. For this I had to turn client_options to a pointer, necessitating many changes from client_options.x to client_options->x. The important changes are in options.{h,cpp} and client_main.cpp: static initializers were turned into functions and options_init is called a bit earlier.

Closes #1538.
Closes #1549.

**Test plan**

* Stress test options (both client and server).
* Ask @wieder-fi to test the Mac binary