### PR TITLE
Add a menu with minimap options next to the minimap

### DIFF
--- a/client/minimap_panel.cpp
+++ b/client/minimap_panel.cpp
@@ -8,9 +8,14 @@
 
 #include "minimap_panel.h"
 
+// Qt
+#include <QMenu>
+
 // client
 #include "icons.h"
 #include "mapview.h"
+#include "options.h"
+#include "overview_common.h"
 #include "page_game.h"
 #include "top_bar.h"
 
@@ -38,6 +43,10 @@ minimap_panel::minimap_panel(map_view *map, QWidget *parent)
       fcIcons::instance()->getIcon(QStringLiteral("zoom-out")));
   connect(ui.zoom_out, &QAbstractButton::clicked, map, &map_view::zoom_out);
 
+  ui.settings->setIcon(
+      fcIcons::instance()->getIcon(QStringLiteral("settings-minimap")));
+  setup_minimap_menu();
+
   connect(ui.turn_done, &QAbstractButton::clicked, top_bar_finish_turn);
 }
 
@@ -60,6 +69,75 @@ void minimap_panel::set_minimap_visible(bool visible)
   // proper QLayout...
   QApplication::postEvent(queen()->game_tab_widget,
                           new QEvent(QEvent::LayoutRequest));
+}
+
+/**
+ * Creates the menu with the minimap settings
+ */
+void minimap_panel::setup_minimap_menu()
+{
+  auto menu = new QMenu;
+
+  m_show_relief = menu->addAction(_("Show Relief"));
+  m_show_relief->setCheckable(true);
+  ;
+  m_show_relief->setChecked(gui_options->overview.layers[OLAYER_RELIEF]);
+  QObject::connect(m_show_relief, &QAction::toggled, [](bool checked) {
+    gui_options->overview.layers[OLAYER_RELIEF] = checked;
+    refresh_overview_canvas();
+  });
+
+  m_show_borders = menu->addAction(_("Show Borders"));
+  m_show_borders->setCheckable(true);
+  ;
+  m_show_borders->setChecked(gui_options->overview.layers[OLAYER_BORDERS]);
+  QObject::connect(m_show_borders, &QAction::toggled, [=](bool checked) {
+    gui_options->overview.layers[OLAYER_BORDERS] = checked;
+    m_show_borders_ocean->setEnabled(checked);
+    refresh_overview_canvas();
+  });
+
+  m_show_borders_ocean = menu->addAction(_("Show Borders on Oceans"));
+  m_show_borders_ocean->setCheckable(true);
+  ;
+  m_show_borders_ocean->setChecked(
+      gui_options->overview.layers[OLAYER_BORDERS_ON_OCEAN]);
+  m_show_borders_ocean->setEnabled(
+      gui_options->overview.layers[OLAYER_BORDERS]);
+  QObject::connect(
+      m_show_borders_ocean, &QAction::toggled, [](bool checked) {
+        gui_options->overview.layers[OLAYER_BORDERS_ON_OCEAN] = checked;
+        refresh_overview_canvas();
+      });
+
+  m_show_cities = menu->addAction(_("Show Cities"));
+  m_show_cities->setCheckable(true);
+  ;
+  m_show_cities->setChecked(gui_options->overview.layers[OLAYER_CITIES]);
+  QObject::connect(m_show_cities, &QAction::toggled, [](bool checked) {
+    gui_options->overview.layers[OLAYER_CITIES] = checked;
+    refresh_overview_canvas();
+  });
+
+  m_show_cities = menu->addAction(_("Show Units"));
+  m_show_cities->setCheckable(true);
+  ;
+  m_show_cities->setChecked(gui_options->overview.layers[OLAYER_UNITS]);
+  QObject::connect(m_show_cities, &QAction::toggled, [](bool checked) {
+    gui_options->overview.layers[OLAYER_UNITS] = checked;
+    refresh_overview_canvas();
+  });
+
+  m_show_fog = menu->addAction(_("Show Fog of War"));
+  m_show_fog->setCheckable(true);
+  ;
+  m_show_fog->setChecked(gui_options->overview.fog);
+  QObject::connect(m_show_fog, &QAction::toggled, [](bool checked) {
+    gui_options->overview.fog = checked;
+    refresh_overview_canvas();
+  });
+
+  ui.settings->setMenu(menu);
 }
 
 /**

--- a/client/minimap_panel.h
+++ b/client/minimap_panel.h
@@ -12,6 +12,8 @@
 // qt-client is one true king
 #include "widgetdecorations.h"
 
+class QAction;
+
 class map_view;
 
 /**
@@ -37,7 +39,12 @@ public:
   auto turn_done() { return ui.turn_done; }
 
 private:
+  void setup_minimap_menu();
+
   Ui::minimap_panel ui;
+
+  QAction *m_show_relief, *m_show_borders, *m_show_borders_ocean,
+      *m_show_cities, *m_show_units, *m_show_fog;
 };
 
 void update_timeout_label();

--- a/client/minimap_panel.ui
+++ b/client/minimap_panel.ui
@@ -80,6 +80,19 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QToolButton" name="settings">
+         <property name="toolTip">
+          <string>Configure</string>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>

--- a/data/themes/gui-qt/icons/settings-minimap.svg
+++ b/data/themes/gui-qt/icons/settings-minimap.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g fill="#000">
+  <path d="m6 1a3 3 0 0 0-2.8 2h-2.2v2h2.2a3 3 0 0 0 2.8 2 3 3 0 0 0 2.8-2h6.2v-2h-6.2a3 3 0 0 0-2.8-2zm0 1a2 2 0 0 1 2 2 2 2 0 0 1-2 2 2 2 0 0 1-2-2 2 2 0 0 1 2-2z"/>
+  <rect x="1" y="11" width="14" height="2"/>
+  <circle cx="10" cy="12" r="3"/>
+ </g>
+</svg>

--- a/data/themes/gui-qt/icons/settings-minimap.svg.license
+++ b/data/themes/gui-qt/icons/settings-minimap.svg.license
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2023 Louis Moureaux


### PR DESCRIPTION
Make the minimap options more visible and easier to change by adding them in a dropdown menu next to the minimap.