### PR TITLE
Fix highlighting the new city when switching with prev/next

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -2191,8 +2191,7 @@ void city_dialog::get_city(bool next)
         city_list_get(client.conn.playing->cities, (i + k + size) % size);
   }
   queen()->mapview_wdg->center_on_tile(other_pcity->tile);
-  pcity = other_pcity;
-  refresh();
+  setup_ui(other_pcity);
 }
 
 /**


### PR DESCRIPTION
Use the generic setup_ui function instead of duplicating its code in get_city.

See #1788.

Backport recommended.