### PR TITLE
Start breaking the city dialog

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -133,6 +133,9 @@ target_sources(
   voteinfo_bar.cpp
   widgetdecorations.cpp
   unithudselector.cpp
+
+  widgets/city/upkeep_widget.cpp
+
   # Generated
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_client_gen.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/tolua_client_gen.h

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -135,6 +135,7 @@ target_sources(
   unithudselector.cpp
 
   utils/improvement_seller.cpp
+  utils/unit_quick_menu.cpp
   widgets/city/upkeep_widget.cpp
 
   # Generated

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -134,6 +134,7 @@ target_sources(
   widgetdecorations.cpp
   unithudselector.cpp
 
+  utils/improvement_seller.cpp
   widgets/city/upkeep_widget.cpp
 
   # Generated

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -56,6 +56,7 @@
 #include "tooltips.h"
 #include "top_bar.h"
 #include "unitlist.h"
+#include "utils/improvement_seller.h"
 
 extern QString split_text(const QString &text, bool cut);
 extern QString cut_helptext(const QString &text);
@@ -806,41 +807,12 @@ void impr_info::update_buildings()
  */
 void impr_item::mouseDoubleClickEvent(QMouseEvent *event)
 {
-  hud_message_box *ask;
-  QString buf;
-  int price;
   const int impr_id = improvement_number(impr);
   const int city_id = pcity->id;
 
-  if (!can_client_issue_orders()) {
-    return;
-  }
-
   if (event->button() == Qt::LeftButton) {
-    ask = new hud_message_box(queen()->city_overlay);
-    if (test_player_sell_building_now(client.conn.playing, pcity, impr)
-        != TR_SUCCESS) {
-      return;
-    }
-
-    price = impr_sell_gold(impr);
-    buf = QString(PL_("Sell %1 for %2 gold?", "Sell %1 for %2 gold?", price))
-              .arg(city_improvement_name_translation(pcity, impr),
-                   QString::number(price));
-
-    ask->set_text_title(buf, (_("Sell Improvement?")));
-    ask->setStandardButtons(QMessageBox::Cancel | QMessageBox::Yes);
-    ask->setDefaultButton(QMessageBox::Cancel);
-    ask->button(QMessageBox::Yes)->setText(_("Yes Sell"));
-    ask->setAttribute(Qt::WA_DeleteOnClose);
-    connect(ask, &hud_message_box::accepted, [=]() {
-      struct city *pcity = game_city_by_number(city_id);
-      if (!pcity) {
-        return;
-      }
-      city_sell_improvement(pcity, impr_id);
-    });
-    ask->show();
+    auto seller = freeciv::improvement_seller(window(), city_id, impr_id);
+    seller();
   }
 }
 

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1878,8 +1878,10 @@ void city_dialog::refresh()
     update_nation_table();
     update_cma_tab();
     update_disabled();
+    ui.upkeep->set_city(pcity->id);
   } else {
     popdown_city_dialog();
+    ui.upkeep->set_city(-1);
   }
 
   update_map_canvas_visible();
@@ -2361,6 +2363,8 @@ void city_dialog::update_improvements()
   ui.city_buildings->update_buildings();
   ui.city_buildings->setUpdatesEnabled(true);
   ui.city_buildings->setUpdatesEnabled(true);
+
+  ui.upkeep->refresh();
 
   ui.curr_impr->setText(QString(_("Improvements: upkeep %1")).arg(upkeep));
 }

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -75,27 +75,16 @@ public:
   void set_units(unit_list *units);
   std::vector<unit *> selected_playable_units() const;
 
-private:
-  void disband();
-  void change_homecity();
-  void activate();
-  void sentry();
-  void fortify();
-  void upgrade();
-  void load();
-  void unload();
-  void unload_all();
+protected:
+  void contextMenuEvent(QContextMenuEvent *event) override;
 
-  void selectionChanged(const QItemSelection &selected,
-                        const QItemSelection &deselected) override;
+private:
+  void activate();
   QPixmap create_unit_image(const unit *punit);
 
 private:
   bool m_oneliner = false;
   bool m_show_upkeep = false;
-
-  QAction *m_activate, *m_sentry, *m_fortify, *m_disband, *m_change_homecity,
-      *m_load, *m_unload, *m_unload_all, *m_upgrade;
 };
 
 /****************************************************************************

--- a/client/citydlg.ui
+++ b/client/citydlg.ui
@@ -24,7 +24,7 @@
     <number>24</number>
    </property>
    <property name="leftMargin">
-    <number>24</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
     <number>24</number>
@@ -165,6 +165,9 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="freeciv::upkeep_widget" name="upkeep"/>
+     </item>
      <item>
       <spacer name="horizontalSpacer_7">
        <property name="orientation">
@@ -562,7 +565,7 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>310</width>
+                 <width>292</width>
                  <height>824</height>
                 </rect>
                </property>
@@ -733,7 +736,7 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>282</width>
+                    <width>264</width>
                     <height>361</height>
                    </rect>
                   </property>
@@ -984,6 +987,11 @@
    <extends>QWidget</extends>
    <header>citydlg.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>freeciv::upkeep_widget</class>
+   <extends>QListView</extends>
+   <header>widgets/city/upkeep_widget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -21,6 +21,7 @@
 #include "options.h"
 
 #include <QColor>
+#include <QEvent>
 
 struct base_type;
 struct help_item;
@@ -100,7 +101,10 @@ struct tileset;
 
 extern struct tileset *tileset;
 
+void tilespec_init();
 const QVector<QString> *get_tileset_list(const struct option *poption);
+
+extern QEvent::Type TilesetChanged;
 
 void tileset_error(struct tileset *t, QtMsgType level, const char *format,
                    ...);

--- a/client/utils/improvement_seller.cpp
+++ b/client/utils/improvement_seller.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ * SPDX-FileCopyrightText: Copyright (c) 1996-2022 Freeciv21 and Freeciv
+ * contributors
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "improvement_seller.h"
+
+#include "citydlg_common.h"
+#include "client_main.h"
+#include "game.h"
+#include "hudwidget.h"
+#include "improvement.h"
+#include "log.h"
+
+#include <QMenu>
+
+namespace freeciv {
+
+/**
+ * @class improvement_seller
+ * @brief
+ * Helper class to safely sell a city improvement.
+ *
+ * This class adds an action to a menu (via @ref add_to_menu) to sell a city
+ * improvement. When the item is activated, the potential gain is displayed
+ * and the user is prompted for confirmation. If the user confirms, the
+ * improvement is sold.
+ *
+ * The seller can also be used directly with its @ref operator().
+ *
+ * This class handles all corner cases where the city may be disbanded or the
+ * improvement disappear for some reason.
+ */
+
+/**
+ * Constructor.
+ */
+improvement_seller::improvement_seller(QWidget *parent, int city_id,
+                                       int improvement_id)
+    : m_city(city_id), m_improvement(improvement_id), m_parent(parent)
+{
+}
+
+/**
+ * Asks for confirmation then sells the improvement.
+ */
+void improvement_seller::operator()()
+{
+  if (!can_client_issue_orders()) {
+    return; // Kicked
+  }
+
+  const auto city = game_city_by_number(m_city);
+  const auto building = improvement_by_number(m_improvement);
+
+  fc_assert_ret(city != nullptr);
+  fc_assert_ret(building != nullptr);
+
+  // Cannot sell it now
+  if (test_player_sell_building_now(client.conn.playing, city, building)
+      != TR_SUCCESS) {
+    return;
+  }
+
+  const auto price = impr_sell_gold(building);
+  const auto buf =
+      QString(PL_("Sell %1 for %2 gold?", "Sell %1 for %2 gold?", price))
+          .arg(city_improvement_name_translation(city, building),
+               QString::number(price));
+
+  auto ask = new hud_message_box(m_parent);
+  ask->setAttribute(Qt::WA_DeleteOnClose);
+
+  ask->set_text_title(buf, (_("Sell Improvement?")));
+  ask->setStandardButtons(QMessageBox::Cancel | QMessageBox::Yes);
+  ask->setDefaultButton(QMessageBox::Cancel);
+  ask->button(QMessageBox::Yes)->setText(_("Yes Sell"));
+
+  int city_id = m_city, improvement_id = m_improvement; // For lambda capture
+  QObject::connect(ask, &hud_message_box::accepted, [=] {
+    auto city = game_city_by_number(city_id);
+    if (!city || !can_client_issue_orders()) {
+      return;
+    }
+    city_sell_improvement(city, improvement_id);
+  });
+
+  ask->show();
+}
+
+/**
+ * @brief Adds a menu item to sell an improvement in a city.
+ *
+ * The @c parent parameter is used as the parent for the confirmation popup.
+ * It may not be null. The @c parent must outlive the menu.
+ */
+QAction *improvement_seller::add_to_menu(QWidget *parent, QMenu *menu,
+                                         const city *city,
+                                         int improvement_id)
+{
+  fc_assert_ret_val(parent != nullptr, nullptr);
+
+  auto action =
+      menu->addAction(_("Sell Improvement"),
+                      improvement_seller(parent, city->id, improvement_id));
+
+  auto building = improvement_by_number(improvement_id);
+  action->setEnabled(
+      building && can_client_issue_orders()
+      && test_player_sell_building_now(client.conn.playing, city, building)
+             == TR_SUCCESS);
+
+  return action;
+}
+
+} // namespace freeciv

