### PR TITLE
Always send wonder information to the player's team

### DIFF
--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -1207,7 +1207,7 @@ static void package_player_info(struct player *plr,
       const auto bonus = get_target_bonus_effects(
           nullptr, city_owner(pcity), receiver, pcity, pimprove, nullptr,
           nullptr, nullptr, nullptr, nullptr, nullptr, EFT_WONDER_VISIBLE);
-      if (bonus > 0) {
+      if (players_on_same_team(plr, receiver) || bonus > 0) {
         packet->wonders[i] = plr->wonders[i];
       } else {
         packet->wonders[i] = WONDER_NOT_BUILT;


### PR DESCRIPTION
With the introduction of EFT_WONDER_VISIBLE, it became possible not to send (small) wonder information to the team owning them. This is obviously not the right thing to do, since the players can see the wonders in the cities. So always send the info.

Closes #1656.
Closes #1675.
For #1675, unfortunately the governor results will be wrong until this is implemented on the server.

Backport candidate.