### PR TITLE
Fix hud_message_box sometimes showing at the top left of the screen

### DIFF
--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -3394,6 +3394,7 @@ disband_box::disband_box(const std::vector<unit *> &punits, QWidget *parent)
   setDefaultButton(pb);
   connect(pb, &QAbstractButton::clicked, this,
           &disband_box::disband_clicked);
+  pb->show();
 }
 
 /**

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -67,13 +67,12 @@ bool has_player_unit_type(Unit_type_id utype)
  */
 hud_message_box::hud_message_box(QWidget *parent) : QMessageBox(parent)
 {
-  int size;
-  setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Dialog
-                 | Qt::FramelessWindowHint);
+  setWindowFlag(Qt::FramelessWindowHint);
+
   f_text = fcFont::instance()->getFont(fonts::default_font);
   f_title = fcFont::instance()->getFont(fonts::default_font);
 
-  size = f_text.pointSize();
+  auto size = f_text.pointSize();
   if (size > 0) {
     f_text.setPointSize(size * 4 / 3);
     f_title.setPointSize(size * 3 / 2);
@@ -88,7 +87,6 @@ hud_message_box::hud_message_box(QWidget *parent) : QMessageBox(parent)
   fm_title = new QFontMetrics(f_title);
   top = 0;
   m_animate_step = 0;
-  hide();
   mult = 1;
 }
 
@@ -122,7 +120,6 @@ void hud_message_box::set_text_title(const QString &s1, const QString &s2)
   QSpacerItem *spacer;
   QGridLayout *layout;
   int w, w2, h;
-  QPoint p;
 
   if (s1.contains('\n')) {
     int i;
@@ -151,11 +148,6 @@ void hud_message_box::set_text_title(const QString &s1, const QString &s2)
   text = s1;
   title = s2;
 
-  p = QPoint((parentWidget()->width() - w) / 2,
-             (parentWidget()->height() - h) / 2);
-  p = parentWidget()->mapToGlobal(p);
-  move(p);
-  show();
   m_timer.start();
   startTimer(45);
 }

--- a/client/views/view_economics.cpp
+++ b/client/views/view_economics.cpp
@@ -253,6 +253,7 @@ void eco_report::disband_units()
       result->show();
     }
   });
+  ask->show();
 }
 
 /**
@@ -297,6 +298,7 @@ void eco_report::sell_buildings()
     result->setAttribute(Qt::WA_DeleteOnClose);
     result->show();
   });
+  ask->show();
 }
 
 /**
@@ -340,6 +342,7 @@ void eco_report::sell_redundant()
     result->setAttribute(Qt::WA_DeleteOnClose);
     result->show();
   });
+  ask->show();
 }
 
 /**


### PR DESCRIPTION
Turned out that calling show() twice moves the widget around. Don't call it from set_text_title() and always call it externally instead.

Closes #1422.

Backporting not envisioned because if I missed a `show()`, that dialog wouldn't show up at all.