### PR TITLE
Change the options dialog to be a tool window

### DIFF
--- a/client/optiondlg.cpp
+++ b/client/optiondlg.cpp
@@ -111,6 +111,8 @@ option_dialog::option_dialog(const QString &name, const option_set *options,
                              QWidget *parent)
     : qfc_dialog(parent)
 {
+  setWindowFlag(Qt::Tool); // Stays on top without blocking input
+
   QPushButton *but;
 
   curr_options = options;


### PR DESCRIPTION
This way it doesn't block input, but should also always stay on top of the main window.

Closes #1035.

Will need a Mac tester to confirm that it's actually working as intended.