### PR TITLE
Small hex tileset improvements

### DIFF
--- a/client/layer_terrain.cpp
+++ b/client/layer_terrain.cpp
@@ -933,8 +933,9 @@ void layer_terrain::fill_terrain_sprite_array(
           // Not matching against this terrain, pretend current terrain
           // continues (it's always at match index 0)
           indices[j] = 0;
+        } else {
+          indices[j] = std::distance(info.matches_with.begin(), it);
         }
-        indices[j] = std::distance(info.matches_with.begin(), it);
       }
 
       // Pick the sprite

--- a/client/tilespec.cpp
+++ b/client/tilespec.cpp
@@ -2937,6 +2937,7 @@ static bool load_river_sprites(struct tileset *t,
                                struct river_sprites *store,
                                const char *tag_pfx)
 {
+  bool ok = true;
   int i;
   QString buffer;
 
@@ -2945,7 +2946,9 @@ static bool load_river_sprites(struct tileset *t,
         QStringLiteral("%1_s_%2").arg(tag_pfx, cardinal_index_str(t, i));
     store->spec[i] = load_sprite(t, buffer);
     if (store->spec[i] == nullptr) {
-      return false;
+      qCritical("Missing \"%s\" for \"%s\".", qUtf8Printable(buffer),
+                tag_pfx);
+      ok = false;
     }
   }
 
@@ -2957,11 +2960,11 @@ static bool load_river_sprites(struct tileset *t,
     if (store->outlet[i] == nullptr) {
       qCritical("Missing \"%s\" for \"%s\".", qUtf8Printable(buffer),
                 tag_pfx);
-      return false;
+      ok = false;
     }
   }
 
-  return true;
+  return ok;
 }
 
 /**

--- a/docs/Modding/Tilesets/terrain.rst
+++ b/docs/Modding/Tilesets/terrain.rst
@@ -437,12 +437,14 @@ Each land terrain must be declared within the ``land`` matching group, while sea
     num_layers = 1
     layer0_match_type = "water"
     layer0_match_with = "land", "water"
+    layer0_sprite_type = "hex_corner"
 
     [tile_plains]
     tag = "plains"
     num_layers = 1
     layer0_match_type = "land"
     layer0_match_with = "land", "water"
+    layer0_sprite_type = "hex_corner"
 
     ; etc
 


### PR DESCRIPTION
Three small changes in one PR:

* More logging when loading broken tilesets
* Crash fix with `hex_corner` (stupid control flow). AFAIK `hex_corner` is only used in `project-vectron`
* Doc fix for `hex_corner`

Would like to backport.