### PR TITLE
Diplomacy Visibility

### DIFF
--- a/client/diplodlg.cpp
+++ b/client/diplodlg.cpp
@@ -843,11 +843,7 @@ void handle_diplomacy_accept_treaty(int counterpart, bool I_accepted,
   dw->treaty.accept0 = I_accepted;
   dw->treaty.accept1 = other_accepted;
   dw->update_wdg();
-  if (dd->count() > 0) {
-    update_top_bar_diplomacy_status(true);
-  } else {
-    update_top_bar_diplomacy_status(false);
-  }
+  update_top_bar_diplomacy_status(dd->count() > 0);
 }
 
 /**
@@ -894,11 +890,7 @@ void handle_diplomacy_init_meeting(int counterpart, int initiated_from)
   if (player_by_number(initiated_from) == client.conn.playing) {
     queen()->game_tab_widget->setCurrentIndex(i);
   }
-  if (dd->count() > 0) {
-    update_top_bar_diplomacy_status(true);
-  } else {
-    update_top_bar_diplomacy_status(false);
-  }
+  update_top_bar_diplomacy_status(dd->count() > 0);
 }
 
 /**
@@ -944,11 +936,7 @@ void handle_diplomacy_cancel_meeting(int counterpart, int initiated_from)
   w = queen()->game_tab_widget->widget(i);
   dd = qobject_cast<diplo_dlg *>(w);
   dd->close_widget(counterpart);
-  if (dd->count() > 0) {
-    update_top_bar_diplomacy_status(true);
-  } else {
-    update_top_bar_diplomacy_status(false);
-  }
+  update_top_bar_diplomacy_status(dd->count() > 0);
 }
 
 /**

--- a/client/diplodlg.cpp
+++ b/client/diplodlg.cpp
@@ -39,6 +39,7 @@
 #include "fc_client.h"
 #include "icons.h"
 #include "page_game.h"
+#include "plrdlg.h"
 #include "sprite.h"
 #include "top_bar.h"
 
@@ -831,6 +832,7 @@ void handle_diplomacy_accept_treaty(int counterpart, bool I_accepted,
   QWidget *w;
 
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
+    update_top_bar_diplomacy_status(false);
     return;
   }
   i = queen()->gimmeIndexOf(QStringLiteral("DDI"));
@@ -841,6 +843,11 @@ void handle_diplomacy_accept_treaty(int counterpart, bool I_accepted,
   dw->treaty.accept0 = I_accepted;
   dw->treaty.accept1 = other_accepted;
   dw->update_wdg();
+  if (dd->count() > 0) {
+    update_top_bar_diplomacy_status(true);
+  } else {
+    update_top_bar_diplomacy_status(false);
+  }
 }
 
 /**
@@ -887,6 +894,11 @@ void handle_diplomacy_init_meeting(int counterpart, int initiated_from)
   if (player_by_number(initiated_from) == client.conn.playing) {
     queen()->game_tab_widget->setCurrentIndex(i);
   }
+  if (dd->count() > 0) {
+    update_top_bar_diplomacy_status(true);
+  } else {
+    update_top_bar_diplomacy_status(false);
+  }
 }
 
 /**
@@ -901,6 +913,7 @@ void handle_diplomacy_create_clause(int counterpart, int giver,
   QWidget *w;
 
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
+    update_top_bar_diplomacy_status(false);
     return;
   }
   i = queen()->gimmeIndexOf(QStringLiteral("DDI"));
@@ -923,6 +936,7 @@ void handle_diplomacy_cancel_meeting(int counterpart, int initiated_from)
   QWidget *w;
 
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
+    update_top_bar_diplomacy_status(false);
     return;
   }
   i = queen()->gimmeIndexOf(QStringLiteral("DDI"));
@@ -930,6 +944,11 @@ void handle_diplomacy_cancel_meeting(int counterpart, int initiated_from)
   w = queen()->game_tab_widget->widget(i);
   dd = qobject_cast<diplo_dlg *>(w);
   dd->close_widget(counterpart);
+  if (dd->count() > 0) {
+    update_top_bar_diplomacy_status(true);
+  } else {
+    update_top_bar_diplomacy_status(false);
+  }
 }
 
 /**
@@ -944,6 +963,7 @@ void handle_diplomacy_remove_clause(int counterpart, int giver,
   QWidget *w;
 
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
+    update_top_bar_diplomacy_status(false);
     return;
   }
   i = queen()->gimmeIndexOf(QStringLiteral("DDI"));
@@ -968,12 +988,14 @@ void close_all_diplomacy_dialogs()
 
   qApp->alert(king()->central_wdg);
   if (!queen()->isRepoDlgOpen(QStringLiteral("DDI"))) {
+    update_top_bar_diplomacy_status(false);
     return;
   }
   i = queen()->gimmeIndexOf(QStringLiteral("DDI"));
   fc_assert(i != -1);
   w = queen()->game_tab_widget->widget(i);
   dd = qobject_cast<diplo_dlg *>(w);
+  update_top_bar_diplomacy_status(false);
   dd->close();
   delete dd;
 }

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -202,7 +202,7 @@ void pageGame::reloadSidebarIcons()
   sw_map->setIcon(fcIcons::instance()->getIcon(QStringLiteral("view")));
   sw_cunit->setIcon(fcIcons::instance()->getIcon(QStringLiteral("units")));
   sw_cities->setIcon(fcIcons::instance()->getIcon(QStringLiteral("cities")));
-  sw_diplo->setIcon(fcIcons::instance()->getIcon(QStringLiteral("nations")));
+  sw_diplo->setIcon(fcIcons::instance()->getIcon(QStringLiteral("flag")));
   sw_science->setIcon(
       fcIcons::instance()->getIcon(QStringLiteral("research")));
   sw_economy->setIcon(

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -1011,7 +1011,6 @@ void close_intel_dialog(struct player *p) { real_players_dialog_update(p); }
  */
 void update_top_bar_diplomacy_status(bool blinker)
 {
-
   if (blinker) {
     queen()->sw_diplo->keep_blinking = true;
     queen()->sw_diplo->sblink();

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -726,13 +726,10 @@ plr_report::plr_report() : QWidget()
     ui.plr_wdg->sortByColumn(king()->qt_settings.player_repo_sort_col,
                              king()->qt_settings.player_report_sort);
   }
-  if (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0) {
-    ui.diplo_but->setEnabled(true);
-    update_top_bar_diplomacy_status(true);
-  } else {
-    ui.diplo_but->setEnabled(false);
-    update_top_bar_diplomacy_status(false);
-  }
+  const bool has_meeting =
+      (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0);
+  ui.diplo_but->setEnabled(has_meeting);
+  update_top_bar_diplomacy_status(has_meeting);
   queen()->updateSidebarTooltips();
   ui.plr_wdg->set_pr_rep(this);
 }