--- a/client/utils/improvement_seller.h
+++ b/client/utils/improvement_seller.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+class QAction;
+class QMenu;
+class QWidget;
+
+struct city;
+struct building;
+
+namespace freeciv {
+
+class improvement_seller {
+public:
+  improvement_seller(QWidget *parent, int city_id, int improvement_id);
+
+  void operator()();
+
+  static QAction *add_to_menu(QWidget *parent, QMenu *menu, const city *city,
+                              int improvement_id);
+
+private:
+  int m_city, m_improvement;
+  QWidget *m_parent;
+};
+
+} // namespace freeciv

--- a/client/utils/unit_quick_menu.cpp
+++ b/client/utils/unit_quick_menu.cpp
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ * SPDX-FileCopyrightText: Copyright (c) 1996-2022 Freeciv21 and Freeciv
+ * contributors
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "unit_quick_menu.h"
+#include "actions.h"
+#include "citydlg.h"
+#include "client_main.h"
+#include "control.h"
+#include "dialogs.h"
+#include "game.h"
+#include "page_game.h"
+#include "qtg_cxxside.h"
+#include "unit.h"
+#include "unitlist.h"
+
+#include <QMenu>
+#include <algorithm>
+
+namespace freeciv {
+
+namespace /* anonymous */ {
+
+/**
+ * Creates a callback function to call @c cb with @c unit_ids turned into
+ * valid unit pointers.
+ */
+template <class Callback>
+auto unit_action_helper(const std::vector<int> &unit_ids, Callback &&cb)
+{
+  return [unit_ids, cb] {
+    // Check playable units
+    if (!can_client_issue_orders()) {
+      return;
+    }
+
+    auto units = std::vector<unit *>();
+    for (const auto id : unit_ids) {
+      const auto unit = game_unit_by_number(id);
+      // Maybe some units died
+      if (unit && unit_owner(unit) == client_player()) {
+        units.push_back(unit);
+      }
+    }
+
+    cb(units);
+  };
+}
+
+/**
+ * Callback taking a single unit.
+ */
+template <class RetType> using unit_callback_type = RetType (*)(unit *);
+
+/**
+ * Creates a callback function to call @c cb repeatedly for each valid unit
+ * in
+ * @c unit_ids turned into a unit pointer.
+ */
+template <class RetType>
+auto unit_action_helper(const std::vector<int> &unit_ids,
+                        unit_callback_type<RetType> cb)
+{
+  return unit_action_helper(unit_ids, [cb](auto units) {
+    std::for_each(units.begin(), units.end(), cb);
+  });
+}
+
+/**
+ * Adds an action to @c menu with the given @c text, applying @c cb to the
+ * units listed in @c unit_ids. The menu item is automatically disabled if
+ * the client cannot issue orders.
+ */
+template <class Callback>
+void add_units_action(QMenu *menu, const QString &text,
+                      const std::vector<int> &unit_ids, bool enabled,
+                      Callback &&cb)
+{
+  auto action = menu->addAction(text, unit_action_helper(unit_ids, cb));
+  action->setEnabled(enabled && can_client_issue_orders());
+}
+
+/**
+ * Callback to activate units.
+ */
+void activate_callback(const std::vector<unit *> &units)
+{
+  unit_focus_set(nullptr); // Clear
+  for (const auto unit : units) {
+    unit_focus_add(unit);
+  }
+
+  if (!units.empty()) {
+    queen()->city_overlay->dont_focus = true;
+    popdown_city_dialog();
+  }
+}
+
+/**
+ * Callback to load units into transports.
+ */
+void load_callback(const std::vector<unit *> &units)
+{
+  for (const auto unit : units) {
+    request_transport(unit, unit_tile(unit));
+  }
+}
+
+} // anonymous namespace
+
+/**
+ * Adds a small set of common unit actions to a menu. The menu items will
+ * operate on the given units.
+ */
+void add_quick_unit_actions(QMenu *menu, const std::vector<unit *> &units)
+{
+  // Get unit IDs (don't store pointers that could be deleted)
+  std::vector<int> unit_ids;
+  std::transform(units.begin(), units.end(), std::back_inserter(unit_ids),
+                 [](auto u) { return u->id; });
+
+  add_units_action(menu, _("Activate Unit"), unit_ids, true,
+                   activate_callback);
+
+  add_units_action(menu, _("Sentry Unit"), unit_ids,
+                   can_units_do_activity(units, ACTIVITY_SENTRY),
+                   request_unit_sentry);
+
+  add_units_action(menu, action_id_name_translation(ACTION_FORTIFY),
+                   unit_ids,
+                   units_can_do_action(units, ACTION_FORTIFY, true),
+                   request_unit_fortify);
+
+  add_units_action(menu, action_id_name_translation(ACTION_DISBAND_UNIT),
+                   unit_ids,
+                   units_can_do_action(units, ACTION_DISBAND_UNIT, true),
+                   popup_disband_dialog);
+
+  add_units_action(menu, action_id_name_translation(ACTION_HOME_CITY),
+                   unit_ids,
+                   units_can_do_action(units, ACTION_HOME_CITY, true),
+                   request_unit_change_homecity);
+
+  add_units_action(menu, action_id_name_translation(ACTION_TRANSPORT_BOARD),
+                   unit_ids, units_can_load(units), load_callback);
+
+  add_units_action(menu, action_id_name_translation(ACTION_TRANSPORT_ALIGHT),
+                   unit_ids, units_can_unload(units), request_unit_unload);
+
+  add_units_action(menu, action_id_name_translation(ACTION_TRANSPORT_UNLOAD),
+                   unit_ids, units_are_occupied(units),
+                   request_unit_unload_all);
+
+  add_units_action(menu, action_id_name_translation(ACTION_UPGRADE_UNIT),
+                   unit_ids, units_can_upgrade(units), popup_upgrade_dialog);
+}
+
+} // namespace freeciv

