### PR TITLE
Don't refresh the whole map with every change to a city

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1891,8 +1891,6 @@ void city_dialog::refresh()
     ui.upkeep->set_city(-1);
   }
 
-  update_map_canvas_visible();
-
   ui.production_combo_p->blockSignals(false);
   setUpdatesEnabled(true);
 
@@ -2008,6 +2006,15 @@ void city_dialog::update_info_label()
  */
 void city_dialog::setup_ui(struct city *qcity)
 {
+  if (pcity != qcity) {
+    if (pcity) {
+      refresh_city_mapcanvas(pcity, pcity->tile, true);
+    }
+    if (qcity) {
+      refresh_city_mapcanvas(qcity, qcity->tile, true);
+    }
+  }
+
   pcity = qcity;
   ui.production_combo_p->blockSignals(true);
   refresh();


### PR DESCRIPTION
The refresh had been introduced to highlight the correct tiles when switching city from the city dialog. Detect such changes and refresh the relevant working areas only.

This improves performance of city management dramatically when using small tilesets or large windows.

Reported by Corbeau [on Discord](https://discord.com/channels/378908274113904641/912500712833974322/1068120449822765076).

Testing:
* Use a small tileset like Trident (more tiles to refresh)
* Make sure most of the map is explored and visible
* Try to manage citizens in a city
* Notice the reduced latency with the patch

Suggest to backport.