### PR TITLE
Docs/contrib update to Style Guide

### DIFF
--- a/docs/Contributing/bugs.rst
+++ b/docs/Contributing/bugs.rst
@@ -1,6 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 Filing Bugs and Enhancement Requests
 ************************************
@@ -28,7 +28,7 @@ note of the following when thinking of submitting an issue.
 * Check that it is not listed as a known issue. For a continuously updated list, see:
   https://github.com/longturn/freeciv21/issues
 
-* Check the Freeciv21 Releases page at https://github.com/longturn/freeciv21/releases, to ensure you're
+* Check the Freeciv21 Releases page at https://github.com/longturn/freeciv21/releases, to ensure you are
   playing the latest version. We may have already fixed the problem.
 
 * If the first two items do not work, then feel free to submit a new issue. We have implemented GitHub issue
@@ -40,4 +40,5 @@ note of the following when thinking of submitting an issue.
     developers of Freeciv21 understand the nature of the issue.
 
   * If there is an issue in a translation, please report it. We are still getting organized with
-    internationalization (i18n) support for the client and server. The more we know the better.
+    :doc:`internationalization </Coding/internationalization>` (i18n) support for the client and server.
+    The more we know the better.

--- a/docs/Contributing/capitalized-terms.rst
+++ b/docs/Contributing/capitalized-terms.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit

--- a/docs/Contributing/dev-env.rst
+++ b/docs/Contributing/dev-env.rst
@@ -1,6 +1,5 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 Set up a Development Environment
 ********************************
@@ -65,7 +64,7 @@ You can get the appropriate path by going to your forked copy in a browser, clic
 select the SSH option as shown in this sample screenshot:
 
 .. GitHub Clone SSH:
-.. figure:: ../_static/images/github_clone_ssh.png
+.. figure:: /_static/images/github_clone_ssh.png
     :align: center
     :height: 250
     :alt: GitHub Clone SSH
@@ -105,7 +104,7 @@ On Linux, the easiest way to install KDevelop is with a command such as this:
 
 .. code-block:: sh
 
-    sudo apt install kdevelop
+    $ sudo apt install kdevelop
 
 
 Once installed, you can then import the Freeciv21 project into it. Follow these steps:
@@ -114,6 +113,9 @@ Once installed, you can then import the Freeciv21 project into it. Follow these 
 #. :menuselection:`Project --> Open/Import Project`
 #. Find :file:`freeciv21/CMakeLists.txt`
 #. :menuselection:`Session --> Rename Current Session` to Freeciv21
+#. :menuselection:`Project --> Open Configuration --> Language Support`. Click on the
+   :guilabel:`Language Support` tab and ensure that the C++ Profile is `c++17`, the C Profile is `c99`, the
+   OpenCL C Profile is `CL1.1`, the CUDA C Profile is `c++11`, and finall the Compiler for Path is `GCC`.
 #. Allow kdevelop to parse all of the code. This can take a while. Eventually you will see a full tree of
    the code in the Projects tab on the left.
 
@@ -134,7 +136,7 @@ you will want to install Qt Creator. You do so with a command such as this:
 
 .. code-block:: sh
 
-    sudo apt install qtcreator
+    $ sudo apt install qtcreator
 
 
 Once installed you will get access to a program called :strong:`Qt Designer`. This tool is a graphical

--- a/docs/Contributing/eval-pull-request.rst
+++ b/docs/Contributing/eval-pull-request.rst
@@ -1,8 +1,7 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 louis94 <m_louis30@yahoo.com>
-    SPDX-FileCopyrightText: 2022 Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-FileCopyrightText: Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
 
 Evaluating a Pull Request
 *************************
