### PR TITLE
Fix crash when failing to load a ruleset

### DIFF
--- a/common/government.cpp
+++ b/common/government.cpp
@@ -408,6 +408,7 @@ government::government()
 {
   item_number = 0;
   ruler_titles = new QHash<const struct nation_type *, struct ruler_title *>;
+  helptext = nullptr;
   requirement_vector_init(&reqs);
   changed_to_times = 0;
   ruledit_disabled = false;


### PR DESCRIPTION
The server was crashing when a ruleset was failing to load before governments were initialized. This prevents the crash.

**Test plan:**
Read the code. Trust me initializing a field in the constructor prevents a crash (it's good practice anyway).