### PR TITLE
Specify which action a sanity warning is emitted for

### DIFF
--- a/server/rssanity.cpp
+++ b/server/rssanity.cpp
@@ -1228,7 +1228,8 @@ bool sanity_check_ruleset_data(bool ignore_retired)
         problem = action_enabler_suggest_improvement(enabler);
         if (problem != nullptr) {
           // There is a potential for improving this enabler.
-          qCWarning(deprecations_category, "%s", problem->description);
+          qCWarning(deprecations_category, "Enabler for action %s: %s",
+                    action_id_rule_name(act), problem->description);
         }
       }
     }


### PR DESCRIPTION
When emitting warnings about action enablers, include the action name in the message (unfortunately, we currently don't store the enabler section name). This gives some context to messages that would previously look like:

  This action enabler is never used by any unit.

**Test plan:**
Load the latest LTX (from [LTT-LTX](https://github.com/longturn/LTT-LTX)) with and without this change.