### PR TITLE
Always display fuel in turns.

### DIFF
--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -626,12 +626,8 @@ void hud_units::update_actions()
   text_str = text_str + " ";
   mp = QString(move_points_text(punit->moves_left, false));
   if (utype_fuel(unit_type_get(punit))) {
-    mp = mp + QStringLiteral("(")
-         + QString(move_points_text(
-             (unit_type_get(punit)->move_rate * ((punit->fuel) - 1)
-              + punit->moves_left),
-             false))
-         + QStringLiteral(")");
+    mp = mp + QStringLiteral("(") + QString::number(punit->fuel - 1)
+         + QStringLiteral(" T)");
   }
   // TRANS: MP = Movement points
   mp = QString(_("MP: ")) + mp;

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -626,8 +626,8 @@ void hud_units::update_actions()
   text_str = text_str + " ";
   mp = QString(move_points_text(punit->moves_left, false));
   if (utype_fuel(unit_type_get(punit))) {
-    mp = mp + QStringLiteral("(") + QString::number(punit->fuel - 1)
-         + QStringLiteral(" T)");
+    // TRANS: T for turns
+    mp += " " + QString(_("(%1T)")).arg(punit->fuel - 1);
   }
   // TRANS: MP = Movement points
   mp = QString(_("MP: ")) + mp;

--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -164,14 +164,10 @@ void units_select::create_pixmap()
 
       if (client_is_global_observer()
           || unit_owner(punit) == client.conn.playing) {
-        auto rate = unit_type_get(punit)->move_rate;
         auto f = ((punit->fuel) - 1);
         auto str = QString(move_points_text(punit->moves_left, false));
         if (utype_fuel(unit_type_get(punit))) {
-          str = str + "("
-                + QString(
-                    move_points_text((rate * f) + punit->moves_left, false))
-                + ")";
+          str = str + "(" + QString::number(f) + " T)";
         }
         // TRANS: MP = Movement points
         str = QString(_("MP:")) + str;

--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -164,10 +164,10 @@ void units_select::create_pixmap()
 
       if (client_is_global_observer()
           || unit_owner(punit) == client.conn.playing) {
-        auto f = ((punit->fuel) - 1);
         auto str = QString(move_points_text(punit->moves_left, false));
         if (utype_fuel(unit_type_get(punit))) {
-          str = str + "(" + QString::number(f) + " T)";
+          // TRANS: T for turns
+          str += " " + QString(_("(%1T)")).arg(punit->fuel - 1);
         }
         // TRANS: MP = Movement points
         str = QString(_("MP:")) + str;

--- a/common/unit.cpp
+++ b/common/unit.cpp
@@ -1102,16 +1102,14 @@ void unit_activity_astr(const struct unit *punit, QString &s)
   switch (punit->activity) {
   case ACTIVITY_IDLE:
     if (utype_fuel(unit_type_get(punit))) {
-      int rate, f;
+      int f;
 
-      rate = unit_type_get(punit)->move_rate;
       f = ((punit->fuel) - 1);
 
       /* Add in two parts as move_points_text() returns ptr to static
        * End result: "Moves: (fuel)moves_left" */
-      s += QStringLiteral("%1: (%2)\n")
-               .arg(_("Moves"),
-                    move_points_text((rate * f) + punit->moves_left, false));
+      s +=
+          QStringLiteral("%1: (%2 T)\n").arg(_("Moves"), QString::number(f));
       s += QStringLiteral("%1").arg(
           move_points_text(punit->moves_left, false));
     } else {

--- a/common/unit.cpp
+++ b/common/unit.cpp
@@ -1102,16 +1102,9 @@ void unit_activity_astr(const struct unit *punit, QString &s)
   switch (punit->activity) {
   case ACTIVITY_IDLE:
     if (utype_fuel(unit_type_get(punit))) {
-      int f;
-
-      f = ((punit->fuel) - 1);
-
-      /* Add in two parts as move_points_text() returns ptr to static
-       * End result: "Moves: (fuel)moves_left" */
-      s +=
-          QStringLiteral("%1: (%2 T)\n").arg(_("Moves"), QString::number(f));
-      s += QStringLiteral("%1").arg(
-          move_points_text(punit->moves_left, false));
+      s += QString(_("Moves: (%1T) %2"))
+               .arg(QString::number(punit->fuel - 1),
+                    move_points_text(punit->moves_left, false));
     } else {
       s += QStringLiteral("%1: %2\n")
                .arg(_("Moves"), move_points_text(punit->moves_left, false));

--- a/common/unittype.cpp
+++ b/common/unittype.cpp
@@ -1297,9 +1297,7 @@ const char *utype_values_string(const struct unit_type *punittype)
               punittype->defense_strength,
               move_points_text(punittype->move_rate, true));
   if (utype_fuel(punittype)) {
-    cat_snprintf(buffer, sizeof(buffer), "(%s)",
-                 move_points_text(
-                     punittype->move_rate * utype_fuel(punittype), true));
+    cat_snprintf(buffer, sizeof(buffer), "(%d)", utype_fuel(punittype));
   }
   return buffer;
 }


### PR DESCRIPTION
It is tracked as turns internally and helps shows it as turns, it is highly misleading and confusing to show it as movement points instead.