### PR TITLE
Fix random button ordering in PAGE_LOAD

### DIFF
--- a/client/page_load.cpp
+++ b/client/page_load.cpp
@@ -75,8 +75,9 @@ page_load::page_load(QWidget *parent, fc_client *c) : QWidget(parent)
   connect(ui.show_preview, &QCheckBox::stateChanged, this,
           &page_load::state_preview);
 
-  auto browse = ui.buttons->button(QDialogButtonBox::Open);
-  browse->setText(_("Browse..."));
+  auto browse =
+      ui.buttons->addButton(_("Browse..."), QDialogButtonBox::ActionRole);
+  browse->setIcon(QIcon::fromTheme(QStringLiteral("document-open-folder")));
   connect(browse, &QAbstractButton::clicked, this, &page_load::browse_saves);
 
   connect(ui.buttons->button(QDialogButtonBox::Cancel),

--- a/client/page_load.ui
+++ b/client/page_load.ui
@@ -116,7 +116,7 @@
    <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttons">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Open</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -110,6 +110,10 @@ QPushButton:disabled, QToolButton:disabled {
   border-image: url(LittleFingerbutton-insensitive.png) 3 3 3 3;
 }
 
+QDialogButtonBox {
+  button-layout: 3;
+}
+
 QLabel {
  color: black;
 }


### PR DESCRIPTION
Ensure that "Browse..." always has a different role than Ok, otherwise Qt does fancy things.

Closes #1582.