### PR TITLE
Make passing a fc21:// URL to the client trigger autoconnect

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -480,6 +480,7 @@ int client_main(int argc, char *argv[])
         qFatal("%s", qPrintable(url.errorString()));
       }
     }
+    auto_connect = true;
   } else if (!positional.isEmpty()) {
     qFatal(_("Too many positional arguments."));
   } else {


### PR DESCRIPTION
When invoking the client by clicking on a fc21 link, the expected behaviour is that it tries and joins the linked-to game. This is only possible if passing a URL implies -a.

Suggest backporting this to `stable`.

Closes #1743.