### PR TITLE
Use SSL v3 libraries for MSYS2

### DIFF
--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -55,15 +55,15 @@ if(MSYS OR MINGW)
   if("$ENV{MSYSTEM}" STREQUAL "MINGW32")
     install(
       FILES
-      ${MINGW_PATH}/libcrypto-1_1.dll
-      ${MINGW_PATH}/libssl-1_1.dll
+      ${MINGW_PATH}/libcrypto-3.dll
+      ${MINGW_PATH}/libssl-3.dll
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT freeciv21)
   else()
     install(
       FILES
-      ${MINGW_PATH}/libcrypto-1_1-x64.dll
-      ${MINGW_PATH}/libssl-1_1-x64.dll
+      ${MINGW_PATH}/libcrypto-3-x64.dll
+      ${MINGW_PATH}/libssl-3-x64.dll
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT freeciv21)
   endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
   "dependencies": [
     "qt5-base",
     "qt5-svg",
+    "openssl",
     "lua",
     {
       "name": "gettext",
@@ -16,12 +17,6 @@
     {
       "name": "readline",
       "platform": "windows"
-    }
-  ],
-  "overrides": [
-    {
-      "name": "openssl",
-      "version-string": "1.1.1l"
     }
   ]
 }


### PR DESCRIPTION
This change will fix the CI. We need upstream MSYS2 team to fix `QSslSocket` so the modpack installer will work.

I will want to push some more commits for vcpkg here too as its related.