### PR TITLE
Remove the HAVE_CONFIG_H macro

### DIFF
--- a/ai/default/daicity.cpp
+++ b/ai/default/daicity.cpp
@@ -11,9 +11,6 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 #include <cstring>
 
 // utility

--- a/ai/default/daidiplomacy.cpp
+++ b/ai/default/daidiplomacy.cpp
@@ -9,9 +9,6 @@ received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 #include <cstdarg>
 #include <cstring>
 

--- a/ai/stub/stubai.c
+++ b/ai/stub/stubai.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* common */
 #include "ai.h"

--- a/ai/tex/texai.c
+++ b/ai/tex/texai.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* common */
 #include "ai.h"

--- a/ai/tex/texaicity.c
+++ b/ai/tex/texaicity.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* utility */
 #include "log.h"

--- a/ai/tex/texaimsg.c
+++ b/ai/tex/texaimsg.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* ai/tex */
 #include "texaiplayer.h"

--- a/ai/tex/texaiplayer.c
+++ b/ai/tex/texaiplayer.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* utility */
 #include "log.h"

--- a/ai/tex/texaiworld.c
+++ b/ai/tex/texaiworld.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* common */
 #include "idex.h"

--- a/ai/threaded/taicity.c
+++ b/ai/threaded/taicity.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* utility */
 #include "log.h"

--- a/ai/threaded/taimsg.c
+++ b/ai/threaded/taimsg.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* ai/threaded */
 #include "taiplayer.h"

--- a/ai/threaded/taiplayer.c
+++ b/ai/threaded/taiplayer.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QMutexLocker>
 

--- a/ai/threaded/threadedai.c
+++ b/ai/threaded/threadedai.c
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* common */
 #include "ai.h"

--- a/client/audio/audio.cpp
+++ b/client/audio/audio.cpp
@@ -9,9 +9,7 @@ received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QString>
 #include <QVector>

--- a/client/audio/audio_sdl.cpp
+++ b/client/audio/audio_sdl.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #ifdef FREECIV_MSWINDOWS
 #include <windows.h> // LoadLibrary()

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QString>

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -8,9 +8,7 @@
     a copy of the GNU General Public License along with Freeciv21. If not,
                   see https://www.gnu.org/licenses/.
  */
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QCoreApplication>

--- a/client/luascript/tolua_client.pkg
+++ b/client/luascript/tolua_client.pkg
@@ -15,9 +15,7 @@
   to keep also the old one running.
 *****************************************************************************/
 
-$#ifdef HAVE_CONFIG_H
 $#include <fc_config.h>
-$#endif
 
 /* common/scriptcore */
 $#include "luascript_types.h"

--- a/client/menu.h
+++ b/client/menu.h
@@ -9,9 +9,7 @@
 **************************************************************************/
 #pragma once
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 #include <sys/stat.h>

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QBitArray>
 #include <QDateTime>

--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -9,9 +9,7 @@
                   see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include "servers.h"
 

--- a/client/themes_common.cpp
+++ b/client/themes_common.cpp
@@ -8,8 +8,6 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
   :X:      received a copy of the GNU General Public License along with
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
  */
-#ifdef HAVE_CONFIG_H
-#endif
 
 // utility
 #include "log.h"

--- a/common/ai.cpp
+++ b/common/ai.cpp
@@ -9,9 +9,7 @@ received a copy of the GNU General Public License along with Freeciv21.
                               If not, see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 

