### PR TITLE
Fix installing dependent modpacks with relative URLs

### DIFF
--- a/tools/fcmp/download.cpp
+++ b/tools/fcmp/download.cpp
@@ -298,25 +298,24 @@ const char *download_modpack(const QUrl &url, const struct fcmp_params *fcmp,
       // We have everything
       auto inst_ver =
           mpdb_installed_version(qUtf8Printable(dep_name), dep_type);
-      if (inst_ver != nullptr) {
-        if (!cvercmp_max(qUtf8Printable(dep_version), inst_ver)) {
-          qDebug() << "Dependency modpack" << dep_name << "needed.";
+      if (!inst_ver || !cvercmp_max(qUtf8Printable(dep_version), inst_ver)) {
+        qInfo() << "Dependency modpack" << QString(inst_ver) << dep_version
+                << "needed.";
 
-          if (mcb != nullptr) {
-            mcb(_("Download dependency modpack"));
-          }
+        if (mcb != nullptr) {
+          mcb(_("Download dependency modpack"));
+        }
 
-          auto dep_qurl = QUrl(dep_url);
-          if (dep_qurl.isRelative()) {
-            dep_qurl = url.resolved(dep_qurl);
-          }
+        auto dep_qurl = QUrl(dep_url);
+        if (dep_qurl.isRelative()) {
+          dep_qurl = url.resolved(dep_qurl);
+        }
 
-          auto msg =
-              download_modpack(dep_url, fcmp, mcb, pbcb, recursion + 1);
+        auto msg =
+            download_modpack(dep_qurl, fcmp, mcb, pbcb, recursion + 1);
 
-          if (msg != nullptr) {
-            return msg;
-          }
+        if (msg != nullptr) {
+          return msg;
         }
       }
     }


### PR DESCRIPTION
The URL of the dependency wasn't used correctly. Noticed while developing RoundHex.

Old fix I never committed. Test by pasting the RoundHex modpack URL into the installer:
* https://raw.githubusercontent.com/lmoureaux/RoundSquare/hex/RoundHex.json

Backport proposed.