### PR TITLE
Add the continent number to lua

### DIFF
--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -60,6 +60,7 @@ struct Tile {
   Player *owner;
 
   const int index @ id;
+  const int continent @ continent;
 };
 
 struct Government {


### PR DESCRIPTION
No related issue. Access through `tile.continent`.