### PR TITLE
Check cache fc_version.h at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(AutoRevision)
 list(LENGTH FC21_REV_TAG_LIST FC21_REV_TAG_LIST_LENGTH)
 
 # When we tag a stable release we only get 2 of the 4 components populated
-#  So we manually set some of the variables we need for the full version.
+#   So we manually set some of the variables we need for the full version.
 if(${FC21_REV_TAG_LIST_LENGTH} EQUAL 2)
   list(GET FC21_REV_TAG_LIST 0 FC21_MAJOR_VERSION)
   list(GET FC21_REV_TAG_LIST 1 FC21_MINOR_VERSION)
@@ -106,6 +106,19 @@ add_subdirectory(tools)
 
 # Add docs
 add_subdirectory(docs)
+
+# Check to see if the current patch version from git matches the cache version.
+#   If not, then remove the cache fc_version.h so it can be written.
+if(EXISTS "${CMAKE_BINARY_DIR}/utility/fc_version.h")
+  file(STRINGS "${CMAKE_BINARY_DIR}/utility/fc_version.h"
+               FC_VERSION_H REGEX "PATCH_VERSION")
+  string(REPLACE "#define PATCH_VERSION " "" FC_VERSION_H_2 ${FC_VERSION_H})
+  string(COMPARE NOTEQUAL ${FC21_PATCH_VERSION} ${FC_VERSION_H_2} FC_VERSION_DIFF)
+  if(${FC_VERSION_DIFF})
+    message(STATUS "Cache version not current, removing cached fc_version.h")
+    file(REMOVE "${CMAKE_BINARY_DIR}/utility/fc_version.h")
+  endif()
+endif()
 
 # Use Auto Revision variables to convert some templates to real files at build time
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/utility/fc_version.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,7 @@
 #   "file(GET_RUNTIME_DEPENDENCIES ..." that is only available at v3.16+
 # On other platforms (*nix, MacOS) we need to support older 3.12+ for the
 #   server and other components
-if(WIN32 OR MSYS OR MINGW)
-  cmake_minimum_required(VERSION 3.16...3.20 FATAL_ERROR)
-else()
-  cmake_minimum_required(VERSION 3.12...3.17 FATAL_ERROR)
-endif()
+cmake_minimum_required(VERSION 3.21...3.22 FATAL_ERROR)
 
 # Set vcpkg if exists. Used by MacOS and Visual Studio
 if(DEFINED ENV{VCPKG_ROOT} AND FREECIV_USE_VCPKG)
@@ -107,25 +103,13 @@ add_subdirectory(tools)
 # Add docs
 add_subdirectory(docs)
 
-# Check to see if the current patch version from git matches the cache version.
-#   If not, then remove the cache fc_version.h so it can be written.
-if(EXISTS "${CMAKE_BINARY_DIR}/utility/fc_version.h")
-  file(STRINGS "${CMAKE_BINARY_DIR}/utility/fc_version.h"
-               FC_VERSION_H REGEX "PATCH_VERSION")
-  string(REPLACE "#define PATCH_VERSION " "" FC_VERSION_H_2 ${FC_VERSION_H})
-  string(COMPARE NOTEQUAL ${FC21_PATCH_VERSION} ${FC_VERSION_H_2} FC_VERSION_DIFF)
-  if(${FC_VERSION_DIFF})
-    message(STATUS "Cache version not current, removing cached fc_version.h")
-    file(REMOVE "${CMAKE_BINARY_DIR}/utility/fc_version.h")
-  endif()
-endif()
-
-# Use Auto Revision variables to convert some templates to real files at build time
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/utility/fc_version.h")
-  configure_file(${CMAKE_SOURCE_DIR}/utility/fc_version.h.in
-                utility/fc_version.h
-                @ONLY NEWLINE_STYLE UNIX)
-endif()
+# Use Auto Revision variables to convert some templates to real files at build
+# time. Avoid overwriting if the version didn't change.
+configure_file("utility/fc_version.h.in" utility/fc_version.h.new
+               @ONLY NEWLINE_STYLE UNIX)
+file(COPY_FILE "${CMAKE_BINARY_DIR}/utility/fc_version.h.new"
+               "${CMAKE_BINARY_DIR}/utility/fc_version.h"
+     ONLY_IF_DIFFERENT)
 
 # Include Installation Commands
 include(FreecivInstall)

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -311,7 +311,7 @@ int client_main(int argc, char *argv[])
       Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
   QApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   i_am_client(); // Tell to libfreeciv that we are client
 

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -25,6 +25,9 @@
 #include "fcintl.h"
 #include "log.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "packets.h"
 

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -29,6 +29,9 @@
 #include "shared.h"
 #include "support.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "events.h"
 #include "version.h"
