### PR TITLE
Move governor settings widget to its own class with a .ui

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -137,6 +137,7 @@ target_sources(
   views/view_units.cpp
   widgets/decorations.cpp
   widgets/city/city_icon_widget.cpp
+  widgets/city/governor_widget.cpp
   widgets/city/upkeep_widget.cpp
   widgets/report_widget.cpp
 

--- a/client/attribute.h
+++ b/client/attribute.h
@@ -10,6 +10,8 @@
 **************************************************************************/
 #pragma once
 
+#include <cstddef>
+
 /*
  * If 4 byte wide signed int is used this gives 20 object types with
  * 100 million keys each.

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -58,6 +58,7 @@
 #include "utils/unit_quick_menu.h"
 #include "views/view_cities.h" // hIcon
 #include "views/view_map.h"
+#include "widgets/city/governor_widget.h"
 
 extern QString split_text(const QString &text, bool cut);
 extern QString cut_helptext(const QString &text);
@@ -742,135 +743,6 @@ void city_info::update_labels(struct city *pcity)
   m_airlift->setToolTip(get_city_dialog_airlift_text(pcity));
 }
 
-governor_sliders::governor_sliders(QWidget *parent) : QGroupBox(parent)
-{
-  QStringList str_list;
-  QSlider *slider;
-  QLabel *some_label;
-  QGridLayout *slider_grid = new QGridLayout;
-
-  str_list << _("Food") << _("Shield") << _("Trade") << _("Gold")
-           << _("Luxury") << _("Science") << _("Celebrate");
-  some_label = new QLabel(_("Minimal Surplus"));
-  some_label->setFont(fcFont::instance()->getFont(fonts::notify_label));
-  some_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  slider_grid->addWidget(some_label, 0, 0, 1, 3);
-  some_label = new QLabel(_("Priority"));
-  some_label->setFont(fcFont::instance()->getFont(fonts::notify_label));
-  some_label->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
-  slider_grid->addWidget(some_label, 0, 3, 1, 3);
-
-  for (int i = 0; i < str_list.count(); i++) {
-    some_label = new QLabel(str_list.at(i));
-    slider_grid->addWidget(some_label, i + 1, 0, 1, 1);
-    some_label = new QLabel(QStringLiteral("0"));
-    some_label->setMinimumWidth(25);
-
-    if (i != str_list.count() - 1) {
-      slider = new QSlider(Qt::Horizontal);
-      slider->setPageStep(1);
-      slider->setFocusPolicy(Qt::TabFocus);
-      slider_tab[2 * i] = slider;
-      slider->setRange(-20, 20);
-      slider->setSingleStep(1);
-      slider_grid->addWidget(some_label, i + 1, 1, 1, 1);
-      slider_grid->addWidget(slider, i + 1, 2, 1, 1);
-      slider->setProperty("FC", QVariant::fromValue((void *) some_label));
-
-      connect(slider, &QAbstractSlider::valueChanged, this,
-              &governor_sliders::cma_slider);
-    } else {
-      cma_celeb_checkbox = new QCheckBox;
-      slider_grid->addWidget(cma_celeb_checkbox, i + 1, 2, 1, 1);
-      connect(cma_celeb_checkbox, &QCheckBox::stateChanged, this,
-              &governor_sliders::cma_celebrate_changed);
-    }
-
-    some_label = new QLabel(QStringLiteral("0"));
-    some_label->setMinimumWidth(25);
-    slider = new QSlider(Qt::Horizontal);
-    slider->setFocusPolicy(Qt::TabFocus);
-    slider->setRange(0, 25);
-    slider_tab[2 * i + 1] = slider;
-    slider->setProperty("FC", QVariant::fromValue((void *) some_label));
-    slider_grid->addWidget(some_label, i + 1, 3, 1, 1);
-    slider_grid->addWidget(slider, i + 1, 4, 1, 1);
-    connect(slider, &QAbstractSlider::valueChanged, this,
-            &governor_sliders::cma_slider);
-  }
-  setLayout(slider_grid);
-}
-
-/**
-   CMA options on slider has been changed
- */
-void governor_sliders::cma_slider(int value)
-{
-  QVariant qvar;
-  QSlider *slider;
-  QLabel *label;
-
-  slider = qobject_cast<QSlider *>(sender());
-  qvar = slider->property("FC");
-
-  if (qvar.isNull() || !qvar.isValid()) {
-    return;
-  }
-
-  label = reinterpret_cast<QLabel *>(qvar.value<void *>());
-  label->setText(QString::number(value));
-
-  queen()->city_overlay->cma_check_agent();
-}
-
-/**
-   CMA option 'celebrate' qcheckbox state has been changed
- */
-void governor_sliders::cma_celebrate_changed(int val)
-{
-  Q_UNUSED(val)
-  queen()->city_overlay->cma_check_agent();
-}
-
-/**
-   Updates sliders ( cma params )
- */
-void governor_sliders::update_sliders(struct cm_parameter &param)
-{
-  int output;
-  QVariant qvar;
-  QLabel *label;
-
-  for (output = O_FOOD; output < 2 * O_LAST; output++) {
-    slider_tab[output]->blockSignals(true);
-  }
-
-  for (output = O_FOOD; output < O_LAST; output++) {
-    qvar = slider_tab[2 * output + 1]->property("FC");
-    label = reinterpret_cast<QLabel *>(qvar.value<void *>());
-    label->setText(QString::number(param.factor[output]));
-    slider_tab[2 * output + 1]->setValue(param.factor[output]);
-    qvar = slider_tab[2 * output]->property("FC");
-    label = reinterpret_cast<QLabel *>(qvar.value<void *>());
-    label->setText(QString::number(param.minimal_surplus[output]));
-    slider_tab[2 * output]->setValue(param.minimal_surplus[output]);
-  }
-
-  slider_tab[2 * O_LAST + 1]->blockSignals(true);
-  qvar = slider_tab[2 * O_LAST + 1]->property("FC");
-  label = reinterpret_cast<QLabel *>(qvar.value<void *>());
-  label->setText(QString::number(param.happy_factor));
-  slider_tab[2 * O_LAST + 1]->setValue(param.happy_factor);
-  slider_tab[2 * O_LAST + 1]->blockSignals(false);
-  cma_celeb_checkbox->blockSignals(true);
-  cma_celeb_checkbox->setChecked(param.require_happy);
-  cma_celeb_checkbox->blockSignals(false);
-
-  for (output = O_FOOD; output < 2 * O_LAST; output++) {
-    slider_tab[output]->blockSignals(false);
-  }
-}
-
 /**
    Constructor for city_dialog, sets layouts, policies ...
  */
@@ -951,7 +823,6 @@ city_dialog::city_dialog(QWidget *parent) : QWidget(parent)
 
   // governor tab
   ui.qgbox->setTitle(_("Presets:"));
-  ui.qsliderbox->setTitle(_("Governor settings"));
 
   ui.cma_table->horizontalHeader()->setSectionResizeMode(
       QHeaderView::Stretch);
@@ -1000,6 +871,9 @@ city_dialog::city_dialog(QWidget *parent) : QWidget(parent)
   ui.tabs_right->setTabText(0, _("General"));
   ui.tabs_right->setTabText(1, _("Citizens"));
   ui.tabs_right->setTabText(2, _("Governor"));
+
+  connect(ui.governor, &freeciv::governor_widget::parameters_changed, this,
+          &city_dialog::cma_check_agent);
 
   ui.present_units_list->set_oneliner(true);
 
@@ -1198,24 +1072,10 @@ void city_dialog::save_cma()
                                _("Name new preset"), _("new preset"));
   ask->setAttribute(Qt::WA_DeleteOnClose);
   connect(ask, &hud_message_box::accepted, this, [=]() {
-    struct cm_parameter param;
-    QByteArray ask_bytes = ask->input_edit.text().toLocal8Bit();
-    QString text = ask_bytes.data();
-    if (!text.isEmpty()) {
-      param.max_growth = false;
-      param.allow_disorder = false;
-      param.allow_specialists = true;
-      param.require_happy = ui.qsliderbox->cma_celeb_checkbox->isChecked();
-      param.happy_factor =
-          ui.qsliderbox->slider_tab[2 * O_LAST + 1]->value();
-
-      for (int i = O_FOOD; i < O_LAST; i++) {
-        param.minimal_surplus[i] = ui.qsliderbox->slider_tab[2 * i]->value();
-        param.factor[i] = ui.qsliderbox->slider_tab[2 * i + 1]->value();
-      }
-
-      ask_bytes = text.toLocal8Bit();
-      cmafec_preset_add(ask_bytes.data(), &param);
+    auto name = ask->input_edit.text();
+    if (!name.isEmpty()) {
+      const auto params = ui.governor->parameters();
+      cmafec_preset_add(qUtf8Printable(name), &params);
       update_cma_tab();
     }
   });
@@ -1241,19 +1101,8 @@ void city_dialog::cma_enable()
  */
 void city_dialog::cma_changed()
 {
-  struct cm_parameter param;
-
-  param.allow_disorder = false;
-  param.allow_specialists = true;
-  param.require_happy = ui.qsliderbox->cma_celeb_checkbox->isChecked();
-  param.happy_factor = ui.qsliderbox->slider_tab[2 * O_LAST + 1]->value();
-
-  for (int i = O_FOOD; i < O_LAST; i++) {
-    param.minimal_surplus[i] = ui.qsliderbox->slider_tab[2 * i]->value();
-    param.factor[i] = ui.qsliderbox->slider_tab[2 * i + 1]->value();
-  }
-
-  cma_put_city_under_agent(pcity, &param);
+  const auto params = ui.governor->parameters();
+  cma_put_city_under_agent(pcity, &params);
 }
 
 /**
@@ -1692,18 +1541,17 @@ void city_dialog::refresh()
 
 void city_dialog::update_sliders()
 {
-  struct cm_parameter param;
-  const struct cm_parameter *cparam;
-
-  if (!cma_is_city_under_agent(pcity, &param)) {
+  cm_parameter params;
+  if (!cma_is_city_under_agent(pcity, &params)) {
     if (ui.cma_table->currentRow() == -1 || cmafec_preset_num() == 0) {
       return;
     }
-    cparam = cmafec_preset_get_parameter(ui.cma_table->currentRow());
-    cm_copy_parameter(&param, cparam);
+    params = *cmafec_preset_get_parameter(ui.cma_table->currentRow());
   }
-  ui.qsliderbox->update_sliders(param);
+
+  ui.governor->set_parameters(params);
 }
+
 /**
    Updates nationality table in happiness tab
  */
@@ -2292,13 +2140,18 @@ void city_dialog::save_worklist()
   ask->show();
 }
 
