### PR TITLE
Fix maxconnectionsperhost

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -468,15 +468,16 @@ void server::accept_connections()
       {
         // Use TolerantConversion so one connections from the same address on
         // IPv4 and IPv6 are rejected as well.
-        if (socket->peerAddress().isEqual(
+        if (!socket->peerAddress().isEqual(
                 pconn->sock->peerAddress(),
                 QHostAddress::TolerantConversion)) {
           continue;
         }
         if (++count >= game.server.maxconnectionsperhost) {
-          qDebug("Rejecting new connection from %s: maximum number of "
-                 "connections for this address exceeded (%d).",
-                 qUtf8Printable(remote), game.server.maxconnectionsperhost);
+          qWarning("Rejecting new connection from %s: maximum number of "
+                   "connections for this address exceeded (%d).",
+                   qUtf8Printable(remote),
+                   game.server.maxconnectionsperhost);
 
           success = false;
           socket->deleteLater();


### PR DESCRIPTION
It was doing the exact opposite of the intended behavior, allowing an infinite number of connections from the same host but disallowing any new connection once N players were connected.

Closes #1754.

Also upgrade the rejection message to a warning so it appears in the server logs.

Backport recommended.