### PR TITLE
Docs/Coding Style Guide Update

### DIFF
--- a/docs/Coding/ai.rst
+++ b/docs/Coding/ai.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
@@ -14,7 +13,7 @@ Artificial Intelligence (AI)
 ****************************
 
 
-This document is about Freeciv21's default AI.
+This document is about Freeciv21's default :term:`AI`.
 
 .. warning::
 
@@ -23,27 +22,28 @@ This document is about Freeciv21's default AI.
 Introduction
 ============
 
-The Freeciv21 AI is capable of developing complex nations and provides a challenging opponent for beginners.
-It is, however, still too easy for experienced players, mostly due to it being very predictable.
-Code that implements the AI is divided between the :file:`ai/` and :file:`server/advisors` code directories.
-The latter is used also by human players for automatic helpers such as auto-settlers and auto-explorers.
+The Freeciv21 :term:`AI` is capable of developing complex nations and provides a challenging opponent for
+beginners. It is, however, still too easy for experienced players, mostly due to it being very predictable.
+Code that implements the :term:`AI` is divided between the :file:`ai/` and :file:`server/advisors` code
+directories. The latter is used also by human players for automatic helpers such as auto-settlers and
+auto-explorers.
 
 
 Long-Term AI Development Goals
 ==============================
 
-The long-term goals for Freeciv21 AI development are:
+The long-term goals for Freeciv21 :term:`AI` development are:
 
-* To create a challenging and fun AI for human players to defeat.
-* To create an AI that can handle all the ruleset possibilities that Freeciv21 can offer, no matter how
-  complicated or unique the implementation of the rules.
+* To create a challenging and fun :term:`AI` for human players to defeat.
+* To create an :term:`AI` that can handle all the ruleset possibilities that Freeciv21 can offer, no matter
+  how complicated or unique the implementation of the rules.
 
 
 Want Calculations
 =================
 
 Build calculations are expressed through a structure called :code:`adv_choice`. This has a variable called
-"want", which determines how much the AI wants whatever item is pointed to by :code:`choice->type`.
+"want", which determines how much the :term:`AI` wants whatever item is pointed to by :code:`choice->type`.
 :code:`choice->want` is:
 
 ======== ======