@@ -4270,7 +4273,7 @@ void options_load()
     log_debug("Error loading option file '%s':\n%s", name, secfile_error());
     // try to create the rc file
     sf = secfile_new(true);
-    secfile_insert_str(sf, VERSION_STRING, "client.version");
+    secfile_insert_str(sf, freeciv21_version(), "client.version");
 
     create_default_cma_presets();
     gui_options->first_boot = true;
@@ -4394,7 +4397,7 @@ void options_save(option_save_log_callback log_cb)
   }
 
   sf = secfile_new(true);
-  secfile_insert_str(sf, VERSION_STRING, "client.version");
+  secfile_insert_str(sf, freeciv21_version(), "client.version");
 
   secfile_insert_bool(sf, gui_options->save_options_on_exit,
                       "client.save_options_on_exit");

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -26,6 +26,9 @@
 #include "rand.h"
 #include "support.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "achievements.h"
 #include "actions.h"
@@ -351,11 +354,7 @@ void handle_server_join_reply(bool you_can_join, const char *message,
     }
 
     client_info._obsolete = 5; // Old value for gui_type(GUI_QT)
-#ifdef EMERGENCY_VERSION
     client_info.emerg_version = EMERGENCY_VERSION;
-#else
-    client_info.emerg_version = 0;
-#endif
     qstrncpy(client_info.distribution, FREECIV_DISTRIBUTOR,
              sizeof(client_info.distribution));
     send_packet_client_info(&client.conn, &client_info);

--- a/client/page_main.cpp
+++ b/client/page_main.cpp
@@ -44,8 +44,9 @@ page_main::page_main(QWidget *parent, fc_client *gui) : QWidget(parent)
           [gui]() { gui->switch_page(PAGE_LOAD); });
 
   // TRANS: "version 2.6.0, Qt client"
-  msgbuf =
-      QString(_("%1%2, Qt client")).arg(word_version()).arg(VERSION_STRING);
+  msgbuf = QString(_("%1%2, Qt client"))
+               .arg(word_version())
+               .arg(freeciv21_version());
 #if IS_BETA_VERSION
   beta = beta_message();
 #endif // IS_BETA_VERSION

--- a/client/page_scenario.cpp
+++ b/client/page_scenario.cpp
@@ -12,19 +12,24 @@
  */
 
 #include "page_scenario.h"
-// Qt
-#include <QFileDialog>
+
 // utility
 #include "fcintl.h"
+
 // common
 #include "chatline_common.h"
 #include "connectdlg_common.h"
-#include "version.h"
+
+// generated
+#include "fc_version.h"
+
 // client
 #include "client_main.h"
-// gui-qt
 #include "dialogs.h"
 #include "fc_client.h"
+
+// Qt
+#include <QFileDialog>
 
 page_scenario::page_scenario(QWidget *parent, fc_client *gui)
     : QWidget(parent)

--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -30,6 +30,9 @@
 // utility
 #include "net_types.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "capstr.h"
 #include "dataio.h"
@@ -430,7 +433,7 @@ static bool begin_metaserver_scan(struct server_scan *scan)
 
   QNetworkRequest request(cmd_metaserver);
   request.setHeader(QNetworkRequest::UserAgentHeader,
-                    QLatin1String("Freeciv21/" VERSION_STRING));
+                    QLatin1String("Freeciv21/") + freeciv21_version());
   request.setHeader(QNetworkRequest::ContentTypeHeader,
                     QLatin1String("application/x-www-form-urlencoded"));
   auto *reply =

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -90,7 +90,6 @@ add_library(
   unit_utils.cpp
   unitlist.cpp
   unittype.cpp
-  version.cpp
   victory.cpp
   vision.cpp
   workertask.cpp

--- a/common/capstr.cpp
+++ b/common/capstr.cpp
@@ -13,11 +13,11 @@
 
 #include <cstdlib> // getenv()
 
-// gen_headers
-#include "fc_version.h"
-
 // utility
 #include "support.h"
+
+// generated
+#include "fc_version.h"
 
 // common
 #include "connection.h" // MAX_LEN_CAPSTR

--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
 #endif // SIGPIPE
 
   QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   // initialize server
   srv_init();

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -23,6 +23,9 @@
 #include "log.h"
 #include "support.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "capstr.h"
 #include "events.h"
@@ -397,11 +400,7 @@ bool handle_login_request(struct connection *pconn,
     info.major_version = MAJOR_VERSION;
     info.minor_version = MINOR_VERSION;
     info.patch_version = PATCH_VERSION;
-#ifdef EMERGENCY_VERSION
     info.emerg_version = EMERGENCY_VERSION;
-#else
-    info.emerg_version = 0;
-#endif
     sz_strlcpy(info.version_label, VERSION_LABEL);
     send_packet_server_info(pconn, &info);
   }

--- a/server/meta.cpp
+++ b/server/meta.cpp
@@ -217,7 +217,7 @@ static void send_metaserver_post(void *arg)
 
   QNetworkRequest request(QUrl(srvarg.metaserver_addr));
   request.setHeader(QNetworkRequest::UserAgentHeader,
-                    QLatin1String("Freeciv21/" VERSION_STRING));
+                    QLatin1String("Freeciv21/") + freeciv21_version());
   request.setHeader(QNetworkRequest::ContentTypeHeader,
                     QLatin1String("application/x-www-form-urlencoded"));
   auto *reply =
