### PR TITLE
Close the city screen when closing reports

### DIFF
--- a/client/cityrep.cpp
+++ b/client/cityrep.cpp
@@ -30,6 +30,7 @@
 #include "mapview.h"
 #include "page_game.h"
 #include "qtg_cxxside.h"
+#include "top_bar.h"
 
 /**
    Overriden compare for sorting items
@@ -456,7 +457,7 @@ void city_widget::center()
   pcity = selected_cities[0];
   Q_ASSERT(pcity != nullptr);
   queen()->mapview_wdg->center_on_tile(pcity->tile);
-  queen()->game_tab_widget->setCurrentIndex(0);
+  top_bar_show_map();
 }
 
 /**
@@ -1252,7 +1253,7 @@ void city_report_dialog_popup()
     fc_assert(i != -1);
     w = queen()->game_tab_widget->widget(i);
     if (w->isVisible()) {
-      queen()->game_tab_widget->setCurrentIndex(0);
+      top_bar_show_map();
       return;
     }
     cr = reinterpret_cast<city_report *>(w);

--- a/client/diplodlg.cpp
+++ b/client/diplodlg.cpp
@@ -777,7 +777,7 @@ diplo_dlg::~diplo_dlg()
     dw->deleteLater();
   }
   queen()->removeRepoDlg(QStringLiteral("DDI"));
-  queen()->game_tab_widget->setCurrentIndex(0);
+  top_bar_show_map();
 }
 
 /**

--- a/client/economyreport.cpp
+++ b/client/economyreport.cpp
@@ -15,6 +15,7 @@
 #include "fc_client.h"
 #include "hudwidget.h"
 #include "page_game.h"
+#include "top_bar.h"
 
 /**
    Constructor for economy report
@@ -373,7 +374,7 @@ void economy_report_dialog_popup()
     fc_assert(i != -1);
     w = queen()->game_tab_widget->widget(i);
     if (w->isVisible()) {
-      queen()->game_tab_widget->setCurrentIndex(0);
+      top_bar_show_map();
       return;
     }
     eco_rep = reinterpret_cast<eco_report *>(w);

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -40,6 +40,7 @@
 #include "mapview.h"
 #include "page_game.h"
 #include "sprite.h"
+#include "top_bar.h"
 #include "widgetdecorations.h"
 
 static QString popup_terrain_info(struct tile *ptile);
@@ -805,7 +806,7 @@ void click_label::mousePressEvent(QMouseEvent *e)
  */
 void click_label::mouse_clicked()
 {
-  queen()->game_tab_widget->setCurrentIndex(0);
+  top_bar_show_map();
   request_center_focus_unit();
 }
 

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -1965,10 +1965,7 @@ void mr_menu::slot_spaceship()
 /**
    Changes tab to mapview
  */
-void mr_menu::slot_show_map()
-{
-  ::queen()->game_tab_widget->setCurrentIndex(0);
-}
+void mr_menu::slot_show_map() { top_bar_show_map(); }
 
 /**
    Action "BUILD_CITY"

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -32,6 +32,7 @@
 #include "fonts.h"
 #include "page_game.h"
 #include "sprite.h"
+#include "top_bar.h"
 
 /**
    Help function to draw checkbox inside delegate
@@ -937,7 +938,7 @@ void popup_players_dialog()
     i = queen()->gimmeIndexOf(QStringLiteral("PLR"));
     w = queen()->game_tab_widget->widget(i);
     if (w->isVisible()) {
-      queen()->game_tab_widget->setCurrentIndex(0);
+      top_bar_show_map();
       return;
     }
     pr = reinterpret_cast<plr_report *>(w);

--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -599,7 +599,7 @@ void top_bar_left_click_science()
     i = queen()->gimmeIndexOf(QStringLiteral("SCI"));
     w = queen()->game_tab_widget->widget(i);
     if (w->isVisible()) {
-      queen()->game_tab_widget->setCurrentIndex(0);
+      top_bar_show_map();
       return;
     }
     sci_rep = reinterpret_cast<science_report *>(w);


### PR DESCRIPTION
Otherwise we may get the minimap and messages overlapping with the city screen widgets. Closing the city screen is maybe not the best solution, but it does work around the inconsistency.

Closes #1606.