### PR TITLE
Fix the terrain alterations table

### DIFF
--- a/data/helpdata.txt
+++ b/data/helpdata.txt
@@ -374,11 +374,9 @@ this usually takes longer than altering. Converting terrain from one type to ano
 way may destroy existing alterations if the new terrain is unsuitable, and will also remove access to \
 special resources if they were specific to the original terrain type.\
 "), _("\
-The requirements for terrain conversion are set by the ruleset. It can be initiated in several ways:\
-"), _("\
- - By issuing \"Irrigate\" or \"Mine\" orders when on terrain unsuitable for tile alterations.\n\
- - By issuing the special \"Transform\" order. This often causes more radical transformations, such as \
-converting a Desert tile to a Plains tile.\
+The requirements for terrain conversion are set by the ruleset. Three orders unit trigger terrain \
+conversions: \"Cultivate\", \"Plant\", and \"Transform\". Not all conversions may be possible from \
+the game start.\
 "), _("\
 In some rulesets, units can even reclaim land from water tiles, and similarly land can be transformed to \
 water, although such radical transformations may require a certain number of surrounding tiles to already be \


### PR DESCRIPTION
The table was showing wrong information since Cultivate was split from Irrigate and Plant was split from Mine. Fix it by displaying only terrain change actions, and simplify the implementation. Irrigate and Mine are no longer included in the summary (adding more columns would take too much space and the overall organization should be improved if another table was to be added).

Closes #1686.