### PR TITLE
Ensure that all options start at their default

### DIFF
--- a/client/options.cpp
+++ b/client/options.cpp
@@ -4359,6 +4359,11 @@ void options_load()
   const char *const prefix = "client";
   const char *str;
 
+  // Ensure all options start with their default value
+  for (auto &option : client_options) {
+    option_reset(OPTION(&option));
+  }
+
   name = get_last_option_file_name(&allow_digital_boolean);
   if (!name) {
     qInfo(_("Didn't find the option file. Creating a new one."));


### PR DESCRIPTION
Before loading options, set them all to their default values. This way, if anything goes wrong while loading, we fall back to the default. This is especially relevant for options like fonts whose default is determined at runtime.

**Test plan**

* Do `cmake --build build --target install` at least once to have the fonts in the install folder
* `rm ~/.local/share/freeciv21/freeciv-client-rc-3.0` or the Windows equivalent
* Start fc21
* Check that Libertinus is in use

May only work properly on top of #1547