### PR TITLE
Classic: Improve contrast between active and disabled buttons

### DIFF
--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -106,6 +106,7 @@ QPushButton:checked, QToolButton:checked {
 }
 
 QPushButton:disabled, QToolButton:disabled {
+  color: #888E93;
   border-image: url(LittleFingerbutton-insensitive.png) 3 3 3 3;
 }
 


### PR DESCRIPTION
Text on disabled buttons (such as Turn Done during turn processing) had the same color as text on active buttons (black). Gray it out when the button is disabled.

Part of #1517.

A couple enabled and disabled buttons:
![image](https://user-images.githubusercontent.com/22327575/205505165-a2c3ec7f-dfc3-4d61-8b91-20ecc3084779.png)
