### PR TITLE
Make the national budget dialog unique

### DIFF
--- a/client/include/ratesdlg_g.h
+++ b/client/include/ratesdlg_g.h
@@ -10,7 +10,6 @@
 **************************************************************************/
 #pragma once
 
-void popup_rates_dialog();
 void real_multipliers_dialog_update(void *unused);
 
 // Actually defined in update_queue.c

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -2701,7 +2701,7 @@ void mr_menu::load_new_tileset()
 /**
    Action "NATIONAL BUDGET"
  */
-void mr_menu::slot_popup_tax_rates() { popup_rates_dialog(); }
+void mr_menu::slot_popup_tax_rates() { queen()->popup_budget_dialog(); }
 
 /**
    Action "MULTIPLERS RATES"

--- a/client/page_game.h
+++ b/client/page_game.h
@@ -27,6 +27,7 @@ class message_widget;
 class hud_battle_log;
 class gold_widget;
 class goto_dialog;
+class national_budget_dialog;
 class national_budget_widget;
 class top_bar;
 class top_bar_widget;
@@ -65,6 +66,9 @@ public:
   void removeRepoDlg(const QString &str);
   bool isRepoDlgOpen(const QString &str);
   void updateInfoLabel();
+
+  void popup_budget_dialog();
+
   QWidget *game_main_widget;
   fc_game_tab_widget *game_tab_widget;
   top_bar *top_bar_wdg;
@@ -95,6 +99,7 @@ private:
   top_bar_widget *sw_cities;
   gold_widget *sw_economy;
   top_bar_widget *sw_map;
+  national_budget_dialog *budget_dialog;
   national_budget_widget *sw_tax;
 };
 

--- a/client/ratesdlg.h
+++ b/client/ratesdlg.h
@@ -42,6 +42,8 @@ public:
   ~fc_double_edge() override;
   int current_min;
   int current_max;
+
+  void refresh();
   QSize sizeHint() const override;
 
 protected:
@@ -59,12 +61,13 @@ class national_budget_dialog : public qfc_dialog {
 public:
   national_budget_dialog(QWidget *parent = 0);
 
+  void refresh();
+
 private:
   fc_double_edge *fcde;
-private slots:
-  void slot_ok_button_pressed();
-  void slot_cancel_button_pressed();
-  void slot_apply_button_pressed();
+  QLabel *m_info;
+
+  void apply();
 };
 
 /**************************************************************************

--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -456,16 +456,6 @@ void top_bar_show_map()
 void top_bar_finish_turn() { key_end_turn(); }
 
 /**
-   Callback to popup rates dialog
- */
-void top_bar_rates_wdg()
-{
-  if (!client_is_observer()) {
-    popup_rates_dialog();
-  }
-}
-
-/**
    Callback to center on current unit
  */
 void top_bar_center_unit()

--- a/client/top_bar.h
+++ b/client/top_bar.h
@@ -21,7 +21,6 @@ typedef void (*pfcn)();
 void top_bar_center_unit();
 void top_bar_finish_turn();
 void top_bar_indicators_menu();
-void top_bar_rates_wdg();
 void top_bar_right_click_diplomacy();
 void top_bar_right_click_science();
 void top_bar_left_click_science();


### PR DESCRIPTION
Implementing this was somewhat complicated by existing code (throwing one-shot dialogs without a refresh ability). I did some refactoring to get rid of that.

Main behaviour changes:
* The dialog is now shown right under the taxes display instead of under the mouse.
* Some checks done to avoid the dialog going off screen should work better on multi-screen systems.
* The dialog is unique.

Closes #1602.

Will not be backported due to the patch complexity.