### PR TITLE
Add a city icon to the city dialog

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -134,8 +134,10 @@ target_sources(
   widgetdecorations.cpp
   unithudselector.cpp
 
+  tileset/drawn_sprite.cpp
   utils/improvement_seller.cpp
   utils/unit_quick_menu.cpp
+  widgets/city/city_icon_widget.cpp
   widgets/city/upkeep_widget.cpp
 
   # Generated

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1878,9 +1878,11 @@ void city_dialog::refresh()
     update_nation_table();
     update_cma_tab();
     update_disabled();
+    ui.icon->set_city(pcity->id);
     ui.upkeep->set_city(pcity->id);
   } else {
     popdown_city_dialog();
+    ui.icon->set_city(-1);
     ui.upkeep->set_city(-1);
   }
 

--- a/client/citydlg.ui
+++ b/client/citydlg.ui
@@ -19,10 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
-   <property name="spacing">
-    <number>24</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout_3">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -35,10 +32,10 @@
    <property name="bottomMargin">
     <number>24</number>
    </property>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1">
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="1,0,1">
      <item>
-      <spacer name="horizontalSpacer_3">
+      <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -51,105 +48,51 @@
       </spacer>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="1">
-         <widget class="QPushButton" name="lcity_name">
+      <widget class="QGroupBox" name="groupBox_3">
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="QLabel" name="curr_units">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="text">
-           <string>PushButton</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="city_label" name="citizens_label">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>citizens</string>
+           <string>TextLabel</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="0" column="3" rowspan="2">
-         <widget class="QPushButton" name="bclose">
+        <item>
+         <widget class="unit_list_widget" name="present_units_list">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string/>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
-          <property name="shortcut">
-           <string>Esc</string>
+          <property name="flow">
+           <enum>QListView::LeftToRight</enum>
           </property>
-          <property name="flat">
-           <bool>true</bool>
+          <property name="resizeMode">
+           <enum>QListView::Adjust</enum>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="2" rowspan="2">
-         <widget class="QPushButton" name="next_city_but">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="shortcut">
-           <string>Right</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
+          <property name="viewMode">
+           <enum>QListView::IconMode</enum>
           </property>
          </widget>
-        </item>
-        <item row="0" column="0" rowspan="2">
-         <widget class="QPushButton" name="prev_city_but">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="shortcut">
-           <string>Left</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="cityIconInfoLabel" name="info_icon_label" native="true"/>
         </item>
        </layout>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_6">
+      <spacer name="horizontalSpacer_4">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -163,11 +106,8 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="freeciv::upkeep_widget" name="upkeep"/>
-     </item>
      <item>
       <spacer name="horizontalSpacer_7">
        <property name="orientation">
@@ -566,7 +506,7 @@
                  <x>0</x>
                  <y>0</y>
                  <width>292</width>
-                 <height>824</height>
+                 <height>860</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -872,10 +812,10 @@
      </item>
     </layout>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="1,0,1">
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1">
      <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -888,51 +828,105 @@
       </spacer>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_3">
-       <layout class="QVBoxLayout" name="verticalLayout_5">
-        <item>
-         <widget class="QLabel" name="curr_units">
+      <widget class="QGroupBox" name="groupBox">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="1">
+         <widget class="QPushButton" name="lcity_name">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string>PushButton</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          <property name="flat">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="unit_list_widget" name="present_units_list">
+        <item row="1" column="1">
+         <widget class="city_label" name="citizens_label">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>citizens</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3" rowspan="2">
+         <widget class="QPushButton" name="bclose">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="selectionMode">
-           <enum>QAbstractItemView::ExtendedSelection</enum>
+          <property name="text">
+           <string/>
           </property>
-          <property name="flow">
-           <enum>QListView::LeftToRight</enum>
+          <property name="shortcut">
+           <string>Esc</string>
           </property>
-          <property name="resizeMode">
-           <enum>QListView::Adjust</enum>
-          </property>
-          <property name="viewMode">
-           <enum>QListView::IconMode</enum>
+          <property name="flat">
+           <bool>true</bool>
           </property>
          </widget>
+        </item>
+        <item row="0" column="2" rowspan="2">
+         <widget class="QPushButton" name="next_city_but">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="shortcut">
+           <string>Right</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" rowspan="2">
+         <widget class="QPushButton" name="prev_city_but">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="shortcut">
+           <string>Left</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="cityIconInfoLabel" name="info_icon_label" native="true"/>
         </item>
        </layout>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_4">
