### PR TITLE
Order top bar buttons consistently with F-keys

### DIFF
--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -162,12 +162,12 @@ pageGame::pageGame(QWidget *parent)
         }
       });
 
-  top_bar_wdg->addWidget(sw_map);
-  top_bar_wdg->addWidget(sw_cunit);
-  top_bar_wdg->addWidget(sw_cities);
-  top_bar_wdg->addWidget(sw_diplo);
-  top_bar_wdg->addWidget(sw_science);
-  top_bar_wdg->addWidget(sw_economy);
+  top_bar_wdg->addWidget(sw_map);     // F1
+  top_bar_wdg->addWidget(sw_cunit);   // F2
+  top_bar_wdg->addWidget(sw_diplo);   // F3
+  top_bar_wdg->addWidget(sw_cities);  // F4
+  top_bar_wdg->addWidget(sw_economy); // F5
+  top_bar_wdg->addWidget(sw_science); // F6
   top_bar_wdg->addWidget(sw_tax);
   top_bar_wdg->addWidget(sw_indicators);
   top_bar_wdg->addWidget(sw_message);


### PR DESCRIPTION
The shortcuts for top bar buttons use the F1-F6 keys. Visually order the widget to make the shortcuts more consistent with the on-screen layout.

![image](https://user-images.githubusercontent.com/22327575/205505901-c8c32831-67d0-4c60-a8cb-85898a6f5ca2.png)
