### PR TITLE
Don't hard code master for autorevision and source tarballs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
       - run: git rev-parse --short=5 HEAD > cmake/AutoRevision.txt
       - run: git describe --tags `git rev-list --tags --max-count=1` >> cmake/AutoRevision.txt
       - run: cat cmake/AutoRevision.txt
@@ -32,7 +31,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
       - run: git rev-parse --short=5 HEAD > cmake/AutoRevision.txt
       - run: git describe --tags `git rev-list --tags --max-count=1` >> cmake/AutoRevision.txt
       - run: cat cmake/AutoRevision.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,14 +10,26 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - # Make sure there are no unstaged changes
+        # Was reporting changes to eol=crlf files in .gitattributes
+        run: git checkout -- .
       - run: git rev-parse --short=5 HEAD > cmake/AutoRevision.txt
       - run: git describe --tags `git rev-list --tags --max-count=1` >> cmake/AutoRevision.txt
       - run: cat cmake/AutoRevision.txt
+      - name: Find target branch
+        id: branch
+        # We're running on a tag so have no direct access to the branch. Find it.
+        # Strip the first 3 components (ref/remotes/username)
+        run: |
+          git diff branch=$(git branch -r --contains HEAD --format '%(refname:strip=3)')
+          echo Target branch is $branch
+          echo branch=$branch >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.0.4
         with:
+          base: ${{ steps.branch.outputs.branch }}
           commit-message: "Release update of AutoRevision.txt"
-          branch: "release/autorevision"
+          branch: release/autorevision/${{ steps.branch.outputs.branch }}
           title: "Release update of AutoRevision.txt"
           body: >
             Automatic changes triggered by a new release.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
           body: >
             Automatic changes triggered by a new release.
 
+            This PR updates `${{ steps.branch.outputs.branch }}`.
             Close and reopen this pull request to start the CI.
           delete-branch: true
   update-archive:

--- a/docs/Contributing/release.rst
+++ b/docs/Contributing/release.rst
@@ -1,6 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+.. SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>s
 
 The Release Process
 *******************
@@ -26,6 +26,19 @@ These are the general steps to prepare and finalize a release:
    need to delay in any way or if we are good to proceed as normal.
 #. When it is time, the release manager will finalize the release notes and ask for an editorial review in the
    ``#releases-project`` channel. Updates are made as per review.
+#. If the release will be the :strong:`first release candidate` towards a stable release, the release manager
+   will:
+
+   #. Delete the existing ``stable`` branch on Github's
+      `branches page <https://github.com/longturn/freeciv21/branches>`_.
+   #. From the same page, create a new ``stable`` branch from ``master``.
+   #. Update ``cmake/AutoRevision.txt`` with the hash of the last commit in ``master`` and
+      ``v[major version].[minor version]-dev`` with the version of the :strong:`next stable release`, then
+      open a PR for this change to ``master``. This way, development builds from ``master`` will immediately
+      use the version number of the next stable.
+
+#. If the release is a :strong:`release candidate` or a :strong:`stable release`, the release manager will
+   make sure that the :guilabel:`Target` branch in the release draft is set to ``stable``.
 #. The release manager will add a tag to the release notes page and then click :guilabel:`Publish Release`.
    The format of the tag is ``v[major version].[minor version]-[pre-release name].[number]``. For example:
    ``v3.0-beta.6``. :strong:`The format is very important` to the build configuration process.

--- a/docs/Contributing/release.rst
+++ b/docs/Contributing/release.rst
@@ -11,6 +11,10 @@ use the term "loosely" as there is a large amount of discretion with regard to t
 a release at any time to fix a nasty bug or slow a release down to get in a PR a developer is really close
 to completing and wants it in the next release. However, we do aim to release around 6 to 8 times per year.
 
+Pre-releases are done from the ``master`` branch, while release candidates and stable releases use the
+``stable`` branch, which contains bug fixes backported from master. See
+:doc:`the dedicated page <stable-branch>` for how this is done.
+
 These are the general steps to prepare and finalize a release:
 
 #. A release manager will open a draft release notes page from: https://github.com/longturn/freeciv21/releases.

--- a/docs/Contributing/stable-branch.rst
+++ b/docs/Contributing/stable-branch.rst
@@ -1,5 +1,6 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Maintaining the Stable Branch
 *****************************
@@ -14,6 +15,8 @@ occasions where we are introducing major breaking changes that take time to reso
 ``stable`` branch. As development occurs on the ``master`` branch, there are going to be times when we want to
 back-port a commit (a single patch) or a Pull Request (a collection of commits) over to the ``stable`` branch.
 
+The ``stable`` branch is created when preparing for the first Release Candidate towards a stable release, see
+:doc:`release`.
 This page documents the rules and procedures for maintaining the ``stable`` branch.
 
 Requirements for a Back-Port


### PR DESCRIPTION
We released 3.0-rc.3 with code from master. This should not happen.

Also update the CI so it can push new version numbers to `stable` when we make RC releases and document when `stable` gets created (as a first draft to be revisited when we reach 3.1 and make a new `stable` branch).

The branch part was tested in https://github.com/lmoureaux/freeciv21/pull/4.

Backporting recommended.