### PR TITLE
Reset the internal password when the user connects

### DIFF
--- a/client/page_network.cpp
+++ b/client/page_network.cpp
@@ -415,6 +415,9 @@ void page_network::handle_authentication_req(enum authentication_type type,
 
       sz_strlcpy(reply.password, qUtf8Printable(client_url().password()));
       send_packet_authentication_reply(&client.conn, &reply);
+
+      // Don't store the password
+      client_url().setPassword(QString());
       return;
     } else {
       set_connection_state(ENTER_PASSWORD_TYPE);

--- a/server/connecthand.h
+++ b/server/connecthand.h
@@ -17,8 +17,6 @@
 
 struct connection;
 struct conn_list;
-struct packet_authentication_reply;
-struct packet_login_request;
 struct packet_server_join_req;
 
 void conn_set_access(struct connection *pconn, enum cmdlevel new_level,


### PR DESCRIPTION
The server stores a password in memory. If set, this password is sent to the server automatically when requested. This is true for *any* server, so setting the password, connecting to the correct server, disconnecting and going to another server would send the same password.

Prevent this by wiping the password when the user attempts to connect.

Looking at this code in the context of #785, but this is unlikely to fix it.