### PR TITLE
Prevent the autocenter option from autochanging

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -413,6 +413,15 @@ static struct tile *find_a_focus_unit_tile_to_center_on()
   }
 }
 
+namespace {
+bool auto_center_enabled = true;
+}
+
+/**
+ * Allows disabling automatic map recentering
+ */
+void set_auto_center_enabled(bool enabled) { auto_center_enabled = enabled; }
+
 /**
    Center on the focus unit, if off-screen and auto_center_on_unit is true.
  */
@@ -420,7 +429,7 @@ void auto_center_on_focus_unit()
 {
   struct tile *ptile = find_a_focus_unit_tile_to_center_on();
 
-  if (ptile && gui_options->auto_center_on_unit
+  if (ptile && gui_options->auto_center_on_unit && auto_center_enabled
       && !tile_visible_and_not_on_border_mapcanvas(ptile)) {
     queen()->mapview_wdg->center_on_tile(ptile);
   }

--- a/client/control.h
+++ b/client/control.h
@@ -154,7 +154,9 @@ void unit_focus_urgent(struct unit *punit);
 void unit_focus_advance();
 void unit_focus_update();
 
+void set_auto_center_enabled(bool enabled);
 void auto_center_on_focus_unit();
+
 void update_unit_pix_label(const std::vector<unit *> &units);
 
 unit *find_visible_unit(const ::tile *ptile);

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -262,8 +262,7 @@ void map_view::shortcut_pressed(shortcut_id id)
     }
 
     if (!goto_is_active()) {
-      stored_autocenter = gui_options->auto_center_on_unit;
-      gui_options->auto_center_on_unit = false;
+      set_auto_center_enabled(false);
       action_button_pressed(pos.x(), pos.y(), SELECT_FOCUS);
       return;
     }
@@ -393,8 +392,8 @@ void map_view::shortcut_released(Qt::MouseButton bt)
     }
     if (!keyboardless_goto_active || goto_is_active()) {
       action_button_pressed(pos.x(), pos.y(), SELECT_POPUP);
-      gui_options->auto_center_on_unit = stored_autocenter;
     }
+    set_auto_center_enabled(true);
     release_goto_button(pos.x(), pos.y());
     return;
   }

--- a/client/mapview.cpp
+++ b/client/mapview.cpp
@@ -148,7 +148,6 @@ map_view::map_view()
   timer->start(200);
   resize(0, 0);
   setMouseTracking(true);
-  stored_autocenter = gui_options->auto_center_on_unit;
   setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
 }
 

--- a/client/mapview.h
+++ b/client/mapview.h
@@ -101,7 +101,6 @@ private slots:
   void timer_event();
 
 private:
-  bool stored_autocenter;
   int cursor_frame{0};
   int cursor;
   freeciv::renderer *m_renderer;


### PR DESCRIPTION
The "auto center on unit" option was being changed without user interaction because of badly engineered code that was temporarily changing its value and failing to restore it. Make the code safer by introducing a new, purely internal, flag to pause the auto centering so we don't need to touch the user-visible setting.

Closes #1316.