### PR TITLE
Remove python3 from macOS CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,6 +115,7 @@ jobs:
       - name: Build
         run: |
           cmake --build build
+
   windows:
     name: "Windows MSYS2 (gcc)"
     runs-on: windows-latest
@@ -222,7 +223,6 @@ jobs:
           brew install \
             cmake \
             ninja \
-            python3 \
             gettext \
             create-dmg
           brew link gettext --force


### PR DESCRIPTION
Remove python3 from macOS CI since its included in the image and is causing a conflict.