### PR TITLE
Fix loading audio plugin and theme options

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -504,11 +504,12 @@ int client_main(int argc, char *argv[])
 
   init_our_capability();
 
+  audio_init();
   options_init();
   configure_fonts();
-  options_load();
+  init_themes();
 
-  audio_init();
+  options_load();
 
   (void) user_username(gui_options->default_user_name, MAX_LEN_NAME);
   if (!is_valid_username(gui_options->default_user_name)) {
@@ -538,8 +539,6 @@ int client_main(int argc, char *argv[])
   fc_at_quick_exit(emergency_exit);
 
   init_player_dlg_common();
-  init_themes();
-
   script_client_init();
 
   if (sound_set_name.isEmpty()) {

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -2138,7 +2138,9 @@ static bool client_option_str_set(struct option *poption, const char *str)
   }
 
   const auto allowed_values = client_option_str_values(poption);
-  if (allowed_values && !client_option_str_values(poption)->contains(str)) {
+  if (allowed_values && !allowed_values->contains(str)) {
+    qWarning() << "Unrecognized value for option" << option_name(poption)
+               << ":" << QString(str);
     return false;
   }
 


### PR DESCRIPTION
The list of available options wasn't initialized properly before loading.

**Test plan:**
Set Classic theme, check that it's picked up after restart. Check other options that use a combo box.