### PR TITLE
Set the connection state before starting the metaserver scan

### DIFF
--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -247,9 +247,9 @@ void fc_client::switch_page(int new_pg)
     break;
   case PAGE_NETWORK:
     qobject_cast<page_network *>(pages[PAGE_NETWORK])
-        ->update_network_lists();
-    qobject_cast<page_network *>(pages[PAGE_NETWORK])
         ->set_connection_state(LOGIN_TYPE);
+    qobject_cast<page_network *>(pages[PAGE_NETWORK])
+        ->update_network_lists();
     break;
   case PAGE_LOADING:
   case PAGE_COUNT:


### PR DESCRIPTION
Setting the connection state resets, among others, the password field. The metaserver scan runs synchronously with its own nested event loop.

If a user was fast enough to start connecting before the scan was finished, the password field would be reset when the scan finished.

Closes #785.
This is the patch proposed by @daavko.