-void city_dialog::cma_check_agent()
+/**
+ * Triggers a governor update if the parameters changed.
+ */
+void city_dialog::cma_check_agent(const cm_parameter &params)
 {
-  if (cma_is_city_under_agent(pcity, nullptr)) {
+  cm_parameter current;
+  if (cma_is_city_under_agent(pcity, &current) && !(current == params)) {
     cma_changed();
     update_cma_tab();
   }
 }
+
 /**
    Puts city name and people count on title
  */

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -46,7 +46,6 @@ class QRadioButton;
 class QRect;
 class QResizeEvent;
 class QShowEvent;
-class QSlider;
 class QSplitter;
 class QTableWidget;
 class QTableWidgetItem;
@@ -270,19 +269,6 @@ private:
       *m_pollution, *m_plague_label, *m_plague, *m_stolen, *m_airlift;
 };
 
-class governor_sliders : public QGroupBox {
-  Q_OBJECT
-
-public:
-  governor_sliders(QWidget *parent = 0);
-  void update_sliders(struct cm_parameter &param);
-  QCheckBox *cma_celeb_checkbox{nullptr};
-  QSlider *slider_tab[2 * O_LAST + 2]{nullptr};
-private slots:
-  void cma_slider(int val);
-  void cma_celebrate_changed(int val);
-};
-
 #include "ui_citydlg.h"
 /****************************************************************************
   City dialog
@@ -304,7 +290,6 @@ public:
   ~city_dialog() override;
   void setup_ui(struct city *qcity);
   void refresh();
-  void cma_check_agent();
   struct city *pcity = nullptr;
   bool dont_focus{false};
 
@@ -342,6 +327,7 @@ private slots:
   void cma_remove();
   void cma_enable();
   void cma_changed();
+  void cma_check_agent(const cm_parameter &params);
   void cma_selected(const QItemSelection &sl, const QItemSelection &ds);
   void cma_double_clicked(int row, int column);
   void cma_context_menu(const QPoint p);

--- a/client/citydlg.ui
+++ b/client/citydlg.ui
@@ -834,10 +834,15 @@
                </widget>
               </item>
               <item>
-               <widget class="governor_sliders" name="qsliderbox">
-                <property name="acceptDrops">
-                 <bool>false</bool>
+               <widget class="QGroupBox" name="groupBox">
+                <property name="title">
+                 <string>Settings</string>
                 </property>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <item>
+                  <widget class="freeciv::governor_widget" name="governor" native="true"/>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>
@@ -871,12 +876,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>governor_sliders</class>
-   <extends>QGroupBox</extends>
-   <header>citydlg.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>unit_list_widget</class>
    <extends>QListWidget</extends>
    <header>citydlg.h</header>
@@ -896,6 +895,12 @@
    <class>freeciv::city_icon_widget</class>
    <extends>QWidget</extends>
    <header>widgets/city/city_icon_widget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>freeciv::governor_widget</class>
+   <extends>QWidget</extends>
+   <header>widgets/city/governor_widget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/client/governor.cpp
+++ b/client/governor.cpp
@@ -42,7 +42,7 @@
 #define SHOW_APPLY_RESULT_ON_SERVER_ERRORS false
 #define ALWAYS_APPLY_AT_SERVER false
 #define MAX_LEN_PRESET_NAME 80
-#define SAVED_PARAMETER_SIZE 29
+#define SAVED_PARAMETER_SIZE 32
 
 #define CMA_NUM_PARAMS 5
 
@@ -451,7 +451,8 @@ bool cma_yoloswag::get_parameter(enum attr_city attr, int city_id,
   int version, dummy;
 
   /* Changing this function is likely to break compatability with old
-   * savegames that store these values. */
+   * savegames that store these values. Always add new parameters at the end.
+   */
 
   len = attr_city_get(attr, city_id, sizeof(buffer), buffer);
   if (len == 0) {
@@ -482,6 +483,11 @@ bool cma_yoloswag::get_parameter(enum attr_city attr, int city_id,
   fc_assert_ret_val(dio_get_bool8_raw(&din, &parameter->require_happy),
                     false);
 
+  // Optional fields
+  dio_get_bool8_raw(&din, &parameter->max_growth);
+  dio_get_bool8_raw(&din, &parameter->allow_disorder);
+  dio_get_bool8_raw(&din, &parameter->allow_specialists);
+
   return true;
 }
 
@@ -508,6 +514,10 @@ void cma_yoloswag::set_parameter(enum attr_city attr, int city_id,
   dio_put_sint16_raw(&dout, parameter->happy_factor);
   dio_put_uint8_raw(&dout, 0); // Dummy value; used to be factor_target.
   dio_put_bool8_raw(&dout, parameter->require_happy);
+
+  dio_put_bool8_raw(&dout, parameter->max_growth);
+  dio_put_bool8_raw(&dout, parameter->allow_disorder);
+  dio_put_bool8_raw(&dout, parameter->allow_specialists);
 
   fc_assert(dio_output_used(&dout) == SAVED_PARAMETER_SIZE);
 
@@ -708,7 +718,7 @@ void cmafec_get_fe_parameter(struct city *pcity, struct cm_parameter *dest)
 /**
    Adds a preset.
  */
-void cmafec_preset_add(const char *descr_name, struct cm_parameter *pparam)
+void cmafec_preset_add(const char *descr_name, const cm_parameter *pparam)
 {
   struct cma_preset *ppreset = new cma_preset;
 

--- a/client/governor.h
+++ b/client/governor.h
@@ -64,7 +64,7 @@ const char *cmafec_get_short_descr_of_city(const struct city *pcity);
 /*
  * Preset handling
  */
-void cmafec_preset_add(const char *descr_name, struct cm_parameter *pparam);
+void cmafec_preset_add(const char *descr_name, const cm_parameter *pparam);
 void cmafec_preset_remove(int idx);
 int cmafec_preset_get_index_of_parameter(
     const struct cm_parameter *const parameter);

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -3631,13 +3631,16 @@ static void load_cma_preset(struct section_file *file, int i)
         secfile_lookup_int_default(file, 0, "cma.preset%d.factor%d", i, o);
   }
   output_type_iterate_end;
-  parameter.max_growth = false;
+  parameter.max_growth =
+      secfile_lookup_bool_default(file, false, "cma.preset%d.max_growth", i);
   parameter.require_happy =
       secfile_lookup_bool_default(file, false, "cma.preset%d.reqhappy", i);
   parameter.happy_factor =
       secfile_lookup_int_default(file, 0, "cma.preset%d.happyfactor", i);
-  parameter.allow_disorder = false;
-  parameter.allow_specialists = true;
+  parameter.allow_disorder = secfile_lookup_bool_default(
+      file, false, "cma.preset%d.allow_disorder", i);
+  parameter.allow_specialists = secfile_lookup_bool_default(
+      file, true, "cma.preset%d.allow_specialists", i);
 
   cmafec_preset_add(name, &parameter);
 }
@@ -3664,6 +3667,12 @@ static void save_cma_preset(struct section_file *file, int i)
                       i);
   secfile_insert_int(file, pparam->happy_factor, "cma.preset%d.happyfactor",
                      i);