@@ -22,41 +21,41 @@ This page assumes the user knows how to use :file:`git`, compile Freeciv21 and u
 
 :strong:`Create A Testing Branch`
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ git fetch upstream master
-  $ git checkout -b testing/pr_[pr-number] upstream/master
+    $ git fetch upstream master
+    $ git checkout -b testing/pr_[pr-number] upstream/master
 
 
 :strong:`Get A Copy Of The Pull Request`
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ wget https://github.com/longturn/freeciv21/pull/[pr-number].diff -O pr[pr-number].diff
+    $ wget https://github.com/longturn/freeciv21/pull/[pr-number].diff -O pr[pr-number].diff
 
 
 :strong:`Apply The Downloaded Update To Local`
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ patch -p1 < pr[pr-number].diff
+    $ patch -p1 < pr[pr-number].diff
 
 
 :strong:`Ensure The Build Directory Is Empty`
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ rm -Rf build
+    $ rm -Rf build
 
 
 :strong:`Configure And Compile The Code`
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ cmake . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install
-  $ cmake --build build
-  $ cmake --build build --target install
-  $ cmake --build build --target package      # MSys2 and Debian Linux Only
+    $ cmake . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install
+    $ cmake --build build
+    $ cmake --build build --target install
+    $ cmake --build build --target package      # MSys2 and Debian Linux Only
 
 
 :strong:`Read The Issue's Notes`
@@ -70,8 +69,8 @@ probably have to re-download the diff and run another test.
 If it is a big change, it might be worthwhile to run an entire game with just AI to make sure it does not
 break anything. You can compile the code, with additional checks such as address sanitizer with
 :code:`$ cmake . --preset ASan`. Once the code is compiled, you can run the autogame with
-:code:`./build/freeciv21-server -r ./data/test-autogame.serv`. You can also observe the game with
-:code:`./build/freeciv21-client -a -p 5556 -s localhost`. ASan by default halts on every error, this is
+:code:`$ ./build/freeciv21-server -r ./data/test-autogame.serv`. You can also observe the game with
+:code:`$ ./build/freeciv21-client -a -p 5556 -s localhost`. ASan by default halts on every error, this is
 sometimes useful to developers to fix the errors sequentially. If you'd rather prefer listing all the errors
 at once, set the environment variable using :code:`$ export ASAN_OPTIONS="halt_on_error=0"`
 
