### PR TITLE
Improvements for fixedlength games

### DIFF
--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -281,7 +281,8 @@ void establish_new_connection(struct connection *pconn)
   event_cache_add_for_all(&connect_info);
 
   // if need be, tell who we're waiting on to end the game.info.turn
-  if (S_S_RUNNING == server_state() && game.server.turnblock) {
+  if (S_S_RUNNING == server_state() && game.server.turnblock
+      && !game.server.fixedlength) {
     players_iterate_alive(cplayer)
     {
       if (is_human(cplayer) && !cplayer->phase_done

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -821,6 +821,9 @@ void connection_detach(struct connection *pconn, bool remove_unused_player)
           send_player_info_c(pplayer, nullptr);
 
           reset_all_start_commands(true);
+        } else {
+          // is_connected has changed
+          send_player_info_c(pplayer, nullptr);
         }
       }
     }

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -3061,7 +3061,11 @@ void handle_player_phase_done(struct player *pplayer, int turn)
      * previous turn but we didn't receive it until now.  The player
      * probably didn't actually mean to end their turn! */
     return;
+  } else if (game.server.fixedlength) {
+    // Disallow Turn Done if the turn has a fixed length
+    return;
   }
+
   pplayer->phase_done = true;
 
   check_for_full_turn_done();


### PR DESCRIPTION
* Disallow Turn Done at the server side in fixedlength mode.
* Don't spam the console with "waiting for X to finish turn" nonsense if fixedlength
* Ensure "moving"/"blocking" information in the player list is accurate after a player has disconnected