### PR TITLE
Remove unused variable

### DIFF
--- a/client/minimap_panel.h
+++ b/client/minimap_panel.h
@@ -44,7 +44,7 @@ private:
   Ui::minimap_panel ui;
 
   QAction *m_show_relief, *m_show_borders, *m_show_borders_ocean,
-      *m_show_cities, *m_show_units, *m_show_fog;
+      *m_show_cities, *m_show_fog;
 };
 
 void update_timeout_label();


### PR DESCRIPTION
Coverity warned about it not being initialized, it's in fact never used.

Closes #1701.
Backport candidate.