### PR TITLE
CI: Run Windows clang only once a week

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,6 +170,7 @@ jobs:
     name: "Windows Clang"
     runs-on: windows-latest
     needs: clang-format
+    if: github.event_name == 'schedule'
     env:
       VCPKG_ROOT: C:/vcpkg
       VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg/bincache


### PR DESCRIPTION
It has shown long-lasting breakage and takes forever. Save on computing resources and reduce spurious failures.

Closes #1437.