@@ -297,8 +297,7 @@ static bool send_to_metaserver(enum meta_flag flag)
     if (srvtype != nullptr) {
       post->addQueryItem(QStringLiteral("type"), QString::fromUtf8(srvtype));
     }
-    post->addQueryItem(QStringLiteral("version"),
-                       QStringLiteral(VERSION_STRING));
+    post->addQueryItem(QStringLiteral("version"), freeciv21_version());
     post->addQueryItem(QStringLiteral("patches"),
                        QString::fromUtf8(get_meta_patches_string()));
     post->addQueryItem(QStringLiteral("capability"),

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1587,7 +1587,7 @@ void log_civ_score_now()
                   game.server.scorefile);
         goto log_civ_score_disable;
       }
-      fprintf(score_log->fp, "%s%s\n", scorelog_magic, VERSION_STRING);
+      fprintf(score_log->fp, "%s%s\n", scorelog_magic, freeciv21_version());
       fprintf(score_log->fp, "\n"
                              "# For a specification of the format of this "
                              "see doc/README.scorelog or \n"

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -86,6 +86,9 @@
 #include "support.h" // bool type
 #include "timing.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "achievements.h"
 #include "ai.h"
@@ -2375,9 +2378,7 @@ static void sg_save_scenario(struct savedata *saving)
 
   game_version =
       MAJOR_VERSION * 1000000 + MINOR_VERSION * 10000 + PATCH_VERSION * 100;
-#ifdef EMERGENCY_VERSION
   game_version += EMERGENCY_VERSION;
-#endif // EMERGENCY_VERSION
   secfile_insert_int(saving->file, game_version, "scenario.game_version");
 
   if (!saving->scenario || !game.scenario.is_scenario) {

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -30,6 +30,9 @@
 #include "support.h"
 #include "timing.h"
 
+// generated
+#include "fc_version.h"
+
 // common
 #include "dataio.h"
 #include "events.h"

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -1232,7 +1232,7 @@ static void write_init_script(char *script_filename)
   if (QFile::exists(real_filename)
       && (script_file = fc_fopen(real_filename, "w"))) {
     fprintf(script_file, "#FREECIV SERVER COMMAND FILE, version %s\n",
-            VERSION_STRING);
+            freeciv21_version());
     fputs(
         "# These are server options saved from a running freeciv-server.\n",
         script_file);

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -210,7 +210,7 @@ static bool manual_command(struct tag_types *tag_info)
     case MANUAL_SETTINGS:
       // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
       fprintf(doc, _("%sFreeciv21 %s server options (%s)%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, game.control.name,
+              tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
       settings_iterate(SSET_ALL, pset)
       {
@@ -295,7 +295,8 @@ static bool manual_command(struct tag_types *tag_info)
     case MANUAL_COMMANDS:
       // TRANS: markup ... Freeciv21 version ... markup
       fprintf(doc, _("%sFreeciv21 %s server commands%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, tag_info->title_end);
+              tag_info->title_begin, freeciv21_version(),
+              tag_info->title_end);
       for (i = 0; i < CMD_NUM; i++) {
         const struct command *cmd = command_by_number(i);
 
@@ -331,7 +332,7 @@ static bool manual_command(struct tag_types *tag_info)
     case MANUAL_TERRAIN:
       // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
       fprintf(doc, _("%sFreeciv21 %s terrain help (%s)%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, game.control.name,
+              tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
       fprintf(doc, "<table><tr bgcolor=#9bc3d1><th colspan=2>%s</th>",
               _("Terrain"));
@@ -468,13 +469,13 @@ static bool manual_command(struct tag_types *tag_info)
       if (manuals == MANUAL_BUILDINGS) {
         // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
         fprintf(doc, _("%sFreeciv21 %s buildings help (%s)%s\n\n"),
-                tag_info->title_begin, VERSION_STRING, game.control.name,
-                tag_info->title_end);
+                tag_info->title_begin, freeciv21_version(),
+                game.control.name, tag_info->title_end);
       } else {
         // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
         fprintf(doc, _("%sFreeciv21 %s wonders help (%s)%s\n\n"),
-                tag_info->title_begin, VERSION_STRING, game.control.name,
-                tag_info->title_end);
+                tag_info->title_begin, freeciv21_version(),
+                game.control.name, tag_info->title_end);
       }
 
       fprintf(doc,
@@ -541,7 +542,7 @@ static bool manual_command(struct tag_types *tag_info)
       // FIXME: this doesn't resemble the wiki manual at all.
       // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
       fprintf(doc, _("%sFreeciv21 %s governments help (%s)%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, game.control.name,
+              tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
       for (auto &pgov : governments) {
         char buf[64000];
@@ -563,7 +564,7 @@ static bool manual_command(struct tag_types *tag_info)
       // FIXME: this doesn't resemble the wiki manual at all.
       // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
       fprintf(doc, _("%sFreeciv21 %s unit types help (%s)%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, game.control.name,
+              tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
       unit_type_iterate(putype)
       {
@@ -620,7 +621,7 @@ static bool manual_command(struct tag_types *tag_info)
       // FIXME: this doesn't resemble the wiki manual at all.
       // TRANS: markup ... Freeciv21 version ... ruleset name ... markup
       fprintf(doc, _("%sFreeciv21 %s tech help (%s)%s\n\n"),
-              tag_info->title_begin, VERSION_STRING, game.control.name,
+              tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
       advance_iterate(A_FIRST, ptech)
       {
@@ -665,7 +666,7 @@ int main(int argc, char **argv)
   struct tag_types *tag_info = &html_tags;
 
   QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   init_nls();
   init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);

--- a/tools/fcmp/mpcli.cpp
+++ b/tools/fcmp/mpcli.cpp
@@ -83,7 +83,7 @@ static void setup_modpack_list(const QString &name, const QUrl &url,
 int main(int argc, char *argv[])
 {
   QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   // Delegate option parsing to the common function.
   fcmp_parse_cmdline(app);
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
 
   qInfo(_("Freeciv21 modpack installer (command line version)"));
 
-  qInfo("%s%s", word_version(), VERSION_STRING);
+  qInfo("%s%s", word_version(), freeciv21_version());
 
   qInfo("%s", "");
 

--- a/tools/fcmp/mpgui_qt.cpp
+++ b/tools/fcmp/mpgui_qt.cpp
@@ -81,7 +81,7 @@ static void gui_download_modpack(const QString &url);
 int main(int argc, char **argv)
 {
   QApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   // Delegate option parsing to the common function.
   fcmp_parse_cmdline(app);
@@ -169,7 +169,7 @@ void mpgui::setup(QWidget *central, struct fcmp_params *params)
   char verbuf[2048];
 
   fc_snprintf(verbuf, sizeof(verbuf), "%s%s", word_version(),
-              VERSION_STRING);
+              freeciv21_version());
 
   version_label = new QLabel(QString::fromUtf8(verbuf));
   version_label->setAlignment(Qt::AlignHCenter);

--- a/tools/ruledit/ruledit.cpp
+++ b/tools/ruledit/ruledit.cpp
@@ -30,6 +30,7 @@
 #include "fciconv.h"
 #include "fcintl.h"
 #include "log.h"
+#include "version.h"
 
 // common
 #include "fc_interface.h"
@@ -57,7 +58,7 @@ struct ruledit_arguments reargs;
 int main(int argc, char **argv)
 {
   QApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   log_init();
 

--- a/tools/ruledit/ruledit_qt.cpp
+++ b/tools/ruledit/ruledit_qt.cpp
@@ -30,6 +30,7 @@
 #include "fcintl.h"
 #include "log.h"
 #include "registry.h"
+#include "version.h"
 
 // common
 #include "game.h"
@@ -94,7 +95,7 @@ ruledit_gui::ruledit_gui(ruledit_main *main) : QObject(main)
   main->setCentralWidget(central);
 
   fc_snprintf(verbuf, sizeof(verbuf), "%s%s", word_version(),
-              VERSION_STRING);
+              freeciv21_version());
 
   main_layout = new QStackedLayout();
 

--- a/tools/ruleup.cpp
+++ b/tools/ruleup.cpp
@@ -26,6 +26,7 @@
 // utility
 #include "fciconv.h"
 #include "registry.h"
+#include "version.h"
 
 // common
 #include "fc_interface.h"
@@ -105,7 +106,7 @@ static void conv_log(const char *msg) { qInfo("%s", msg); }
 int main(int argc, char **argv)
 {
   QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(VERSION_STRING);
+  QCoreApplication::setApplicationVersion(freeciv21_version());
 
   log_init();
 

--- a/translations/core/POTFILES.in
+++ b/translations/core/POTFILES.in
@@ -96,7 +96,6 @@ common/terrain.h
 common/unit.cpp
 common/unittype.cpp
 common/unittype.h
-common/version.cpp
 data/alien/buildings.ruleset
 data/alien/cities.ruleset
 data/alien/game.ruleset
@@ -313,3 +312,4 @@ utility/netfile.cpp
 utility/registry_ini.cpp
 utility/shared.cpp
 utility/support.cpp
+utility/version.cpp

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(
   shared.cpp
   support.cpp
   timing.cpp
+  version.cpp
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/specenum_gen.h
 )

--- a/utility/cmake_fc_config.h.in
+++ b/utility/cmake_fc_config.h.in
@@ -1,5 +1,3 @@
-#include "fc_version.h"
-
 #define CMAKE_BUILD
 
 #define LOCALEDIR "${CMAKE_INSTALL_FULL_LOCALEDIR}"

--- a/utility/netfile.cpp
+++ b/utility/netfile.cpp
@@ -29,6 +29,7 @@
 // utility
 #include "fcintl.h"
 #include "registry.h"
+#include "version.h"
 
 #include "netfile.h"
 
@@ -47,7 +48,7 @@ static bool netfile_download_file_core(const QUrl &url, QIODevice *out,
   // Initiate the request
   auto request = QNetworkRequest(url);
   request.setHeader(QNetworkRequest::UserAgentHeader,
-                    QLatin1String("Freeciv21/" VERSION_STRING));
+                    QLatin1String("Freeciv21/") + freeciv21_version());
   request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                        QNetworkRequest::NoLessSafeRedirectPolicy);
 

--- a/utility/version.cpp
+++ b/utility/version.cpp
@@ -15,13 +15,20 @@
 #include <fc_config.h>
 #endif
 
+#include "version.h"
+
 // utility
 #include "fcintl.h"
 #include "shared.h"
 #include "support.h"
 
-// common
-#include "version.h"
+// generated
+#include "fc_version.h"
+
+/**
+ * Returns the raw version string
+ */
+const char *freeciv21_version() { return VERSION_STRING; }
 
 /**
    Return string containing both name of Freeciv21 and version.
@@ -32,10 +39,10 @@ const char *freeciv_name_version()
 
 #if IS_BETA_VERSION
   fc_snprintf(msgbuf, sizeof(msgbuf), _("Freeciv21 version %s %s"),
-              VERSION_STRING, _("(beta version)"));
+              freeciv21_version(), _("(beta version)"));
 #else
   fc_snprintf(msgbuf, sizeof(msgbuf), _("Freeciv21 version %s"),
-              VERSION_STRING);
+              freeciv21_version());
 #endif
 
   return msgbuf;
@@ -58,7 +65,7 @@ const char *word_version()
    This does not handle git revisions, as there's no way to compare
    which of the two commits is "higher".
  */
-const char *fc_comparable_version() { return VERSION_STRING; }
+const char *fc_comparable_version() { return freeciv21_version(); }
 
 /**
    Return the BETA message.
@@ -101,7 +108,7 @@ const char *freeciv_datafile_version()
   static char buf[500] = {'\0'};
 
   if (buf[0] == '\0') {
-    fc_snprintf(buf, sizeof(buf), "%s", VERSION_STRING);
+    fc_snprintf(buf, sizeof(buf), "%s", freeciv21_version());
   }
 
   return buf;

--- a/utility/version.h
+++ b/utility/version.h
@@ -23,6 +23,7 @@
 #endif
 
 // version informational strings
+const char *freeciv21_version();
 const char *freeciv_name_version();
 const char *word_version();
 const char *fc_comparable_version();


### PR DESCRIPTION
For devs who do not clean their cache directory often, we do a check for the generated `fc_version.h` and if the patch version is different then we delete the cache file. Closes #1564