### PR TITLE
Add the city status (content/happy/...) to the city dialog

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1026,7 +1026,9 @@ city_info::city_info(QWidget *parent) : QWidget(parent)
 
 void city_info::update_labels(struct city *pcity)
 {
-  m_size->setText(QString::asprintf("%3d", pcity->size));
+  m_size->setText(
+      QString::asprintf("%3d (%s)", pcity->size,
+                        qUtf8Printable(get_city_dialog_status_text(pcity))));
   m_size->setToolTip(get_city_dialog_size_text(pcity));
 
   m_food->setText(

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -830,6 +830,26 @@ QString get_city_dialog_size_text(const struct city *pcity)
 }
 
 /**
+ * Return text describing the city's status: disorder/celebrating/...
+ */
+QString get_city_dialog_status_text(const struct city *pcity)
+{
+  if (city_unhappy(pcity)) {
+    // TRANS: City dialog Status: Disorder
+    return _("Disorder");
+  } else if (city_celebrating(pcity)) {
+    // TRANS: City dialog Status: Celebrating
+    return _("Celebrating");
+  } else if (city_happy(pcity)) {
+    // TRANS: City dialog Status: Happy
+    return _("Happy");
+  } else {
+    // TRANS: City dialog Status: Content
+    return _("Content");
+  }
+}
+
+/**
  * Return time until next growth
  */
 QString get_city_dialog_growth_value(const struct city *pcity)

--- a/client/citydlg_common.h
+++ b/client/citydlg_common.h
@@ -36,6 +36,7 @@ QString get_city_dialog_culture_text(const struct city *pcity);
 QString get_city_dialog_illness_text(const struct city *pcity);
 QString get_city_dialog_airlift_text(const struct city *pcity);
 QString get_city_dialog_size_text(const struct city *pcity);
+QString get_city_dialog_status_text(const struct city *pcity);
 
 QString get_city_dialog_growth_value(const struct city *pcity);
 QString get_city_dialog_airlift_value(const struct city *pcity);


### PR DESCRIPTION
Merge into the "Citizens" line since this happiness is eventually related to them.

Closes #1581.

![image](https://user-images.githubusercontent.com/22327575/206881213-be59efb9-9942-4f65-964d-9cadb9b03930.png)