+  secfile_insert_bool(file, pparam->max_growth, "cma.preset%d.max_growth",
+                      i);
+  secfile_insert_bool(file, pparam->allow_disorder,
+                      "cma.preset%d.allow_disorder", i);
+  secfile_insert_bool(file, pparam->allow_specialists,
+                      "cma.preset%d.allow_specialists", i);
 }
 
 /**

--- a/client/widgets/city/governor_widget.cpp
+++ b/client/widgets/city/governor_widget.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#include "widgets/city/governor_widget.h"
+
+// client
+#include "fc_types.h"
+#include "governor.h"
+
+// common
+#include "cm.h"
+
+// Qt
+#include <QSlider>
+
+namespace freeciv {
+
+/**
+ * \class governor_widget
+ * A widget that lets the user edit governor settings.
+ */
+
+/**
+ * Constructor.
+ */
+governor_widget::governor_widget(QWidget *parent) : QWidget(parent)
+{
+  ui.setupUi(this);
+
+  const auto labels = {
+      ui.food_surplus_label,         ui.food_priority_label,
+      ui.production_surplus_label,   ui.production_priority_label,
+      ui.trade_surplus_label,        ui.trade_priority_label,
+      ui.gold_surplus_label,         ui.gold_priority_label,
+      ui.luxury_goods_surplus_label, ui.luxury_goods_priority_label,
+      ui.science_surplus_label,      ui.science_priority_label,
+      ui.celebrate_priority_label,
+  };
+  for (auto label : labels) {
+    label->setNum(0);
+  }
+
+  const auto sliders = {
+      ui.food_surplus,          ui.food_priority,   ui.production_surplus,
+      ui.production_priority,   ui.trade_surplus,   ui.trade_priority,
+      ui.gold_surplus,          ui.gold_priority,   ui.luxury_goods_surplus,
+      ui.luxury_goods_priority, ui.science_surplus, ui.science_priority,
+      ui.celebrate_priority,
+  };
+  for (auto slider : sliders) {
+    connect(slider, &QSlider::valueChanged, this,
+            &governor_widget::emit_params_changed);
+  }
+
+  const auto checkboxes = {
+      ui.celebrate_surplus,
+      ui.optimize_growth,
+      ui.allow_disorder,
+      ui.allow_specialists,
+  };
+  for (auto box : checkboxes) {
+    connect(box, &QCheckBox::toggled, this,
+            &governor_widget::emit_params_changed);
+  }
+}
+
+/**
+ * Returns the parameters currently shown by the widget.
+ */
+cm_parameter governor_widget::parameters() const
+{
+  auto params = cm_parameter();
+
+#define get_output(name, O_TYPE)                                            \
+  params.minimal_surplus[O_TYPE] = ui.name##_surplus->value();              \
+  params.factor[O_TYPE] = ui.name##_priority->value();
+  get_output(food, O_FOOD);
+  get_output(production, O_SHIELD);
+  get_output(trade, O_TRADE);
+  get_output(gold, O_GOLD);
+  get_output(luxury_goods, O_LUXURY);
+  get_output(science, O_SCIENCE);
+#undef get_output
+
+  params.require_happy = ui.celebrate_surplus->isChecked();
+  params.happy_factor = ui.celebrate_priority->value();
+
+  params.max_growth = ui.optimize_growth->isChecked();
+  params.allow_disorder = ui.allow_disorder->isChecked();
+  params.allow_specialists = ui.allow_specialists->isChecked();
+
+  return params;
+}
+
+/**
+ * Changes the parameters displayed by this widget.
+ */
+void governor_widget::set_parameters(const cm_parameter &params)
+{
+  // Labels are updated automatically through signal connections
+
+#define sync_output(name, O_TYPE)                                           \
+  ui.name##_surplus->setValue(params.minimal_surplus[O_TYPE]);              \
+  ui.name##_priority->setValue(params.factor[O_TYPE]);
+  sync_output(food, O_FOOD);
+  sync_output(production, O_SHIELD);
+  sync_output(trade, O_TRADE);
+  sync_output(gold, O_GOLD);
+  sync_output(luxury_goods, O_LUXURY);
+  sync_output(science, O_SCIENCE);
+#undef sync_output
+
+  ui.celebrate_surplus->setChecked(params.require_happy);
+  ui.celebrate_priority->setValue(params.happy_factor);
+
+  ui.optimize_growth->setChecked(params.max_growth);
+  ui.allow_disorder->setChecked(params.allow_disorder);
+  ui.allow_specialists->setChecked(params.allow_specialists);
+}
+
+/**
+ * \fn governor_widget::parameters_changed
+ * Signal emitted when the governor settings are changed. Note that this may
+ * be emitted very often.
+ */
+
+/**
+ * Helper to fill the argument of \ref parameters_changed.
+ */
+void governor_widget::emit_params_changed()
+{
+  emit parameters_changed(parameters());
+}
+
+} // namespace freeciv