@@ -144,7 +144,7 @@ Then the :code:`find_something_to_kill()` function finds a victim for the (virtu
 :unit:`Riflemen` standing right next to the city. Then the :code:`process_attacker_want()` function figures
 out that since the enemy is right beside us, it can be taken out easier using an :unit:`Artillery`. It also
 figures that a :unit:`Howitzer` would do this job even better, so bumps up our desire for
-:title-reference:`Robotics`.
+:advance:`Robotics`.
 
 
 Ferry System
@@ -188,15 +188,15 @@ degree.
 Diplomacy
 =========
 
-The AI's diplomatic behaviour is current only regulated by the ``diplomacy`` server setting.
+The :term:`AI`'s diplomatic behaviour is current only regulated by the ``diplomacy`` server setting.
 
-AI proposes Cease-fire on first contact.
+:term:`AI` proposes Cease-fire on first contact.
 
-AI is not very trusting for NEUTRAL and PEACE modes, but once it hits ALLIANCE, this changes completely, and
-it will happily hand over any technologies and maps it has to you. The only thing that will make the AI
-attack you then is if you build a Spaceship.
+:term:`AI` is not very trusting for NEUTRAL and PEACE modes, but once it hits ALLIANCE, this changes
+completely, and it will happily hand over any technologies and maps it has to you. The only thing that will
+make the :term:`AI` attack you then is if you build a Spaceship.
 
-For people who want to hack at this part of the AI code, please note:
+For people who want to hack at this part of the :term:`AI` code, please note:
 
 * The ``pplayers_at_war(p1,p2)`` function returns ``FALSE`` if ``p1==p2``
 * The ``pplayers_non_attack(p1,p2)`` function returns ``FALSE`` if ``p1==p2``
@@ -208,10 +208,10 @@ any kind of non-attack treaty with themselves, and we always consider a Nation t
 themself.
 
 The introduction of Diplomacy is fraught with many problems. One is that it usually benefits only human
-players and not AI players, since humans are so much smarter, and know how to exploit Diplomacy. For AIs,
-they mostly only add constraints on what it can do. This means Diplomacy either has to be optional, or have
-fine-grained controls on who can do what Diplomatic deals to whom, which are set from rulesets. The latter is
-not yet well implemented.
+players and not :term:`AI` players, since humans are so much smarter, and know how to exploit Diplomacy. For
+:term:`AI`'s, they mostly only add constraints on what it can do. This means Diplomacy either has to be
+optional, or have fine-grained controls on who can do what Diplomatic deals to whom, which are set from
+rulesets. The latter is not yet well implemented.
 
 Difficulty Levels
 =================
@@ -227,10 +227,10 @@ There are currently seven difficulty levels:
 #. Experimental
 
 The ``hard`` level is no-holds-barred. ``Cheating`` is the same except that it has ruleset defined extra
-bonuses, while ``normal`` has a number of handicaps. In ``easy``, the AI also does random stupid things
-through the :code:`ai_fuzzy()` function. In ``novice`` the AI researches slower than normal players. The
-``experimental`` level is only for coding. You can gate new code with the ``H_EXPERIMENTAL`` handicap and test
-``experimental`` level AIs against ``hard`` level AIs.
+bonuses, while ``normal`` has a number of handicaps. In ``easy``, the :term:`AI` also does random stupid
+things through the :code:`ai_fuzzy()` function. In ``novice`` the :term:`AI` researches slower than normal
+players. The ``experimental`` level is only for coding. You can gate new code with the ``H_EXPERIMENTAL``
+handicap and test ``experimental`` level :term:`AI`'s against ``hard`` level :term:`AI`'s.
 
 Other handicaps used are:
 
@@ -259,18 +259,18 @@ Things That Need To Be Fixed
 ============================
 
 * Cities do not realize units are on their way to defend it.
-* AI builds cities without regard to danger at that location.
-* AI will not build cross-country roads outside of the city vision radius.
+* :term:`AI` builds cities without regard to danger at that location.
+* :term:`AI` will not build cross-country roads outside of the city vision radius.
 * ``Locally_zero_minimap`` is not implemented when wilderness tiles change.
 * If no path to a chosen victim is found, a new victim should be chosen.
 * Emergencies in two cities at once are not handled properly.
-* :unit:`Explorers` will not use ferryboats to get to new lands to explore. The AI will also not build units
-  to explore new islands, leaving Huts alone.
-* AI sometimes believes that wasting a horde of weak military units to kill one enemy is profitable.
+* :unit:`Explorers` will not use ferryboats to get to new lands to explore. The :term:`AI` will also not build
+  units to explore new islands, leaving Huts alone.
+* :term:`AI` sometimes believes that wasting a horde of weak military units to kill one enemy is profitable.
 * Stop building shore defense improvements in landlocked cities with a Lake adjacent.
-* Fix the AI valuation of :improvement:`Supermarket`. It currently never builds it. See the
+* Fix the :term:`AI` valuation of :improvement:`Supermarket`. It currently never builds it. See the
   :code:`farmland_food()` and :code:`ai_eval_buildings()` functions in :file:`advdomestic.cpp`.
-* Teach the AI to coordinate the units in an attack.
+* Teach the :term:`AI` to coordinate the units in an attack.
 
 
 Idea Space

--- a/docs/Coding/architecture.rst
+++ b/docs/Coding/architecture.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Architecture
 ************
@@ -25,16 +24,16 @@ Repository Organization
 The source code is organized in directories at the root of the repository. The client and server share a lot
 of code found in the :file:`common` and :file:`utility` folders. The first one contains code to manage the
 game state, of which both the client and server have a copy, and the second is home to various lower-level
-utilities that do not have an equivalent in Qt or the standard library. Freeciv21 also ships with a couple of
-external dependencies under :file:`dependencies`.
+utilities that do not have an equivalent in Qt or the C standard library. Freeciv21 also ships with a couple
+of external dependencies under :file:`dependencies`.
 
 The client code is found in the :file:`client` folder. The server code is located under :file:`server`,
-with the exception of the computer ("AI") players which is under :file:`ai`. The code for other programs
+with the exception of the computer (:term:`AI`) players which is under :file:`ai`. The code for other programs
 bundled with Freeciv21, such as the :doc:`Modpack Installer </Manuals/modpack-installer>`, is located under
 :file:`tools`.
 
 All the assets used by the client and server are grouped under :file:`data`. This includes among
-others :doc:`rulesets </Modding/Rulesets/overview>` and :ref:`tilesets <Modding/index:Tilesets>`.
+others :doc:`rulesets </Modding/Rulesets/overview>` and :ref:`tilesets <modding-tilesets>`.
 Localization files are located under :file:`translations`.
 
 There are a few additional folders that you will touch less often. The table below describes the complete

--- a/docs/Coding/attributes.rst
+++ b/docs/Coding/attributes.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Attribute Blocks
 ****************

--- a/docs/Coding/fcdb.rst
+++ b/docs/Coding/fcdb.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 Authentication and Database Support (fcdb)
 ******************************************
@@ -44,7 +43,7 @@ is entirely sufficient for a SQLite setup.
 
 Now start the server with:
 
-.. code-block:: rst
+.. code-block:: sh
 
     freeciv21-server --Database fc_auth.conf --auth --Newusers
 
@@ -99,7 +98,8 @@ table layout.
 
 The script lives in :file:`data/database.lua` in the source tree, and is installed to
 ``CMAKE_INSTALL_PREFIX``. Depending on the options given to ``cmake`` at build time, this may be a location
-such as :file:`/usr/local/etc/freeciv21/database.lua.`
+such as :file:`/usr/local/etc/freeciv21/database.lua.` Refer to :doc:`/Getting/compile` for more information
+on ``CMAKE_INSTALL_PREFIX``.
 
 The supplied version supports basic authentication against a SQLite database. It supports configuration as
 shown in the following example:
@@ -117,7 +117,7 @@ shown in the following example:
     table_log="loginlog"
 
 
-If that's sufficient for you, it's not necessary to read on. Freeciv21 expects the following lua functions
+If that is sufficient for you, it is not necessary to read on. Freeciv21 expects the following lua functions
 to be defined in :file:`database.lua`:
 
 * Try to load data for an existing user.

--- a/docs/Coding/hacking.rst
+++ b/docs/Coding/hacking.rst
@@ -1,10 +1,9 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
-    SPDX-FileCopyrightText: 2022 NIKEA-SOFT
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
+..  SPDX-FileCopyrightText: NIKEA-SOFT
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
@@ -24,14 +23,15 @@ The Server
 Server Autogame Testing
 -----------------------
 
-Code changes should always be tested before submission for inclusion into the GitHub source tree. It is
-useful to run the client and server as autogames to verify either a particular savegame no longer shows a
-fixed bug, or as a random sequence of games in a while loop overnight.
+Code changes should always be tested before submission for inclusion into the
+:doc:`GitHub </Contributing/pull-request>` source tree. It is useful to run the client and server as autogames
+to verify either a particular savegame no longer shows a fixed bug, or as a random sequence of games in a
+while loop overnight.
 
-To start a server game with all AI players, create a file (below named :file:`civ.serv`) with lines such as
-the following:
+To start a server game with all :term:`AI` players, create a file (below named :file:`civ.serv`) with lines
+such as the following:
 
-.. code-block:: sh
+.. code-block:: ini
 
     # set gameseed 42       # repeat a particular game (random) sequence
     # set mapseed 42        # repeat a particular map generation sequence
@@ -55,8 +55,8 @@ The commandline to run server-only games can be typed as variations of:
 
 
 To attach one or more clients to an autogame, remove the :code:`start` command, start the server program and
-attach clients to created AI players. Or type :code:`aitoggle <player>` at the server command prompt for each
-player that connects. Finally, type :code:`start` when you are ready to watch the show.
+attach clients to created :term:`AI` players. Or type :code:`aitoggle <player>` at the server command prompt
+for each player that connects. Finally, type :code:`start` when you are ready to watch the show.
 
 .. note::
     The server will eventually flood a client with updates faster than they can be drawn to the screen,
@@ -75,7 +75,7 @@ Old Lists
 
 For variable length list of units and cities Freeciv21 uses a :code:`genlist`, which is implemented in
 :file:`utility/genlist.cpp`. By some macro magic type specific macros have been defined, creating a lot of
-trouble for C++ programmers. These macro-based lists are being phased out in favor of STL containers; in the
+trouble for C++ programmers. These macro-based lists are being phased out in favor of STL containers. In the
 meantime, we preserve here an explanation of how to use them.
 
 For example a ``tile`` struct (the pointer to it we call :code:`ptile`) has a ``unit`` list,
@@ -119,9 +119,9 @@ the mask-pixmaps will not be generated properly, which will certainly not give a
 Each terrain tile is drawn in 16 versions, all the combinations with a green border in one of the main
 directions. Hills, Mountains, Forests, and Rivers are treated in special cases.
 
-Isometric tilesets are drawn in a similar way to how civ2 draws (that is why civ2 graphics are compatible). For
-each base terrain type there exists one tile sprite for that terrain. The tile is blended with nearby tiles to
-get a nice-looking boundary. This is erroneously called "dither" in the code.
+Isometric tilesets are drawn in a similar way to how civ2 draws (that is why civ2 graphics are compatible).
+For each base terrain type there exists one tile sprite for that terrain. The tile is blended with nearby
+tiles to get a nice-looking boundary. This is erroneously called "dither" in the code.
 
 Non-isometric tilesets draw the tiles in the "original" Freeciv21 way, which is both harder and less pretty.
 There are multiple copies of each tile, so that a different copy can be drawn depending on the terrain type of
@@ -471,7 +471,7 @@ introduced :code:`map_x/map_y` or :code:`nat_x/nat_y` to help distinguish whethe
 are being used. Other places are not yet rigorous in keeping them apart, and will often just name their
 variables :code:`x` and :code:`y`. The latter can usually be assumed to be map coordinates.
 
-Note that if you don't need to do some abstract geometry exploit, you will mostly use tile pointers, and give
+Note that if you do not need to do some abstract geometry exploit, you will mostly use tile pointers, and give
 to map tools the ability to perform what you want.
 
 Note that :code:`map.xsize` and :code:`map.ysize` define the dimension of the map in :code:`_native_`
@@ -564,11 +564,11 @@ While :code:`tile_get_known()` returns:
 The values :code:`TILE_UNKNOWN` and :code:`TILE_KNOWN_SEEN` are straightforward. :code:`TILE_KNOWN_UNSEEN` is
 a tile of which the user knows the terrain, but not recent cities, roads, etc.
 
-:code:`TILE_UNKNOWN` tiles never are (nor should be) sent to the client. In the past, :code:`UNKNOWN` tiles that
-were adjacent to :code:`UNSEEN` or :code:`SEEN` were sent to make the drawing process easier, but this has now
-been removed. This means exploring new land may sometimes change the appearance of existing land (but this is
-not fundamentally different from what might happen when you transform land). Sending the extra info, however,
-not only confused the goto code but allowed cheating.
+:code:`TILE_UNKNOWN` tiles never are (nor should be) sent to the client. In the past, :code:`UNKNOWN` tiles
+that were adjacent to :code:`UNSEEN` or :code:`SEEN` were sent to make the drawing process easier, but this
+has now been removed. This means exploring new land may sometimes change the appearance of existing land (but
+this is not fundamentally different from what might happen when you transform land). Sending the extra info,
+however, not only confused the goto code but allowed cheating.
 
 Fog of War is the fact that even when you have seen a tile once you are not sent updates unless it is inside
 the sight range of one of your units or cities.

--- a/docs/Coding/hacking.rst
+++ b/docs/Coding/hacking.rst
@@ -31,7 +31,7 @@ while loop overnight.
 To start a server game with all :term:`AI` players, create a file (below named :file:`civ.serv`) with lines
 such as the following:
 
-.. code-block:: ini
+.. code-block:: sh
 
     # set gameseed 42       # repeat a particular game (random) sequence
     # set mapseed 42        # repeat a particular map generation sequence

--- a/docs/Coding/internationalization.rst
+++ b/docs/Coding/internationalization.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Internationalization
 ********************

--- a/docs/Coding/logging.rst
+++ b/docs/Coding/logging.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 louis94 <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Logging
 *******
@@ -44,7 +43,7 @@ Name                     Used for
 
 For instance, one could disable stack traces and enable Go To ``debug`` message by setting:
 
-.. code-block:: rst
+.. code-block:: sh
 
     export QT_LOGGING_RULES="freeciv.stacktrace*=false\nfreeciv.goto.debug=true"
 

--- a/docs/Coding/network-protocol.rst
+++ b/docs/Coding/network-protocol.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 Network Protocol
 ****************
@@ -173,7 +172,7 @@ denoted by an ``index`` of 255.
 For fields of struct type (or arrays of struct) the following function is used to compare entries, where foo
 stands for the name of the struct:
 
-.. code-block:: rst
+.. code-block:: cpp
 
     bool are_foo_equal(const struct foo *a, const struct foo *b);
 
@@ -230,7 +229,8 @@ Adding a packet:
 
 #. Choose an unused packet number. The generator will make sure that you do not use the same number two times.
 #. Choose a packet name. It should follow the naming style of the other packets:
-   ``PACKET_<group>_<remaining>``. The ``<group>`` may be ``SERVER``, ``CITY``, ``UNIT``, ``PLAYER``, and ``DIPLOMACY``.
+   ``PACKET_<group>_<remaining>``. The ``<group>`` may be ``SERVER``, ``CITY``, ``UNIT``, ``PLAYER``, and
+   ``DIPLOMACY``.
 #. Decide if this packet goes from server to client or client to server.
 #. Choose the field names and types.
 #. Choose packet and field flags.

--- a/docs/Coding/scorelog.rst
+++ b/docs/Coding/scorelog.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 Format Description of the Scorelog
 **********************************


### PR DESCRIPTION
Part of #1250

Updating to match style guide
* Standard SPDX attribution header
* Proper capitalization rules
* Image `:numref:` usage
* Cross document `:ref:` usage
* Consonant usage
* Glossary usage