@@ -85,10 +84,10 @@ at once, set the environment variable using :code:`$ export ASAN_OPTIONS="halt_o
 
 * Checkout the ``master`` branch and delete the testing branch:
 
-.. code-block:: rst
+.. code-block:: sh
 
-  $ git checkout master
-  $ git branch -d testing/pr_[pr-number]
+    $ git checkout master
+    $ git branch -d testing/pr_[pr-number]
 
 
 Art PRs

--- a/docs/Contributing/msys2.rst
+++ b/docs/Contributing/msys2.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 zekoz
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: zekoz
 
 Setting up MSYS2 for Windows
 ****************************
@@ -65,7 +64,7 @@ This chapter is about creating a new MSYS2 build environment.
     * mingw-w64-i686-libunwind / mingw-w64-x86_64-libunwind
     * mingw-w64-i686-make / mingw-w64-x86_64-make
     * mingw-w64-i686-python3 / mingw-w64-x86_64-python3
-    * mingw-w64-i686-python-pip / mingw-w64-x86_64-python-pip
+    * mingw-w64-i686-python3-pip / mingw-w64-x86_64-python3-pip
 
 #. Arch-specific optional packages for building common parts (i686 or x86_64, but not both).
 
@@ -82,13 +81,13 @@ This chapter is about creating a new MSYS2 build environment.
 
     * mingw-w64-i686-nsis / mingw-w64-x86_64-nsis
 
-#. Add some environment variables to the ``.bash_profile`` file. The code sample assumes x86_64.
+#. Add some environment variables to the :file:`.bash_profile` file. The code sample assumes x86_64.
 
 .. code-block:: sh
 
-  export PATH=/mingw64/bin:${PATH}
-  export MSYSTEM=MINGW64
-  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+    export PATH=/mingw64/bin:${PATH}
+    export MSYSTEM=MINGW64
+    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
 
 
 Premade Environment

--- a/docs/Contributing/pull-request.rst
+++ b/docs/Contributing/pull-request.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
 
 How to Submit a Pull Request
 ****************************
@@ -9,12 +8,12 @@ How to Submit a Pull Request
 A Pull Request (PR), also commonly known as a Merge Request, is a mechanism to "pull" code from one repository
 into another one and merge the change into the source repository.
 
-Before we go much further, let's take a few minutes to describe what happened when you :doc:`dev-env` and to
+Before we go much further, let us take a few minutes to describe what happened when you :doc:`dev-env` and to
 define a few terms that will help with further instructions. Starting with a diagram of the setup of the three
 locations where code resides:
 
 .. _GitHub Repositories:
-.. figure:: ../_static/images/github_repos.png
+.. figure:: /_static/images/github_repos.png
     :align: center
     :height: 300
     :alt: Diagram of GitHub Repositories
@@ -30,11 +29,11 @@ it is highly recommended you read the first three chapters of the
 * :strong:`Upstream`: This refers to the source (original) repository. For us this is the Longturn Freeciv21
   or Games repositories.
 * :strong:`Origin`: This refers to the fork you made in your own personal GitHub account.
-* :strong:`Local`: This isn't a :file:`git` term per se, but is a well understood industry standard way of
+* :strong:`Local`: This is not a :file:`git` term per se, but is a well understood industry standard way of
   referring to the copy of code on a person's computer. This is where the changes are made and eventually
   make it back up to origin and over to upstream via a Pull Request.
 
-The arrows represent the path that updates (e.g. changes) of files occurs.
+The arrows represent the path that updates (e.g. changes) of files occur.
 
 1. File updates from `Upstream` are downloaded (pulled) to `Local`.
 2. After changes are made, file updates from `Local` are uploaded (pushed) to `Origin`.
@@ -57,8 +56,8 @@ Upstream:
 
 .. code-block:: sh
 
-  ~/GitHub/freeciv21$ git checkout master
-  ~/GitHub/freeciv21$ git pull upstream master --ff-only
+    ~/GitHub/freeciv21$ git checkout master
+    ~/GitHub/freeciv21$ git pull upstream master --ff-only
 
 
 The first command sets the working branch to ``master`` on Local. The second command downloads the changes
@@ -78,7 +77,7 @@ Now that things are all up to date with the lastest code, let's create a branch 
 
 .. code-block:: sh
 
-  ~/GitHub/freeciv21$ git checkout -b [some_feature] upstream/master
+    ~/GitHub/freeciv21$ git checkout -b [some_feature] upstream/master
 
 
 The tag :code:`[some_feature]` should be replaced by something that matches what you are planning to work on.
@@ -101,11 +100,11 @@ updates.
 
 .. code-block:: sh
 
-  ~/GitHub/freeciv21$ rm -Rf build
-  ~/GitHub/freeciv21$ cmake . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install -DCMAKE_BUILD_TYPE=Debug
-  ~/GitHub/freeciv21$ cmake --build build
-  ~/GitHub/freeciv21$ cmake --build build --target install
-  ~/GitHub/freeciv21$ cmake --build build --target docs
+    ~/GitHub/freeciv21$ rm -Rf build
+    ~/GitHub/freeciv21$ cmake . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install -DCMAKE_BUILD_TYPE=Debug
+    ~/GitHub/freeciv21$ cmake --build build
+    ~/GitHub/freeciv21$ cmake --build build --target install
+    ~/GitHub/freeciv21$ cmake --build build --target docs
 
 The first command cleans out the :file:`build` directory to start with a fresh configuration. The second
 command runs a configure process and then sets things up to do the install portion inside the same
@@ -116,7 +115,7 @@ documentation that you are reading right now. You can open :file:`./build/docs/i
 generated copy of the documentation prior to pushing a change up.
 
 .. note::
