### PR TITLE
Remove ColorDodge in the city screen and other places

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -404,9 +404,8 @@ void progress_bar::paintEvent(QPaintEvent *event)
     }
 
     j = height() - 2 * f_size;
-    p.setCompositionMode(QPainter::CompositionMode_ColorDodge);
-    QFontMetrics fm(*sfont);
 
+    QFontMetrics fm(*sfont);
     if (fm.horizontalAdvance(s1) > rx.width()) {
       s1 = fm.elidedText(s1, Qt::ElideRight, rx.width());
     }
@@ -428,9 +427,8 @@ void progress_bar::paintEvent(QPaintEvent *event)
     int i, j;
     s = text();
     j = height() - f_size;
-    p.setCompositionMode(QPainter::CompositionMode_ColorDodge);
-    QFontMetrics fm(*sfont);
 
+    QFontMetrics fm(*sfont);
     if (fm.horizontalAdvance(s) > rx.width()) {
       s = fm.elidedText(s, Qt::ElideRight, rx.width());
     }

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -832,11 +832,9 @@ void hud_action::paintEvent(QPaintEvent *event)
   QPainter p;
 
   p.begin(this);
-  p.setCompositionMode(QPainter::CompositionMode_Source);
   p.setRenderHint(QPainter::SmoothPixmapTransform);
   icon.paint(&p, rect());
   if (focus) {
-    p.setCompositionMode(QPainter::CompositionMode_DestinationOver);
     p.fillRect(rect(), QColor(palette().color(QPalette::Highlight)));
   }
   p.end();

--- a/client/views/view_map_common.cpp
+++ b/client/views/view_map_common.cpp
@@ -777,7 +777,7 @@ bool tile_visible_and_not_on_border_mapcanvas(struct tile *ptile)
  */
 void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
                        const std::vector<drawn_sprite> &sprites, bool fog,
-                       bool city_dialog, bool city_unit)
+                       bool city_unit)
 {
   QPainter p(pcanvas);
   for (auto s : sprites) {
@@ -785,15 +785,7 @@ void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
       // This can happen, although it should probably be avoided.
       continue;
     }
-    if (city_unit) {
-      p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-      p.setOpacity(0.7);
-      p.drawPixmap(canvas_x + s.offset_x, canvas_y + s.offset_y, *s.sprite);
-    } else if (city_dialog) {
-      p.setCompositionMode(QPainter::CompositionMode_Difference);
-      p.setOpacity(0.5);
-      p.drawPixmap(canvas_x + s.offset_x, canvas_y + s.offset_y, *s.sprite);
-    } else if (fog && s.foggable) {
+    if (fog && s.foggable) {
       // FIXME This looks rather expensive
       QPixmap temp(s.sprite->size());
       temp.fill(Qt::transparent);
@@ -828,20 +820,11 @@ void put_one_element(QPixmap *pcanvas,
                      const struct tile_corner *pcorner,
                      const struct unit *punit, int canvas_x, int canvas_y)
 {
-  bool city_mode = false;
   bool city_unit = false;
   int dummy_x, dummy_y;
   auto sprites = layer->fill_sprite_array(ptile, pedge, pcorner, punit);
   bool fog = (ptile && gui_options->draw_fog_of_war
               && TILE_KNOWN_UNSEEN == client_tile_get_known(ptile));
-  if (ptile) {
-    struct city *xcity = is_any_city_dialog_open();
-    if (xcity) {
-      if (!city_base_to_city_map(&dummy_x, &dummy_y, xcity, ptile)) {
-        city_mode = true;
-      }
-    }
-  }
   if (punit) {
     struct city *xcity = is_any_city_dialog_open();
     if (xcity) {
@@ -851,8 +834,7 @@ void put_one_element(QPixmap *pcanvas,
     }
   }
   /*** Draw terrain and specials ***/
-  put_drawn_sprites(pcanvas, canvas_x, canvas_y, sprites, fog, city_mode,
-                    city_unit);
+  put_drawn_sprites(pcanvas, canvas_x, canvas_y, sprites, fog, city_unit);
 }
 
 /**

--- a/client/views/view_map_common.h
+++ b/client/views/view_map_common.h
@@ -89,7 +89,7 @@ void put_nuke_mushroom_pixmaps(struct tile *ptile);
 
 void put_drawn_sprites(QPixmap *pcanvas, int canvas_x, int canvas_y,
                        const std::vector<drawn_sprite> &sprites, bool fog,
-                       bool citydialog = false, bool city_unit = false);
+                       bool city_unit = false);
 
 void update_map_canvas(int canvas_x, int canvas_y, int width, int height);
 void update_map_canvas_visible();


### PR DESCRIPTION
The fog effect from the city screen is gone, will do it properly if we want to add it back.

Closes #1106.