### PR TITLE
Set resources on player map (FoW map) when loading saved game

### DIFF
--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -6641,6 +6641,21 @@ static void sg_load_player_vision(struct loaddata *loading,
   }
   halfbyte_iterate_extras_end;
 
+  whole_map_iterate(&(wld.map), ptile)
+  {
+    struct player_tile *plrtile = map_get_player_tile(ptile, plr);
+
+    extra_type_by_cause_iterate(EC_RESOURCE, pres)
+    {
+      if (BV_ISSET(plrtile->extras, extra_number(pres))
+          && terrain_has_resource(plrtile->terrain, pres)) {
+        plrtile->resource = pres;
+      }
+    }
+    extra_type_by_cause_iterate_end;
+  }
+  whole_map_iterate_end;
+
   if (game.server.foggedborders) {
     // Load player map (border).
     int x, y;


### PR DESCRIPTION
Fixes the weird issue with resources [seen in LT76Team](https://discord.com/channels/378908274113904641/912500712833974322/1069019470573613147).

Backport recommended.

Testing: load a saved game and check that fogged resources are shown correctly in the middle click popup.