### PR TITLE
Fix exploding nukes

### DIFF
--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -22,6 +22,7 @@
 #include "movement.h"
 #include "nation.h"
 #include "research.h"
+#include "shortcuts.h"
 #include "tile.h"
 #include "tilespec.h"
 #include "unit.h"
@@ -897,7 +898,8 @@ void hud_action::mouse_right_clicked() {}
  */
 void hud_action::mouse_clicked()
 {
-  king()->menu_bar->execute_shortcut(action_shortcut);
+  // Only works if there's an action in the menu!
+  fc_shortcuts::sc()->invoke(action_shortcut, nullptr);
 }
 
 /**

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -390,7 +390,7 @@ void go_act_menu::create()
 
 #define ADD_OLD_SHORTCUT(wanted_action_id, sc_id)                           \
   if (act_id == wanted_action_id) {                                         \
-    item->setShortcut(fc_shortcuts::sc()->get_shortcut(sc_id).keys);        \
+    fc_shortcuts::sc()->link_action(sc_id, item);                           \
   }
 
       /* Create and add the menu item. It will be hidden or shown based on

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -1289,30 +1289,6 @@ void mr_menu::set_tile_for_order(tile *ptile)
 }
 
 /**
-   Finds QAction bounded to given shortcut and triggers it
- */
-void mr_menu::execute_shortcut(int sid)
-{
-  if (sid == SC_GOTO) {
-    queen()->mapview_wdg->menu_click = true;
-    slot_unit_goto();
-    return;
-  }
-
-  auto fcs = fc_shortcuts::sc()->get_shortcut(static_cast<shortcut_id>(sid));
-  auto menu_list = findChildren<QMenu *>();
-  for (const QMenu *m : qAsConst(menu_list)) {
-    QList<QAction *> actions = m->actions();
-    for (QAction *a : qAsConst(actions)) {
-      if (a->shortcut() == fcs.keys && a->isEnabled()) {
-        a->activate(QAction::Trigger);
-        return;
-      }
-    }
-  }
-}
-
-/**
    Returns string assigned to shortcut or empty string if doesnt exist
  */
 bool mr_menu::shortcut_exists(const fc_shortcut &fcs, QString &where)

--- a/client/menu.h
+++ b/client/menu.h
@@ -182,7 +182,6 @@ public:
   void update_roads_menu();
   void update_bases_menu();
   void set_tile_for_order(struct tile *ptile);
-  void execute_shortcut(int sid);
   bool shortcut_exists(const fc_shortcut &fcs, QString &where);
   QString shortcut_2_menustring(int sid);
   QAction *minimap_status = nullptr;

--- a/client/shortcuts.cpp
+++ b/client/shortcuts.cpp
@@ -280,6 +280,20 @@ void fc_shortcuts::create_no_action_shortcuts(map_view *parent)
 }
 
 /**
+ * Invokes the action for a shortcut.
+ */
+void fc_shortcuts::invoke(shortcut_id id, map_view *mapview)
+{
+  if (m_actions.count(id) > 0 && m_actions[id] != nullptr) {
+    m_actions[id]->trigger();
+  } else if (mapview) {
+    // Shortcuts with no action are handled by the mapview directly.
+    // Eventually we should create actions and add them to menus...
+    mapview->shortcut_pressed(id);
+  }
+}
+
+/**
  * If the mouse event corresponds to a registered shortcut, fire the
  * corresponding action.
  */
@@ -292,14 +306,7 @@ void fc_shortcuts::maybe_route_mouse_shortcut(QMouseEvent *event,
   for (const auto &[id, shortcut] : shortcuts()) {
     if (shortcut.type == fc_shortcut::mouse && shortcut.buttons == buttons
         && shortcut.modifiers == modifiers) {
-      // Found a matching shortcut
-      if (m_actions.count(id) > 0 && m_actions[id] != nullptr) {
-        m_actions[id]->trigger();
-      } else {
-        // Shortcuts with no action are handled by the mapview directly.
-        // Eventually we should create actions and add them to menus...
-        mapview->shortcut_pressed(id);
-      }
+      invoke(id, mapview);
     }
   }
 }

--- a/client/shortcuts.h
+++ b/client/shortcuts.h
@@ -142,6 +142,7 @@ public:
 
   void link_action(shortcut_id id, QAction *action);
   void create_no_action_shortcuts(map_view *parent);
+  void invoke(shortcut_id id, map_view *mapview);
   void maybe_route_mouse_shortcut(QMouseEvent *event, map_view *mapview);
 
   static fc_shortcuts *sc();


### PR DESCRIPTION
Well, they could always be exploded with Do..., but it's easier now. Two commits:

1. Fix the duplicate shortcuts message with Go to and... shortcuts (Shift+B, Shift+J, Shift+N). Backporting candidate.
2. Fix the Shift+N button. This one is more risky, not sure if we should backport.

Closes #1650 