### PR TITLE
Mention when units are unbribeable

### DIFF
--- a/client/text.cpp
+++ b/client/text.cpp
@@ -481,8 +481,10 @@ const QString popup_info_text(struct tile *ptile)
     }
     str += qendl();
 
-    if (unit_owner(punit) == client_player()
-        || client_is_global_observer()) {
+    if (!is_action_possible_on_unit(ACTION_SPY_BRIBE_UNIT, punit)) {
+      str += _("Bribing not possible.") + qendl();
+    } else if (unit_owner(punit) == client_player()
+               || client_is_global_observer()) {
       // Show bribe cost for own units.
       str += QString(_("Probable bribe cost: %1"))
                  .arg(QString::number(unit_bribe_cost(punit, nullptr)))

--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -5746,6 +5746,18 @@ bool is_action_possible_on_city(action_id act_id,
 }
 
 /**
+ * Checks if there is any hopes that the action is possible against the
+ * target unit (by chacking the target_reqs).
+ */
+bool is_action_possible_on_unit(action_id act_id, const unit *target_unit)
+{
+  return is_target_possible(act_id, nullptr, unit_owner(target_unit),
+                            unit_home(target_unit), nullptr,
+                            unit_tile(target_unit), target_unit,
+                            unit_type_get(target_unit), nullptr, nullptr);
+}
+
+/**
    Returns TRUE if the wanted action (as far as the player knows) can be
    performed right now by the specified actor unit if an approriate target
    is provided.

--- a/common/actions.h
+++ b/common/actions.h
@@ -760,6 +760,8 @@ bool is_action_possible_on_city(action_id act_id,
                                 const struct player *actor_player,
                                 const struct city *target_city);
 
+bool is_action_possible_on_unit(action_id act_id, const unit *target_unit);
+
 bool action_maybe_possible_actor_unit(const action_id wanted_action,
                                       const struct unit *actor_unit);
 


### PR DESCRIPTION
This uses the target_reqs for action "Bribe Unit", so unit stacks are always listed as unbribeable.

Closes #1677.