-  You don't have to start from the top of the list of commands every time you want to check on things. If you
+  You do not have to start from the top of the list of commands every time you want to check on things. If you
   have already done a full pass to install and then make some more changes, you can go straight to the build
   and install commands. The :file:`cmake` program is smart enough to determine what changed and only compile
   those files again. It's much faster to do things this way!
@@ -124,7 +123,7 @@ generated copy of the documentation prior to pushing a change up.
 
 One more thing to note here, this section is only talking about making changes to the Freeciv21 repository and
 has not really talked about the Games repository, nor talked about Rulesets or Tilesets. In this scenario,
-there isn't any compiling going on. The Ruleset or Tileset editor is editing files and testing locally. The
+there is not any compiling going on. The Ruleset or Tileset editor is editing files and testing locally. The
 Longturn Games repository is effectively a repository of Rulesets.
 
 
@@ -142,18 +141,18 @@ one commit into a Pull Request then you can read about `git add <https://git-scm
 
 .. code-block:: sh
 
-  ~/GitHub/freeciv21$ git status
-  ~/GitHub/freeciv21$ git add --all
-  ~/GitHub/freeciv21$ git clang-format
-  ~/GitHub/freeciv21$ git add --all
-  ~/GitHub/freeciv21$ git commit
+    ~/GitHub/freeciv21$ git status
+    ~/GitHub/freeciv21$ git add --all
+    ~/GitHub/freeciv21$ git clang-format
+    ~/GitHub/freeciv21$ git add --all
+    ~/GitHub/freeciv21$ git commit
 
 
 The :file:`git status` command is used to list out all the changes that :file:`git` has seen. Changed files,
 new files, moved files, etc. are all listed. This command comes in handy when you want to organize your Pull
 Request into more than one commit. It's also very useful to ensure that what you see as changed follows along
 with what you THINK you have actually changed. Sometimes in the course of editing you may inadvertantly made
-a change to another file that you didn't intend to actually change. If you find that you accidentially changed
+a change to another file that you did not intend to actually change. If you find that you accidentially changed
 a file, you can use the :file:`git restore <file>` command. This is also shown on the :file:`git status`
 command output.
 
@@ -166,8 +165,8 @@ it will tell you so. If that happens, then you need to run a subsequent :file:`g
 those files added back into the commit.
 
 Once everything looks good from a :file:`git status` perspective, then issue the last command. The last
