### PR TITLE
Remove paths-ignore

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,5 @@
 name: Build
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
   schedule:
     - cron: "0 5 * * MON"
   workflow_dispatch: {}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  pull_request: {}
   schedule:
     - cron: "0 5 * * MON"
   workflow_dispatch: {}


### PR DESCRIPTION
We require build CI to complete as it is our repo protection mechanism. We had paths-ignore to not run full CI on documentation only updates (docs/**), however that doesn't really work. You have to go through a collection of hoops to actually get it to satisfy the check. Removing as that is easier and keeps our protection mechanism in place.