--- a/client/utils/unit_quick_menu.h
+++ b/client/utils/unit_quick_menu.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include <vector>
+
+class QMenu;
+
+struct unit;
+
+namespace freeciv {
+
+void add_quick_unit_actions(QMenu *menu, const std::vector<unit *> &units);
+
+} // namespace freeciv

--- a/client/widgets/city/upkeep_widget.cpp
+++ b/client/widgets/city/upkeep_widget.cpp
@@ -39,7 +39,8 @@ namespace freeciv {
  */
 
 namespace {
-constexpr auto BuildingRole = Qt::UserRole + 1; ///< Data is an improvement id
+constexpr auto BuildingRole =
+    Qt::UserRole + 1;                       ///< Data is an improvement id
 constexpr auto UnitRole = Qt::UserRole + 2; ///< Data is a unit id
 } // namespace
 

--- a/client/widgets/city/upkeep_widget.cpp
+++ b/client/widgets/city/upkeep_widget.cpp
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "upkeep_widget.h"
+
+// common
+#include "game.h"
+
+// client
+#include "client_main.h"
+#include "climisc.h"
+#include "mapview_common.h"
+#include "text.h"
+#include "tilespec.h"
+#include "tooltips.h"
+
+#include <QPainter>
+
+namespace freeciv {
+
+/**
+ * \class upkeep_widget
+ *
+ * Displays the list of items supported by a city (improvements and units).
+ */
+
+/**
+ * Constructor
+ */
+upkeep_widget::upkeep_widget(QWidget *parent)
+    : QListView(parent), m_model(new QStandardItemModel(this))
+{
+  setModel(m_model);
+
+  setEditTriggers(NoEditTriggers);
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  setSelectionMode(NoSelection);
+  setSizeAdjustPolicy(AdjustToContents);
+  setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+  setVerticalScrollMode(ScrollPerPixel);
+}
+
+/**
+ * Updates the widget from the city.
+ */
+void upkeep_widget::refresh()
+{
+  m_model->clear();
+  const auto city = game_city_by_number(m_city);
+  if (!city) {
+    return;
+  }
+
+  // We assume that improvement icons are at most as wide as the city sprite
+  // Otherwise they will be cropped.
+  const auto icon_width = tileset_unit_width(get_tileset());
+
+  // Improvements and wonders
+  {
+    universal targets[MAX_NUM_PRODUCTION_TARGETS];
+    const auto targets_used = collect_already_built_targets(targets, city);
+
+    item items[MAX_NUM_PRODUCTION_TARGETS];
+    name_and_sort_items(targets, targets_used, items, false, city);
+
+    for (int i = 0; i < targets_used; i++) {
+      const auto *building = items[i].item.value.building;
+      const auto &sprite = *get_building_sprite(tileset, building);
+
+      // Center the sprite
+      auto rect = QRect(QPoint(), sprite.size());
+      rect.moveCenter(QPoint(icon_width / 2, sprite.height() / 2));
+
+      QPixmap pixmap(icon_width, sprite.height());
+      pixmap.fill(Qt::transparent);
+      QPainter p(&pixmap);
+      p.drawPixmap(rect, sprite);
+      p.end();
+
+      auto item = new QStandardItem;
+      item->setData(pixmap, Qt::DecorationRole);
+      item->setEditable(false);
+      item->setToolTip(
+          get_tooltip_improvement(building, city, true).trimmed());
+      m_model->appendRow(item);
+    }
+  }
+
+  // Units
+  {
+    const bool playing = (client.conn.playing == nullptr
+                          || city_owner(city) == client.conn.playing);
+    const auto units =
+        playing ? city->units_supported : city->client.info_units_supported;
+
+    unit_list_iterate(units, unit)
+    {
+      auto pixmap = QPixmap(icon_width,
+                            tileset_unit_with_upkeep_height(get_tileset()));
+      pixmap.fill(Qt::transparent);
+      put_unit(unit, &pixmap, 0, 0);
+
+      auto free_unhappy = get_city_bonus(city, EFT_MAKE_CONTENT_MIL);
+      const auto happy_cost = city_unit_unhappiness(unit, &free_unhappy);
+      put_unit_city_overlays(unit, &pixmap, 0,
+                             tileset_unit_layout_offset_y(get_tileset()),
+                             unit->upkeep, happy_cost);
+
+      auto *item = new QStandardItem();
+      item->setData(pixmap, Qt::DecorationRole);
+      item->setEditable(false);
+      item->setToolTip(unit_description(unit));
+      m_model->appendRow(item);
+    }
+    unit_list_iterate_end;
+  }
+}
+
+/**
+ * Changes the city displayed by this widget
+ */
+void upkeep_widget::set_city(int city_id)
+{
+  if (city_id != m_city) {
+    m_city = city_id;
+    refresh();
+  }
+}
+
+/**
+ * Reimplemented to provide a meaningful size hint.
+ */
+QSize upkeep_widget::viewportSizeHint() const
+{
+  int height = 0;
+  for (int i = 0; i < m_model->rowCount(); ++i) {
+    height += sizeHintForRow(i);
+  }
+  // The 6 extra pixels seem to come from the style
+  return QSize(6 + sizeHintForColumn(0), height);
+}
+
+/**
+ * Reimplemented to allow for tiny tilesets.
+ */
+QSize upkeep_widget::minimumSizeHint() const { return QSize(0, 0); }
+
+/**
+ * Reimplemented protected function.
+ */
+bool upkeep_widget::event(QEvent *event)
+{
+  if (event->type() == TilesetChanged) {
+    refresh();
+    return true;
+  }
+  return QListView::event(event);
+}
+
+} // namespace freeciv

--- a/client/widgets/city/upkeep_widget.cpp
+++ b/client/widgets/city/upkeep_widget.cpp
@@ -24,7 +24,6 @@
 #include <QContextMenuEvent>
 #include <QMenu>
 #include <QPainter>
-#include <qabstractitemview.h>
 
 namespace freeciv {
 

--- a/client/widgets/city/upkeep_widget.cpp
+++ b/client/widgets/city/upkeep_widget.cpp
@@ -7,6 +7,7 @@
 #include "upkeep_widget.h"
 
 // common
+#include "fc_types.h"
 #include "game.h"
 
 // client
@@ -21,8 +22,9 @@
 #include "utils/improvement_seller.h"
 
 #include <QContextMenuEvent>
-#include <QPainter>
 #include <QMenu>
+#include <QPainter>
+#include <qabstractitemview.h>
 
 namespace freeciv {
 
@@ -51,6 +53,9 @@ upkeep_widget::upkeep_widget(QWidget *parent)
   setSizeAdjustPolicy(AdjustToContents);
   setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
   setVerticalScrollMode(ScrollPerPixel);
+
+  connect(this, &QAbstractItemView::doubleClicked, this,
+          &upkeep_widget::item_double_clicked);
 }
 
 /**
@@ -205,6 +210,25 @@ bool upkeep_widget::event(QEvent *event)
     return true;
   }
   return QListView::event(event);
+}
+
+/**
+ * Called when an item is double clicked. Sells improvements and activates
+ * units.
+ */
+void upkeep_widget::item_double_clicked(const QModelIndex &index)
+{
+  const auto item = m_model->itemFromIndex(index);
+  if (!item) {
+    return;
+  }
+
+  if (const auto data = item->data(BuildingRole); data.isValid()) {
+    auto seller = improvement_seller(window(), m_city, data.toInt());
+    seller();
+  } else if (const auto data = item->data(UnitRole); data.isValid()) {
+    // TODO
+  }
 }
 
 } // namespace freeciv

--- a/client/widgets/city/upkeep_widget.h
+++ b/client/widgets/city/upkeep_widget.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include <QListView>
+#include <QStandardItemModel>
+
+namespace freeciv {
+
+class upkeep_widget : public QListView {
+  Q_OBJECT;
+
+public:
+  explicit upkeep_widget(QWidget *parent = nullptr);
+
+  void refresh();
+  void set_city(int city_id);
+
+  QSize viewportSizeHint() const override;
+  QSize minimumSizeHint() const override;
+
+protected:
+  bool event(QEvent *event) override;
+
+private:
+  int m_city = -1;
+  QStandardItemModel *m_model;
+};
+
+} // namespace freeciv

--- a/client/widgets/city/upkeep_widget.h
+++ b/client/widgets/city/upkeep_widget.h
@@ -28,6 +28,9 @@ protected:
   bool event(QEvent *event) override;
 
 private:
+  void item_double_clicked(const QModelIndex &index);
+
+private:
   int m_city = -1;
   QStandardItemModel *m_model;
 };