-command, :file:`git commit`, will open a text editor (in Debian based systems this is often ``nano``). Put a
-message at the bottom below all of the hashes ( ``#`` ) and then save.
+command, :file:`git commit`, will open a text editor (in Debian based systems this is often :file:`nano`). Put
+a message at the bottom below all of the hashes ( ``#`` ) and then save.
 
 You now have a commit of changes that you need to push to Origin.
 
@@ -179,7 +178,7 @@ This is the last major step in the process. To push the commit to your fork, iss
 
 .. code-block:: sh
 
-  ~/GitHub/freeciv21$ git push origin
+    ~/GitHub/freeciv21$ git push origin
 
 
 You will be prompted for your SSH passkey and then the changes in the branch you created in

--- a/docs/Contributing/release.rst
+++ b/docs/Contributing/release.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
-.. SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>s
 
 The Release Process
@@ -41,7 +41,7 @@ These are the general steps to prepare and finalize a release:
       open a PR for this change to ``master``. This way, development builds from ``master`` will immediately
       use the version number of the next stable.
 
-#. If the release is a :strong:`release candidate` or a :strong:`stable release`, the release manager will
+#. If the release is a :strong:`release candidate` for a :strong:`stable release`, the release manager will
    make sure that the :guilabel:`Target` branch in the release draft is set to ``stable``.
 #. The release manager will add a tag to the release notes page and then click :guilabel:`Publish Release`.
    The format of the tag is ``v[major version].[minor version]-[pre-release name].[number]``. For example:
@@ -62,6 +62,8 @@ These are the general steps to prepare and finalize a release:
    browser.
 #. The release manager mentions user @Corbeau on Discord ``#releases-project`` channel giving the new URL to
    update his blog page once all of the GitHub action runners are complete.
+#. The release manager mentions user @panch93 on Discord ``#releases-project`` channel so he can update the
+   Arch AUR with the latest release.
 
 
 Behind the Scenes

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -1,7 +1,6 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 Louis Moureaux <m_louis30@yahoo.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+..  SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
@@ -66,6 +65,34 @@ Heading 4
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+Attribution
+===========
+
+As with our code, the documentation is written by contributors and proper attribution should always be given.
+We follow the `SPDX <https://spdx.dev/>`_ standard for attribution in all our documentation, music, and art
+files. For documentation files, we can the proper SPDX header to the very top of the page. For music and art
+we add a text license file along with the primary file. For example if we have :file:`art.png`, then there
+should be a corresponding :file:`art.png.license` file to give proper attribution. We use the GPL v3.0 or
+later license. Here is what the SPDX header should look like in all scenarios:
+
+.. code-block:: rst
+
+    ..  SPDX-License-Identifier: GPL-3.0-or-later
+    ..  SPDX-FileCopyrightText: [contributor name or handle] <[contributor email address]>
+
+
+.. note::
+    We do not add the copydate date to our attribution blocks. There is recent commentary that this is not
+    needed and leaving the date off makes keeping header blocks up to date easier.
+
+If the file you are working with came from legacy Freeciv, please add this line to the SPDX header for proper
+attribution:
+
+.. code-block:: rst
+
+    ..  SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+
 Interpreted Text Roles
 ======================
 
@@ -94,7 +121,7 @@ to alter is placed inside back-ticks.
   :menuselection:`Game --> Local Options`. To denote submenus, use a test arrow like this: :literal:`-->`
   between the selection items.
 * :literal:`:strong:` -- Strong is used to :strong:`bold some text`. A good use of :literal:`:strong:` is to
-  highlight game elements, such as technologies.
+  highlight game elements.
 * :literal:`:title-reference:` -- Title Reference is used notate a :title-reference:`title entry` in the
   in-game help or to refer to a page in the documentation without giving an actual hyperlink reference
   (see :literal:`:doc:` above).
@@ -121,11 +148,11 @@ Admonitions are specially marked "topics" that can appear anywhere an ordinary b
 admonition is rendered as an offset block in a document, sometimes outlined or shaded, with a title matching
 the admonition type. We use some of the standard admonitions in our documentation as well.
 
-* :literal:`.. attention::` -- Use attention to bring a very important high profile item to the reader's
+* :literal:`.. attention::` -- Use Attention to bring a very important high profile item to the reader's
   attention.
 
 .. attention::
-    This is a really important message! Don't forget to eat breakfast every day.
+    This is a really important message! Do not forget to eat breakfast every day.
 
 * :literal:`.. todo::` -- Use To Do as a reminder for documentation editors to come back and fix things at
   a later date.
@@ -133,13 +160,14 @@ the admonition type. We use some of the standard admonitions in our documentatio
 .. todo::
     Come back and fix something later.
 
-* :literal:`.. note::` --  Use the "note" as the way to give more information to the reader on a topic.
+* :literal:`.. note::` --  Use the Note as the way to give more information to the reader on a topic.
 
 .. note::
-    It's important to note that Freeciv21 is really fun to play with groups of people online.
+    It is important to note that Freeciv21 is really fun to play with groups of people online.
 
 * :literal:`.. code-block:: rst` -- The code block is an excellent way to display actual code or any
-  pre-formatted plain text.
+  pre-formatted plain text. The tag ``rst`` can be replaces by ``sh``, ``cpp``, and ``ini`` as well to give
+  different types of markup for shell commands, C++ code, and ini file formatting.
 
 .. code-block:: rst
 
@@ -150,7 +178,7 @@ Language Usage Elements
 =======================
 
 The documentation is written mostly in US English (en_US), however elements of Queen's English (e.g. en_GB)
-are also found in the documentation. The two forms of English are close enough that we don't worry too much
+are also found in the documentation. The two forms of English are close enough that we do not worry too much
 if one author uses "color" and another uses "colour". Any reader or language translator will be able to figure
 out what the author is trying to say. However, there are some standards that documentation authors do need to
 adhere to, so the documentation is consistently formatted and certain language elements are always used the
@@ -173,7 +201,9 @@ Capitalization
       :doc:`See here for a list. <capitalized-terms>`
 
       This is particularly useful with words that are used ambiguously in the game, such as "granary" which is
-      both the amount of food a city needs before growing and an improvement in many rulesets, or "transport".
+      both the amount of food a city needs before growing and an improvement in many rulesets. Another
+      example is "transport" which covers both the movement of units on a ship and the particular unit type of
+      :unit:`Transport`.
 
     When describing elements of the user interface, use the same capitalization as in the game and wrap the
     text inside markup elements with the :literal:`:guilabel:` or :literal:`:menuselection:` roles. They are
@@ -214,7 +244,7 @@ Figure Numbers
     .. code-block:: rst
 
         .. _Start Screen:
-        .. figure:: ../../_static/images/gui-elements/start-screen.png
+        .. figure:: /_static/images/gui-elements/start-screen.png
           :scale: 65%
           :align: center
           :alt: Freeciv21 Start Screen
@@ -246,9 +276,9 @@ code could be typeset in monospace with ``\texttt{}``, or defining a few symbols
 a long reasoning. The main guideline for formulas is to take your time to make them as readable as possible.
 
 Formulas use the ``:math:`` role or the ``.. math::`` directive. These blocks support most of the LaTeX
-`mathematics syntax <https://en.wikibooks.org/wiki/LaTeX/Mathematics>`_. The ``:math:`` role is used for inline
-math in a paragraph. For instance, ``:math:`a+b=1``` becomes :math:`a+b=1`. The directive is used for longer
-or more important formulas that come on their own line:
+`mathematics syntax <https://en.wikibooks.org/wiki/LaTeX/Mathematics>`_. The ``:math:`` role is used for
+inline math in a paragraph. For instance, ``:math:`a+b=1``` becomes :math:`a+b=1`. The directive is used for
+longer or more important formulas that come on their own line:
 
 .. math::
   a+b=1.

--- a/docs/Contributing/visual-studio.rst
+++ b/docs/Contributing/visual-studio.rst
@@ -1,6 +1,5 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 Visual Studio for Windows
 *************************
@@ -68,7 +67,7 @@ The directory can be anywhere, however the author prefers to :strong:`not` insta
 :file:`C:\\` drive.
 
 Open an Administrative elevated PowerShell terminal window. The easiest way to do this is to right-click on
-the Start Menu and select it from the menu: :guilabel:`Windows PowerShell (Admin)`.
+the :guilabel:`Start Menu` and select it from the menu: :guilabel:`Windows PowerShell (Admin)`.
 
 .. code-block:: sh
 
@@ -241,9 +240,9 @@ these commands:
 
 .. code-block:: sh
 
-  cmake . -B build-vs -G "Visual Studio 17 2022" -DFREECIV_USE_VCPKG=ON -DCMAKE_INSTALL_PREFIX=./build-vs/install
-  cmake --build build-vs
-  cmake --build build-vs --target install
+    cmake . -B build-vs -G "Visual Studio 17 2022" -DFREECIV_USE_VCPKG=ON -DCMAKE_INSTALL_PREFIX=./build-vs/install
+    cmake --build build-vs
+    cmake --build build-vs --target install
 
 
 The first command configures Visual Studio to compile a Debug version of the programs and places the install


### PR DESCRIPTION
Closes #809
Part of #1250 

Updating to match style guide
* Standard SPDX attribution header
* Proper capitalization rules
* Image `:numref:` usage
* Cross document `:ref:` usage
* Consonant usage
* Glossary usage

