### PR TITLE
Don't include the minor version in the data path

### DIFF
--- a/utility/cmake_fc_config.h.in
+++ b/utility/cmake_fc_config.h.in
@@ -5,7 +5,7 @@
 #cmakedefine BUG_URL "${BUG_URL}"
 #define WIKI_URL "https://longturn.readthedocs.io/en/latest/"
 
-#define DATASUBDIR "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+#define DATASUBDIR "${PROJECT_VERSION_MAJOR}.0"
 
 #define AI_MOD_DEFAULT "classic"
 


### PR DESCRIPTION
We don't intend to break file formats as often as Freeciv used to, and when we do we'll indicate this with a new major version.

Closes #1853.