--- a/client/widgets/city/governor_widget.h
+++ b/client/widgets/city/governor_widget.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#pragma once
+
+#include "governor.h"
+#include "widgets/city/ui_governor_widget.h"
+
+namespace freeciv {
+
+class governor_widget : public QWidget {
+  Q_OBJECT
+  Ui::governor_widget ui;
+
+public:
+  explicit governor_widget(QWidget *parent = nullptr);
+  virtual ~governor_widget() = default; ///< Destructor.
+
+  cm_parameter parameters() const;
+  void set_parameters(const cm_parameter &params);
+
+signals:
+  void parameters_changed(const cm_parameter &params);
+
+private:
+  void emit_params_changed();
+};
+
+} // namespace freeciv

--- a/client/widgets/city/governor_widget.ui
+++ b/client/widgets/city/governor_widget.ui
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>governor_widget</class>
+ <widget class="QWidget" name="governor_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>253</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="4" column="1">
+    <widget class="QLabel" name="gold_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="4">
+    <widget class="QSlider" name="luxury_goods_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLabel" name="food_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLabel" name="luxury_goods_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QSlider" name="trade_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>&amp;Trade</string>
+     </property>
+     <property name="buddy">
+      <cstring>trade_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="production_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3" colspan="2">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Priority</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QSlider" name="food_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLabel" name="trade_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QSlider" name="production_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QSlider" name="science_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QCheckBox" name="optimize_growth">
+     <property name="text">
+      <string>Optimize</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>&amp;Science</string>
+     </property>
+     <property name="buddy">
+      <cstring>science_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&amp;Production</string>
+     </property>
+     <property name="buddy">
+      <cstring>production_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="science_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QSlider" name="production_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&amp;Food</string>
+     </property>
+     <property name="buddy">
+      <cstring>food_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>&amp;Gold</string>
+     </property>
+     <property name="buddy">
+      <cstring>gold_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="4">
+    <widget class="QSlider" name="celebrate_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLabel" name="label_8">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Minimal Surplus</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="4">
+    <widget class="QSlider" name="gold_priority">
+     <property name="maximum">
+      <number>25</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="sliderPosition">
+      <number>0</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QLabel" name="production_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QLabel" name="gold_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QSlider" name="trade_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="2">
+    <widget class="QCheckBox" name="celebrate_surplus">
+     <property name="text">
+      <string>&amp;Celebrate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QSlider" name="luxury_goods_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="food_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>&amp;Luxury Goods</string>
+     </property>
+     <property name="buddy">
+      <cstring>luxury_goods_surplus</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="3">
+    <widget class="QLabel" name="celebrate_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="2">
+    <widget class="QCheckBox" name="allow_specialists">
+     <property name="text">
+      <string>Allow Specialists</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="trade_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="QLabel" name="science_priority_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="3" colspan="2">
+    <widget class="QCheckBox" name="allow_disorder">
+     <property name="text">
+      <string>Allow Disorder</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="luxury_goods_surplus_label">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="6">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QSlider" name="gold_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QSlider" name="science_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QSlider" name="food_surplus">
+     <property name="minimum">
+      <number>-20</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="pageStep">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>food_surplus</tabstop>
+  <tabstop>food_priority</tabstop>
+  <tabstop>optimize_growth</tabstop>
+  <tabstop>production_surplus</tabstop>
+  <tabstop>production_priority</tabstop>
+  <tabstop>trade_surplus</tabstop>
+  <tabstop>trade_priority</tabstop>
+  <tabstop>gold_surplus</tabstop>
+  <tabstop>gold_priority</tabstop>
+  <tabstop>luxury_goods_surplus</tabstop>
+  <tabstop>luxury_goods_priority</tabstop>
+  <tabstop>science_surplus</tabstop>
+  <tabstop>science_priority</tabstop>
+  <tabstop>celebrate_surplus</tabstop>
+  <tabstop>celebrate_priority</tabstop>
+  <tabstop>allow_specialists</tabstop>
+  <tabstop>allow_disorder</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>food_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>food_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>50</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>51</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>production_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>production_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>77</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>77</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>trade_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>trade_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>gold_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>gold_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>129</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>luxury_goods_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>luxury_goods_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>155</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>155</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>science_surplus</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>science_surplus_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>181</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>181</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>food_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>food_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>610</x>
+     <y>32</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>51</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>production_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>production_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>588</x>
+     <y>59</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>77</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>trade_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>trade_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>588</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>gold_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>gold_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>576</x>
+     <y>119</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>luxury_goods_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>luxury_goods_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>595</x>
+     <y>153</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>155</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>science_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>science_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>590</x>
+     <y>176</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>181</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>celebrate_priority</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>celebrate_priority_label</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>578</x>
+     <y>203</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>209</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/common/aicore/cm.cpp
+++ b/common/aicore/cm.cpp
@@ -2111,6 +2111,9 @@ bool operator==(const struct cm_parameter &p1, const struct cm_parameter &p2)
     }
   }
   output_type_iterate_end;
+  if (p1.max_growth != p2.max_growth) {
+    return false;
+  }
   if (p1.require_happy != p2.require_happy) {
     return false;
   }


### PR DESCRIPTION
As part of the general city dialog rework in https://github.com/longturn/freeciv21/issues/1591, move the widget used to set
governor parameters to its own file. Implement the layout in a .ui file for
easier edits and rework it:

* Add labels with slider values.
* Set slider pageSteps to 1 for more precise edits.
* Expose max_growth, allow_specialists, and allow_disorder.
* Add accelerator shortcuts.
* Improve typography, in particular removing usage of the notify_label font.

The widget is designed to be used horizontally in the future and thus doesn't
fit very well in the current column-based layout.