@@ -918,13 +915,10 @@ void plr_report::update_report(bool update_selection)
   if (can_meet_with_player(other_player)) {
     ui.meet_but->setEnabled(true);
   }
-  if (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0) {
-    ui.diplo_but->setEnabled(true);
-    update_top_bar_diplomacy_status(true);
-  } else {
-    ui.diplo_but->setEnabled(false);
-    update_top_bar_diplomacy_status(false);
-  }
+  const bool has_meeting =
+      (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0);
+  ui.diplo_but->setEnabled(has_meeting);
+  update_top_bar_diplomacy_status(has_meeting);
   ui.plr_wdg->restore_selection();
 }
 
@@ -1011,15 +1005,12 @@ void close_intel_dialog(struct player *p) { real_players_dialog_update(p); }
  */
 void update_top_bar_diplomacy_status(bool blinker)
 {
+  queen()->sw_diplo->keep_blinking = blinker;
   if (blinker) {
-    queen()->sw_diplo->keep_blinking = true;
     queen()->sw_diplo->sblink();
-    queen()->updateSidebarTooltips();
-    queen()->reloadSidebarIcons();
   } else {
-    queen()->sw_diplo->keep_blinking = false;
     queen()->sw_diplo->update();
-    queen()->updateSidebarTooltips();
-    queen()->reloadSidebarIcons();
   }
+  queen()->updateSidebarTooltips();
+  queen()->reloadSidebarIcons();
 }

--- a/client/plrdlg.cpp
+++ b/client/plrdlg.cpp
@@ -32,6 +32,7 @@
 #include "fonts.h"
 #include "page_game.h"
 #include "sprite.h"
+#include "top_bar.h"
 
 /**
    Help function to draw checkbox inside delegate
@@ -727,7 +728,12 @@ plr_report::plr_report() : QWidget()
   }
   if (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0) {
     ui.diplo_but->setEnabled(true);
+    update_top_bar_diplomacy_status(true);
+  } else {
+    ui.diplo_but->setEnabled(false);
+    update_top_bar_diplomacy_status(false);
   }
+  queen()->updateSidebarTooltips();
   ui.plr_wdg->set_pr_rep(this);
 }
 
@@ -914,6 +920,10 @@ void plr_report::update_report(bool update_selection)
   }
   if (queen()->gimmeIndexOf(QStringLiteral("DDI")) > 0) {
     ui.diplo_but->setEnabled(true);
+    update_top_bar_diplomacy_status(true);
+  } else {
+    ui.diplo_but->setEnabled(false);
+    update_top_bar_diplomacy_status(false);
   }
   ui.plr_wdg->restore_selection();
 }
@@ -944,6 +954,7 @@ void popup_players_dialog()
     queen()->game_tab_widget->setCurrentWidget(pr);
     pr->update_report();
   }
+  queen()->updateSidebarTooltips();
 }
 
 /**
@@ -982,6 +993,7 @@ void popdown_players_report()
     pr = reinterpret_cast<plr_report *>(w);
     pr->deleteLater();
   }
+  queen()->updateSidebarTooltips();
 }
 /**
    Update the intelligence dialog for the given player.  This is called by
@@ -992,3 +1004,23 @@ void update_intel_dialog(struct player *p) { real_players_dialog_update(p); }
    Close an intelligence dialog for the given player.
  */
 void close_intel_dialog(struct player *p) { real_players_dialog_update(p); }
+
+/**
+ * Function to update the top bar button. Blink when there are open
+ * Diplomacy meetings, don't when there are none.
+ */
+void update_top_bar_diplomacy_status(bool blinker)
+{
+
+  if (blinker) {
+    queen()->sw_diplo->keep_blinking = true;
+    queen()->sw_diplo->sblink();
+    queen()->updateSidebarTooltips();
+    queen()->reloadSidebarIcons();
+  } else {
+    queen()->sw_diplo->keep_blinking = false;
+    queen()->sw_diplo->update();
+    queen()->updateSidebarTooltips();
+    queen()->reloadSidebarIcons();
+  }
+}

--- a/client/plrdlg.h
+++ b/client/plrdlg.h
@@ -155,3 +155,4 @@ private slots:
 };
 
 void popdown_players_report();
+void update_top_bar_diplomacy_status(bool blinker);


### PR DESCRIPTION
Similar to how the Research view button will blink on the top bar when no research target is set. We enable the same visual feature to remind a player that there are open meetings to attend to.

Closes #1421 