--- a/client/widgets/city/upkeep_widget.h
+++ b/client/widgets/city/upkeep_widget.h
@@ -24,6 +24,7 @@ public:
   QSize minimumSizeHint() const override;
 
 protected:
+  void contextMenuEvent(QContextMenuEvent *event) override;
   bool event(QEvent *event) override;
 
 private:

--- a/common/improvement.cpp
+++ b/common/improvement.cpp
@@ -1006,7 +1006,7 @@ bool can_city_sell_building(const struct city *pcity,
    (this does not check if such building is in this city)
  */
 enum test_result
-test_player_sell_building_now(struct player *pplayer, struct city *pcity,
+test_player_sell_building_now(struct player *pplayer, const city *pcity,
                               const struct impr_type *pimprove)
 {
   // Check if player can sell anything from this city

--- a/common/improvement.h
+++ b/common/improvement.h
@@ -126,7 +126,7 @@ bool can_sell_building(const struct impr_type *pimprove);
 bool can_city_sell_building(const struct city *pcity,
                             const struct impr_type *pimprove);
 enum test_result
-test_player_sell_building_now(struct player *pplayer, struct city *pcity,
+test_player_sell_building_now(struct player *pplayer, const city *pcity,
                               const struct impr_type *pimprove);
 
 const struct impr_type *


### PR DESCRIPTION
This PR introduces a unified widget to show everything supported by a city: improvements and units. It adopts a purely vertical layout that should be easy to scroll. All items respond to double click and right click. Eventually this widget would be added to a side of the city screen with as much height as possible. I want to add the widget to master early to gather feedback, so this PR adds it to the left of the 3.0 city screen layout.

Some infrastructure work for better tileset changing support is also done in this PR. I also started using a more structured folder layout with #1097 in mind.

![image](https://user-images.githubusercontent.com/22327575/210668256-04cf8f2a-5647-4c94-85e1-a0c0e7553a4a.png)