--- a/common/aicore/aisupport.cpp
+++ b/common/aicore/aisupport.cpp
@@ -9,9 +9,6 @@
                   see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 // utility
 #include "log.h"
 #include "shared.h"

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -1762,9 +1762,7 @@ void delta_stats_reset(void);
             output_c = fc_open(output_c_name)
 
         output_c.write('''
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <string.h>
 
@@ -1935,9 +1933,7 @@ bool client_handle_packet(enum packet_type type, const void *packet);
         f = fc_open(sys.argv[6])
         f.write('''
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 /* common */
 #include "packets.h"

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -16,9 +16,7 @@
  of gui considerations.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QBitArray>
 #include <QList>

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -17,9 +17,7 @@
   old one running.
 *****************************************************************************/
 
-$#ifdef HAVE_CONFIG_H
 $#include <fc_config.h>
-$#endif
 
 /* common/scriptcore */
 $#include "api_common_utilities.h"

--- a/common/scriptcore/tolua_signal.pkg
+++ b/common/scriptcore/tolua_signal.pkg
@@ -17,9 +17,7 @@
   old one running.
 *****************************************************************************/
 
-$#ifdef HAVE_CONFIG_H
 $#include <fc_config.h>
-$#endif
 
 /* common/scriptcore */
 $#include "api_signal_base.h"

--- a/common/team.cpp
+++ b/common/team.cpp
@@ -10,9 +10,7 @@
                                             https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // utility
 #include "fcintl.h"

--- a/common/tile.cpp
+++ b/common/tile.cpp
@@ -10,9 +10,6 @@
                                             https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 #include <QBitArray>
 // utility
 #include "bitvector.h"

--- a/dependencies/cvercmp/cvercmp.c
+++ b/dependencies/cvercmp/cvercmp.c
@@ -8,10 +8,6 @@
 *                                                        *
 *********************************************************/
 
-#ifdef HAVE_CONFIG_H
-#include <fc_config.h>
-#endif
-
 #include <assert.h>
 #include <ctype.h>
 #include <stdbool.h>

--- a/server/aiiface.cpp
+++ b/server/aiiface.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #ifdef AI_MODULES
 #include <ltdl.h>

--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QString>
 

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 

--- a/server/console.cpp
+++ b/server/console.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstdarg>
 #include <cstdio>

--- a/server/fcdb.cpp
+++ b/server/fcdb.cpp
@@ -9,9 +9,6 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
   :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 // Qt
 #include <QHash>
 #include <QString>

--- a/server/generator/mapgen.cpp
+++ b/server/generator/mapgen.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QBitArray>
 #include <cstdlib>

--- a/server/meta.cpp
+++ b/server/meta.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QEventLoop>

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstdio>
 #include <cstring>

--- a/server/savegame/savegame2.cpp
+++ b/server/savegame/savegame2.cpp
@@ -56,9 +56,7 @@
 
 */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QBitArray>
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -62,9 +62,7 @@
 
 */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QBitArray>
 #include <QSet>

--- a/server/savegame/savemain.cpp
+++ b/server/savegame/savemain.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDir>

--- a/server/scripting/tolua_server.pkg
+++ b/server/scripting/tolua_server.pkg
@@ -17,9 +17,7 @@
   old one running.
 *****************************************************************************/
 
-$#ifdef HAVE_CONFIG_H
 $#include <fc_config.h>
-$#endif
 
 /* common/scriptcore */
 $#include "luascript_types.h"

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -9,9 +9,7 @@
                   see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // utility
 #include "astring.h"

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 // Qt

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstdarg>
 #include <cstdio>

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -9,9 +9,7 @@
                   see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QFile>
 #include <cstdlib>

--- a/tools/fcmp/download.cpp
+++ b/tools/fcmp/download.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cerrno>
 

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <sys/stat.h>
 

--- a/tools/fcmp/mpcli.cpp
+++ b/tools/fcmp/mpcli.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstdlib>
 

--- a/tools/fcmp/mpgui_qt.cpp
+++ b/tools/fcmp/mpgui_qt.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QApplication>

--- a/tools/fcmp/mpgui_qt.h
+++ b/tools/fcmp/mpgui_qt.h
@@ -12,9 +12,7 @@
 #ifndef FC__MPGUI_QT_H
 #define FC__MPGUI_QT_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QMainWindow>

--- a/tools/fcmp/mpgui_qt_worker.cpp
+++ b/tools/fcmp/mpgui_qt_worker.cpp
@@ -11,9 +11,6 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
-#endif
-
 // Qt
 #include <QApplication>
 #include <QHeaderView>

--- a/tools/fcmp/mpgui_qt_worker.h
+++ b/tools/fcmp/mpgui_qt_worker.h
@@ -12,9 +12,7 @@
 #ifndef FC__MPGUI_QT_WORKER_H
 #define FC__MPGUI_QT_WORKER_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QString>

--- a/tools/ruledit/conversion_log.h
+++ b/tools/ruledit/conversion_log.h
@@ -12,9 +12,7 @@
 #ifndef FC__CONVERSION_LOG_H
 #define FC__CONVERSION_LOG_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/tools/ruledit/edit_utype.h
+++ b/tools/ruledit/edit_utype.h
@@ -12,9 +12,7 @@
 #ifndef FC__EDIT_UTYPE_H
 #define FC__EDIT_UTYPE_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/tools/ruledit/effect_edit.h
+++ b/tools/ruledit/effect_edit.h
@@ -14,9 +14,7 @@
 #ifndef FC__EFFECT_EDIT_H
 #define FC__EFFECT_EDIT_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/tools/ruledit/req_edit.h
+++ b/tools/ruledit/req_edit.h
@@ -14,9 +14,7 @@
 #ifndef FC__REQ_EDIT_H
 #define FC__REQ_EDIT_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/tools/ruledit/req_vec_fix.h
+++ b/tools/ruledit/req_vec_fix.h
@@ -12,9 +12,7 @@
 #ifndef FC__REQ_VEC_FIX_H
 #define FC__REQ_VEC_FIX_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/requirers_dlg.h
+++ b/tools/ruledit/requirers_dlg.h
@@ -12,9 +12,7 @@
 #ifndef FC__REQUIRERS_DLG_H
 #define FC__REQUIRERS_DLG_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QDialog>

--- a/tools/ruledit/ruledit.cpp
+++ b/tools/ruledit/ruledit.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // ANSI
 #include <cstdlib>

--- a/tools/ruledit/ruledit_qt.cpp
+++ b/tools/ruledit/ruledit_qt.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QApplication>

--- a/tools/ruledit/tab_building.h
+++ b/tools/ruledit/tab_building.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_BUILDING_H
 #define FC__TAB_BUILDING_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_enablers.h
+++ b/tools/ruledit/tab_enablers.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_ENABLERS_H
 #define FC__TAB_ENABLERS_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_extras.h
+++ b/tools/ruledit/tab_extras.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_EXTRAS_H
 #define FC__TAB_EXTRAS_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_good.h
+++ b/tools/ruledit/tab_good.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_GOOD_H
 #define FC__TAB_GOOD_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_gov.h
+++ b/tools/ruledit/tab_gov.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_GOV_H
 #define FC__TAB_GOV_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_multiplier.h
+++ b/tools/ruledit/tab_multiplier.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_MULTIPLIER_H
 #define FC__TAB_MULTIPLIER_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_tech.h
+++ b/tools/ruledit/tab_tech.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_TECH_H
 #define FC__TAB_TECH_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_terrains.h
+++ b/tools/ruledit/tab_terrains.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_TERRAINS_H
 #define FC__TAB_TERRAINS_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruledit/tab_unit.h
+++ b/tools/ruledit/tab_unit.h
@@ -14,9 +14,7 @@
 #ifndef FC__TAB_UNIT_H
 #define FC__TAB_UNIT_H
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 // Qt
 #include <QWidget>

--- a/tools/ruleup.cpp
+++ b/tools/ruleup.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #ifdef FREECIV_MSWINDOWS
 #include <windows.h>

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -74,9 +74,6 @@ if ((MSYS OR MINGW) AND NOT (FREECIV_DEBUG OR FREECIV_TESTMATIC))
   target_link_libraries(utility PRIVATE imagehlp)
 endif()
 
-# config.h is required, but this definition is still required for it to be used.
-target_compile_definitions(utility PUBLIC HAVE_CONFIG_H)
-
 # Suppress warnings from specenum_gen.h
 freeciv_add_flag_if_supported(
   utility -Wno-tautological-constant-out-of-range-compare)

--- a/utility/fciconv.cpp
+++ b/utility/fciconv.cpp
@@ -11,9 +11,7 @@
                                  If not, see https://www.gnu.org/licenses/.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QLocale>
 #include <QTextCodec>

--- a/utility/fcintl.cpp
+++ b/utility/fcintl.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cstring>
 

--- a/utility/fcthread.h
+++ b/utility/fcthread.h
@@ -10,9 +10,7 @@
 **************************************************************************/
 #pragma once
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <QMutex>
 #include <QThread>

--- a/utility/log.cpp
+++ b/utility/log.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <vector>
 

--- a/utility/netfile.cpp
+++ b/utility/netfile.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <memory>
 

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <climits>
 #include <clocale>

--- a/utility/support.cpp
+++ b/utility/support.cpp
@@ -38,9 +38,7 @@
 
  */
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include <cmath> // ceil()
 #include <cstdarg>

--- a/utility/version.cpp
+++ b/utility/version.cpp
@@ -11,9 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#ifdef HAVE_CONFIG_H
 #include <fc_config.h>
-#endif
 
 #include "version.h"
 


### PR DESCRIPTION
The macro was always defined in the build system, so all #ifdef HAVE_CONFIG_H were always taken (except the one in cvercmp).  Dropping it simplifies the code.