### PR TITLE
Add an effect to keep food surplus when a city grows

### DIFF
--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -289,6 +289,9 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_GROWTH_FOOD:
     v += c * 4 + (amount / 7) * pcity->surplus[O_FOOD];
     break;
+  case EFT_GROWTH_SURPLUS_PCT:
+    v += c * (amount / 7) * pcity->surplus[O_FOOD]; // Guessed
+    break;
   case EFT_HEALTH_PCT:
     // Is plague possible
     if (game.info.illness_on) {

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1109,6 +1109,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_UNIT_SHIELD_VALUE_PCT:
   case EFT_BOMBARD_LIMIT_PCT:
   case EFT_NUKE_INFRASTRUCTURE_PCT:
+  case EFT_GROWTH_SURPLUS_PCT:
     // TRANS: per cent
     return QString(PL_("%1%", "%1%", value)).arg(value);
   case EFT_MAX_STOLEN_GOLD_PM:

--- a/common/effects.h
+++ b/common/effects.h
@@ -313,6 +313,8 @@
 #define SPECENUM_VALUE133NAME "Nation_Intelligence"
 #define SPECENUM_VALUE134 EFT_NUKE_INFRASTRUCTURE_PCT
 #define SPECENUM_VALUE134NAME "Nuke_Infrastructure_Pct"
+#define SPECENUM_VALUE135 EFT_GROWTH_SURPLUS_PCT
+#define SPECENUM_VALUE135NAME "Growth_Surplus_Pct"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -96,7 +96,7 @@ to alter is placed inside back-ticks.
 * :literal:`:title-reference:` -- Title Reference is used notate a :title-reference:`title entry` in the
   in-game help or to refer to a page in the documentation without giving an actual hyperlink reference
   (see :literal:`:doc:` above).
-
+* :literal:`.. versionadded::` -- Used at the paragraph level to document the first version in which a feature was added.
 
 The docutils specification allows for custom Interpreted Text Roles and we use this feature. The docutils
 documentation on this feature is available here:

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -1,3 +1,12 @@
+..
+    SPDX-License-Identifier: GPL-3.0-or-later
+    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
+    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+    SPDX-FileCopyrightText: 2022-2023 louis94 <m_louis30@yahoo.com>
+
+.. Custom Interpretive Text Roles for longturn.net/Freeciv21
+.. role:: improvement
+
 Effects
 *******
 
@@ -271,8 +280,19 @@ Conquest_Tech_Pct
     Percent chance that a player conquering a city learns a tech from the former owner.
 
 Growth_Food
-    Food left after cities grow or shrink is amount percent of the capacity of he city's foodbox. This also
-    affects the 'aqueductloss' penalty.
+    Saves some food in the granary when a city grows (or shrinks): this effect controls how much food there
+    will be in the city's granary after growing, as a percentage of the foodbox at the new size, provided
+    there was sufficient food before growing. This also reduces the ``aqueductloss`` penalty in the same
+    fraction.
+
+    .. note:: This is traditionally used for the :improvement:`Granary`.
+
+Growth_Surplus_Pct
+    .. versionadded:: 3.1
+
+    How much of the excess food is kept when a city growth, as a percentage. For example, with a value of
+    100, a city with a granary full at 18/20 and generating 5 food would start the next turn with 3 bushels
+    in its granary. With a value of 50, it would have only 1 bushel.
 
 Have_Contact
     If value > 0, gives contact to all the other players.

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -718,13 +718,6 @@ void update_city_activities(struct player *pplayer)
                   ruler_title_for_player(pplayer, buf, sizeof(buf)));
   }
 
-#if 0
-  // Uncomment to unbalance the game, like in civ1 (CLG).
-  if (pplayer->got_tech && pplayer->research->researched > 0) {
-    pplayer->research->researched = 0;
-  }
-#endif
-
   city_refresh_queue_processing();
 }
 

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -1207,7 +1207,7 @@ static void package_player_info(struct player *plr,
       const auto bonus = get_target_bonus_effects(
           nullptr, city_owner(pcity), receiver, pcity, pimprove, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, EFT_WONDER_VISIBLE);
-      if (bonus > 0) {
+      if (players_on_same_team(plr, receiver) || bonus > 0) {
         packet->wonders[i] = plr->wonders[i];
       } else {
         packet->wonders[i] = WONDER_NOT_BUILT;


### PR DESCRIPTION
Tested by adding the following to `classic/effects.ruleset`:
```ini
[effect_foo]
type    = "Growth_Surplus_Pct"
value   = 100
```

Closes #510.