### PR TITLE
Add detailed info about tech progress to top bar

### DIFF
--- a/client/sciencedlg.cpp
+++ b/client/sciencedlg.cpp
@@ -536,7 +536,6 @@ void real_science_report_dialog_update(void *unused)
 {
   Q_UNUSED(unused)
   int i;
-  int percent;
   science_report *sci_rep;
   bool blk = false;
   QWidget *w;
@@ -549,9 +548,25 @@ void real_science_report_dialog_update(void *unused)
     } else if (research->client.researching_cost != 0) {
       str =
           research_advance_name_translation(research, research->researching);
-      percent = 100 * research->bulbs_researched
-                / research->client.researching_cost;
-      str = str + "\n (" + QString::number(percent) + "%)";
+      str += QStringLiteral("\n");
+
+      const int per_turn = get_bulbs_per_turn(nullptr, nullptr, nullptr);
+      const int when = turns_to_research_done(research, per_turn);
+      if (when >= 0) {
+        // TRANS: current(+surplus)/total  (number of turns)
+        str += QString(PL_("%1(+%2)/%3  (%4 turn)", "%1(+%2)/%3  (%4 turns)",
+                           when))
+                   .arg(research->bulbs_researched)
+                   .arg(per_turn)
+                   .arg(research->client.researching_cost)
+                   .arg(when);
+      } else {
+        // TRANS: current(+surplus)/total  (number of turns)
+        str += QString(_("%1(+%2)/%3  (never)"))
+                   .arg(research->bulbs_researched)
+                   .arg(per_turn)
+                   .arg(research->client.researching_cost);
+      }
     }
     if (research->researching == A_UNSET && research->tech_goal == A_UNSET
         && research->techs_researched < game.control.num_tech_types) {

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -749,8 +749,7 @@ int get_bulbs_per_turn(int *pours, bool *pteam, int *ptheirs)
 /**
    Return turns until research complete. -1 for never.
  */
-static int turns_to_research_done(const struct research *presearch,
-                                  int per_turn)
+int turns_to_research_done(const struct research *presearch, int per_turn)
 {
   if (per_turn > 0) {
     return ceil(static_cast<double>(presearch->client.researching_cost

--- a/client/text.h
+++ b/client/text.h
@@ -51,3 +51,4 @@ QString text_happiness_luxuries(const struct city *pcity);
 QString text_happiness_units(const struct city *pcity);
 QString text_happiness_wonders(const struct city *pcity);
 int get_bulbs_per_turn(int *pours, bool *pteam, int *ptheirs);
+int turns_to_research_done(const struct research *presearch, int per_turn);


### PR DESCRIPTION
Requested by horror-vacui on Discord.

See #1517.

![image](https://user-images.githubusercontent.com/22327575/206941332-fd35ea36-4c15-41e9-8666-a606b14392e7.png)
