### PR TITLE
Fix loading unhappy sprites when there is more than one

### DIFF
--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -2757,18 +2757,18 @@ static void tileset_lookup_sprite_tags(struct tileset *t)
     auto sprite = load_sprite(t, buffer);
     if (sprite) {
       t->sprites.upkeep.output[o].push_back(sprite);
-    }
-    // Start from "upkeep.food2"; there is no "upkeep.food1"
-    for (i = 2;; i++) {
-      buffer =
-          QStringLiteral("upkeep.%1%2")
-              .arg(get_output_identifier(static_cast<Output_type_id>(o)),
-                   QString::number(i + 1));
-      auto sprite = load_sprite(t, buffer);
-      if (!sprite) {
-        break;
+      // Start from "upkeep.food2"; there is no "upkeep.food1"
+      for (i = 2;; i++) {
+        buffer =
+            QStringLiteral("upkeep.%1%2")
+                .arg(get_output_identifier(static_cast<Output_type_id>(o)),
+                     QString::number(i));
+        auto sprite = load_sprite(t, buffer);
+        if (!sprite) {
+          break;
+        }
+        t->sprites.upkeep.output[o].push_back(sprite);
       }
-      t->sprites.upkeep.output[o].push_back(sprite);
     }
   }
   output_type_iterate_end;

--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -2741,7 +2741,8 @@ static void tileset_lookup_sprite_tags(struct tileset *t)
   if (!t->sprites.upkeep.unhappy.back()) {
     tileset_error(t, LOG_FATAL, "Missing sprite upkeep.unhappy");
   }
-  for (i = 1;; i++) {
+  // Start from "upkeep.unhappy2"; there is no "upkeep.unhappy1"
+  for (i = 2;; i++) {
     buffer = QStringLiteral("upkeep.unhappy%1").arg(QString::number(i));
     auto sprite = load_sprite(t, buffer);
     if (!sprite) {
@@ -2757,7 +2758,8 @@ static void tileset_lookup_sprite_tags(struct tileset *t)
     if (sprite) {
       t->sprites.upkeep.output[o].push_back(sprite);
     }
-    for (i = 1;; i++) {
+    // Start from "upkeep.food2"; there is no "upkeep.food1"
+    for (i = 2;; i++) {
       buffer =
           QStringLiteral("upkeep.%1%2")
               .arg(get_output_identifier(static_cast<Output_type_id>(o)),


### PR DESCRIPTION
We were looking for "upkeep.unhappy1", which is actually "upkeep.unhappy" for
historical reasons. So start by looking for "upkeep.unhappy2". Do the same for
other upkeep sprites.

Closes #1859.

Backport candidate.