+      <spacer name="horizontalSpacer_6">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -945,6 +939,12 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="freeciv::city_icon_widget" name="icon" native="true"/>
+   </item>
+   <item row="1" column="0" rowspan="2">
+    <widget class="freeciv::upkeep_widget" name="upkeep"/>
    </item>
   </layout>
  </widget>
@@ -992,6 +992,12 @@
    <class>freeciv::upkeep_widget</class>
    <extends>QListView</extends>
    <header>widgets/city/upkeep_widget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>freeciv::city_icon_widget</class>
+   <extends>QWidget</extends>
+   <header>widgets/city/city_icon_widget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/client/layer.cpp
+++ b/client/layer.cpp
@@ -17,14 +17,6 @@
 #include "layer.h"
 #include "log.h"
 
-drawn_sprite::drawn_sprite(const struct tileset *ts, const QPixmap *sprite,
-                           bool foggable, int offset_x, int offset_y)
-    : sprite(sprite), foggable(foggable && tileset_use_hard_coded_fog(ts)),
-      offset_x(offset_x), offset_y(offset_y)
-{
-  fc_assert(sprite);
-}
-
 namespace freeciv {
 
 std::vector<drawn_sprite>

--- a/client/layer.h
+++ b/client/layer.h
@@ -12,6 +12,8 @@
       \____/        ********************************************************/
 #pragma once
 
+#include "tileset/drawn_sprite.h"
+
 // Forward declarations
 class QPixmap;
 
@@ -43,18 +45,6 @@ struct tile_edge {
 struct tile_corner {
 #define NUM_CORNER_TILES 4
   const struct tile *tile[NUM_CORNER_TILES];
-};
-
-struct drawn_sprite {
-  explicit drawn_sprite(const tileset *ts, const QPixmap *sprite,
-                        bool foggable = true, int offset_x = 0,
-                        int offset_y = 0);
-  drawn_sprite(const drawn_sprite &other) = default;
-  drawn_sprite(drawn_sprite &&other) = default;
-
-  const QPixmap *sprite;
-  bool foggable;          // Set to FALSE for sprites that are never fogged.
-  int offset_x, offset_y; // offset from tile origin
 };
 
 /* Items on the mapview are drawn in layers.  Each entry below represents

--- a/client/tileset/drawn_sprite.cpp
+++ b/client/tileset/drawn_sprite.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Freeciv21 contributors
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "drawn_sprite.h"
+
+#include "tilespec.h"
+
+#include <QPixmap>
+#include <QRect>
+
+/**
+ * Instantiates a drawn sprite, ensuring that it's never null.
+ */
+drawn_sprite::drawn_sprite(const struct tileset *ts, const QPixmap *sprite,
+                           bool foggable, int offset_x, int offset_y)
+    : sprite(sprite), foggable(foggable && tileset_use_hard_coded_fog(ts)),
+      offset_x(offset_x), offset_y(offset_y)
+{
+  fc_assert(sprite);
+}
+
+/**
+ * Calculates the bounding rectangle of the given sprite array.
+ */
+QRect sprite_array_bounds(const std::vector<drawn_sprite> &sprs)
+{
+  QRect bounds;
+  for (const auto &sprite : sprs) {
+    bounds |= QRect(QPoint(sprite.offset_x, sprite.offset_y),
+                    sprite.sprite->size());
+  }
+  return bounds;
+}

--- a/client/tileset/drawn_sprite.h
+++ b/client/tileset/drawn_sprite.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Freeciv21 contributors
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include <vector>
+
+class QPixmap;
+class QRect;
+
+struct tileset;
+
+struct drawn_sprite {
+  explicit drawn_sprite(const tileset *ts, const QPixmap *sprite,
+                        bool foggable = true, int offset_x = 0,
+                        int offset_y = 0);
+  drawn_sprite(const drawn_sprite &other) = default;
+  drawn_sprite(drawn_sprite &&other) = default;
+
+  const QPixmap *sprite;
+  bool foggable;          // Set to FALSE for sprites that are never fogged.
+  int offset_x, offset_y; // offset from tile origin
+};
+
+QRect sprite_array_bounds(const std::vector<drawn_sprite> &sprs);

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -4641,48 +4641,8 @@ fill_sprite_array(struct tileset *t, enum mapview_layer layer,
                           FULL_TILE_X_OFFSET + t->city_flag_offset_x,
                           FULL_TILE_Y_OFFSET + t->city_flag_offset_y);
       }
-      /* For iso-view the city.wall graphics include the full city, whereas
-       * for non-iso view they are an overlay on top of the base city
-       * graphic. */
-      if (t->type == TS_OVERHEAD || pcity->client.walls <= 0) {
-        sprs.emplace_back(t, get_city_sprite(t->sprites.city.tile, pcity),
-                          true, FULL_TILE_X_OFFSET + t->city_offset_x,
-                          FULL_TILE_Y_OFFSET + t->city_offset_y);
-      }
-      if (t->type == TS_ISOMETRIC && pcity->client.walls > 0) {
-        auto spr = get_city_sprite(
-            t->sprites.city.wall[pcity->client.walls - 1], pcity);
-        if (spr == nullptr) {
-          spr = get_city_sprite(t->sprites.city.single_wall, pcity);
-        }
-
-        if (spr != nullptr) {
-          sprs.emplace_back(t, spr, true,
-                            FULL_TILE_X_OFFSET + t->city_offset_x,
-                            FULL_TILE_Y_OFFSET + t->city_offset_y);
-        }
-      }
-      if (!citybar_painter::current()->has_units()
-          && pcity->client.occupied) {
-        sprs.emplace_back(t,
-                          get_city_sprite(t->sprites.city.occupied, pcity),
-                          true, FULL_TILE_X_OFFSET + t->occupied_offset_x,
-                          FULL_TILE_Y_OFFSET + t->occupied_offset_y);
-      }
-      if (t->type == TS_OVERHEAD && pcity->client.walls > 0) {
-        auto spr = get_city_sprite(
-            t->sprites.city.wall[pcity->client.walls - 1], pcity);
-        if (spr == nullptr) {
-          spr = get_city_sprite(t->sprites.city.single_wall, pcity);
-        }
-
-        if (spr != nullptr) {
-          ADD_SPRITE_FULL(spr);
-        }
-      }
-      if (pcity->client.unhappy) {
-        ADD_SPRITE_FULL(t->sprites.city.disorder);
-      }
+      bool occupied_graphic = !citybar_painter::current()->has_units();
+      fill_basic_city_sprite_array(t, sprs, pcity, occupied_graphic);
     }
     break;
 
