### PR TITLE
Fix a client crash after reseting options

### DIFF
--- a/client/shortcuts.cpp
+++ b/client/shortcuts.cpp
@@ -336,7 +336,7 @@ void fc_shortcuts::init_default(bool read)
     suc = this->read();
   }
   if (!suc) {
-    for (int i = 0; i < SC_LAST_SC - 1; i++) {
+    for (int i = 0; i < SC_LAST_SC; i++) {
       fc_shortcut s;
       s.id = default_shortcuts[i].id;
       s.type = default_shortcuts[i].type;


### PR DESCRIPTION
The last shortcut, SC_PILLAGE, was never added back to the map of shortcuts after clearing it for a reset, causing a crash when selecting any pillage-capable unit.