### PR TITLE
Ensure inputfile lines are terminated properly

### DIFF
--- a/utility/inputfile.cpp
+++ b/utility/inputfile.cpp
@@ -312,7 +312,8 @@ static bool at_eol(struct inputfile *inf)
   fc_assert_ret_val(inf_sanity_check(inf), true);
   fc_assert_ret_val(inf->cur_line_pos <= inf->cur_line.length(), true);
 
-  return inf->cur_line_pos >= inf->cur_line.length();
+  // - 1 because of the trailing newline character.
+  return inf->cur_line_pos >= inf->cur_line.length() - 1;
 }
 
 /**
@@ -474,6 +475,7 @@ static bool read_a_line(struct inputfile *inf)
   }
 
   // Normal behavior
+  inf->cur_line += '\n'; // The parsing code needs a termination character.
   inf->cur_line_pos = 0;
   inf->line_num++;
 


### PR DESCRIPTION
The parsing code needs a terminating character to function properly. Make sure it has one (QTextStream strips it when reading a line).

Not having a proper newline had some strange results, the most visible of which was a critical warning on *include lines in spec files. A slightly more subtle issue was that some whitespaces were missing in the help (the ones at the end of a line in the spec files).

Closes #1773.
(not sure the ruleup issue is fixed, but the critical warning definitely is)

Backport recommended.