### PR TITLE
Fix Libertinus Serif Display font name

### DIFF
--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -193,7 +193,7 @@ void configure_fonts()
 
   /* Serif List */
   sl.clear();
-  sl << QStringLiteral("Libertinus Display")
+  sl << QStringLiteral("Libertinus Serif Display")
      << QStringLiteral("Linux Libertine Display O")
      << QStringLiteral("Linux Libertine Display");
 


### PR DESCRIPTION
"Libertinus Display" was used instead of the correct font name.

Closes #1548.