@@ -5438,6 +5398,55 @@ void tileset_init(struct tileset *t)
   player_slots_iterate_end;
 
   t->max_upkeep_height = 0;
+}
+
+/**
+ * Fills @c sprs with sprites to draw a city. The flag and city size are not
+ * included. The occupied graphic is optional.
+ */
+void fill_basic_city_sprite_array(const struct tileset *t,
+                                  std::vector<drawn_sprite> &sprs,
+                                  const city *pcity, bool occupied_graphic)
+{
+  /* For iso-view the city.wall graphics include the full city, whereas
+   * for non-iso view they are an overlay on top of the base city
+   * graphic. */
+  if (t->type == TS_OVERHEAD || pcity->client.walls <= 0) {
+    sprs.emplace_back(t, get_city_sprite(t->sprites.city.tile, pcity), true,
+                      FULL_TILE_X_OFFSET + t->city_offset_x,
+                      FULL_TILE_Y_OFFSET + t->city_offset_y);
+  }
+  if (t->type == TS_ISOMETRIC && pcity->client.walls > 0) {
+    auto spr = get_city_sprite(t->sprites.city.wall[pcity->client.walls - 1],
+                               pcity);
+    if (spr == nullptr) {
+      spr = get_city_sprite(t->sprites.city.single_wall, pcity);
+    }
+
+    if (spr != nullptr) {
+      sprs.emplace_back(t, spr, true, FULL_TILE_X_OFFSET + t->city_offset_x,
+                        FULL_TILE_Y_OFFSET + t->city_offset_y);
+    }
+  }
+  if (occupied_graphic && pcity->client.occupied) {
+    sprs.emplace_back(t, get_city_sprite(t->sprites.city.occupied, pcity),
+                      true, FULL_TILE_X_OFFSET + t->occupied_offset_x,
+                      FULL_TILE_Y_OFFSET + t->occupied_offset_y);
+  }
+  if (t->type == TS_OVERHEAD && pcity->client.walls > 0) {
+    auto spr = get_city_sprite(t->sprites.city.wall[pcity->client.walls - 1],
+                               pcity);
+    if (spr == nullptr) {
+      spr = get_city_sprite(t->sprites.city.single_wall, pcity);
+    }
+
+    if (spr != nullptr) {
+      ADD_SPRITE_FULL(spr);
+    }
+  }
+  if (pcity->client.unhappy) {
+    ADD_SPRITE_FULL(t->sprites.city.disorder);
+  }
 }
 
 /**

--- a/client/tilespec.h
+++ b/client/tilespec.h
@@ -157,6 +157,10 @@ std::vector<drawn_sprite>
 fill_basic_terrain_layer_sprite_array(struct tileset *t, int layer,
                                       struct terrain *pterrain);
 
+void fill_basic_city_sprite_array(const struct tileset *t,
+                                  std::vector<drawn_sprite> &sprs,
+                                  const city *pcity, bool occupied_graphic);
+
 int get_focus_unit_toggle_timeout(const struct tileset *t);
 void reset_focus_unit_state(struct tileset *t);
 void focus_unit_in_combat(struct tileset *t);

--- a/client/widgets/city/city_icon_widget.cpp
+++ b/client/widgets/city/city_icon_widget.cpp
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#include "city_icon_widget.h"
+
+// client
+#include "game.h"
+#include "tilespec.h"
+
+#include <QPainter>
+
+namespace freeciv {
+
+/**
+ * \class city_icon_widget
+ *
+ * Displays an icon representing a city. No more functionality.
+ */
+
+/**
+ * Constructor
+ */
+city_icon_widget::city_icon_widget(QWidget *parent)
+{
+  setAutoFillBackground(true);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+}
+
+/**
+ * Changes the city displayed by this widget
+ */
+void city_icon_widget::set_city(int city_id)
+{
+  if (city_id != m_city) {
+    m_city = city_id;
+    update();
+  }
+}
+
+/**
+ * Reimplemented to allow for tiny tileset.
+ */
+QSize city_icon_widget::minimumSizeHint() const { return QSize(0, 0); }
+
+/**
+ * Reimplemented to pick the size from the tileset.
+ */
+QSize city_icon_widget::sizeHint() const
+{
+  auto size =
+      std::max(tileset_tile_width(tileset), tileset_tile_height(tileset));
+
+  if (auto city = game_city_by_number(m_city); city) {
+    std::vector<drawn_sprite> sprs;
+    fill_basic_city_sprite_array(tileset, sprs, city, true);
+    const auto bounds = sprite_array_bounds(sprs);
+    size = std::max(bounds.width(), bounds.height());
+  }
+
+  return QSize(size, size); // Square
+}
+
+/**
+ * Reimplemented to draw the widget.
+ */
+void city_icon_widget::paintEvent(QPaintEvent *event)
+{
+  Q_UNUSED(event);
+
+  auto city = game_city_by_number(m_city);
+  if (!city) {
+    return;
+  }
+
+  std::vector<drawn_sprite> sprs;
+  // Keeping the occupied flag disabled because it looks bad with amplio2
+  fill_basic_city_sprite_array(tileset, sprs, city, false);
+
+  // Center the sprites
+  auto bounds = sprite_array_bounds(sprs);
+  const auto origin = bounds.topLeft();
+  bounds.moveCenter(QPoint(width() / 2, height() / 2));
+
+  QPainter p(this);
+  p.translate(bounds.topLeft() - origin);
+
+  for (const auto sprite : sprs) {
+    p.drawPixmap(QPointF(sprite.offset_x, sprite.offset_y), *sprite.sprite);
+  }
+}
+
+/**
+ * Reimplemented to handle tileset changes.
+ */
+bool city_icon_widget::event(QEvent *event)
+{
+  if (event->type() == TilesetChanged) {
+    update();
+    return true;
+  }
+  return QWidget::event(event);
+}
+
+} // namespace freeciv

--- a/client/widgets/city/city_icon_widget.h
+++ b/client/widgets/city/city_icon_widget.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Louis Moureaux <m_louis30@yahoo.com>
+ *
+ * SPDX-License-Identifier: GPLv3-or-later
+ */
+
+#pragma once
+
+#include <QWidget>
+
+namespace freeciv {
+
+class city_icon_widget : public QWidget {
+  Q_OBJECT;
+
+public:
+  explicit city_icon_widget(QWidget *parent = nullptr);
+
+  void set_city(int city_id);
+
+  QSize sizeHint() const override;
+  QSize minimumSizeHint() const override;
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+  bool event(QEvent *event) override;
+
+private:
+  int m_city = -1;
+};
+
+} // namespace freeciv


### PR DESCRIPTION
No interaction, this is purely decoration. The PR is a bit big (for the functionality) because I had to extract the sprites from the tileset code (getting the walls correct would be surprisingly hard otherwise). I also modified the city dialog layout.

In the same spirit as #1695, the layout is preliminary so we can test the widget IRL.

See #1591.

![image](https://user-images.githubusercontent.com/22327575/210694022-9bb9df94-b8f5-4921-91aa-421c246ee4b4.png)
