### PR TITLE
Docs/Manuals style update

### DIFF
--- a/docs/Coding/ai.rst
+++ b/docs/Coding/ai.rst
@@ -238,7 +238,7 @@ handicap and test ``experimental`` level :term:`AI`'s against ``hard`` level :te
 
 Other handicaps used are:
 
-.. _ai-difficulty-levels
+.. _ai-difficulty-levels:
 .. table:: AI Difficulty Levels
   :widths: auto
   :align: left

--- a/docs/Coding/ai.rst
+++ b/docs/Coding/ai.rst
@@ -16,7 +16,6 @@ Artificial Intelligence (AI)
 This document is about Freeciv21's default :term:`AI`.
 
 .. warning::
-
     The contents of this page are over 20 years old and have not been reviewed for correctness.
 
 Introduction
@@ -46,17 +45,22 @@ Build calculations are expressed through a structure called :code:`adv_choice`. 
 "want", which determines how much the :term:`AI` wants whatever item is pointed to by :code:`choice->type`.
 :code:`choice->want` is:
 
-======== ======
-Value    Result
-======== ======
--199     get_a_boat
-< 0      an error
-== 0     no want, nothing to do
-<= 100   normal want
-> 100    critical want, used to requisition emergency needs
-> ???    probably an error (1024 is a reasonable upper bound)
-> 200    Frequently used as a cap. When want exceeds this value, it is reduced to a lower number.
-======== ======
+.. _ai-choice-want:
+.. table:: AI Want Ranges
+  :widths: auto
+  :align: left
+
+  ======== ======
+  Value    Result
+  ======== ======
+  -199     get_a_boat
+  < 0      an error
+  == 0     no want, nothing to do
+  <= 100   normal want
+  > 100    critical want, used to requisition emergency needs
+  > ???    probably an error (1024 is a reasonable upper bound)
+  > 200    Frequently used as a cap. When want exceeds this value, it is reduced to a lower number.
+  ======== ======
 
 These are ideal numbers, your mileage while travelling through the code may vary considerably. Technology and
 Diplomats, in particular, seem to violate these standards.
@@ -234,23 +238,28 @@ handicap and test ``experimental`` level :term:`AI`'s against ``hard`` level :te
 
 Other handicaps used are:
 
-================= =======
-Variable          Result
-================= =======
-``H_DIPLOMAT``    Cannot build offensive :unit:`Diplomats`.
-``H_LIMITEDHUTS`` Can get only 25 gold and :unit:`Barbarians` from Huts.
-``H_DEFENSIVE``   Build defensive buildings without calculating need.
-``H_RATES``       Cannot set its national budget rates beyond government limits.
-``H_TARGETS``     Cannot target anything it does not know exists.
-``H_HUTS``        Does not know which unseen tiles have Huts on them.
-``H_FOG``         Cannot see through fog of War.
-``H_NOPLANES``    Does not build air units.
-``H_MAP``         Only knows ``map_is_known`` tiles.
-``H_DIPLOMACY``   Not very good at Diplomacy.
-``H_REVOLUTION``  Cannot skip Anarchy.
-``H_EXPANSION``   Do not like being much larger than human.
-``H_DANGER``      Always thinks its city is in danger.
-================= =======
+.. _ai-difficulty-levels
+.. table:: AI Difficulty Levels
+  :widths: auto
+  :align: left
+
+  ================= =======
+  Variable          Result
+  ================= =======
+  ``H_DIPLOMAT``    Cannot build offensive :unit:`Diplomats`.
+  ``H_LIMITEDHUTS`` Can get only 25 gold and :unit:`Barbarians` from Huts.
+  ``H_DEFENSIVE``   Build defensive buildings without calculating need.
+  ``H_RATES``       Cannot set its national budget rates beyond government limits.
+  ``H_TARGETS``     Cannot target anything it does not know exists.
+  ``H_HUTS``        Does not know which unseen tiles have Huts on them.
+  ``H_FOG``         Cannot see through fog of War.
+  ``H_NOPLANES``    Does not build air units.
+  ``H_MAP``         Only knows ``map_is_known`` tiles.
+  ``H_DIPLOMACY``   Not very good at Diplomacy.
+  ``H_REVOLUTION``  Cannot skip Anarchy.
+  ``H_EXPANSION``   Do not like being much larger than human.
+  ``H_DANGER``      Always thinks its city is in danger.
+  ================= =======
 
 For an up-to-date list of all handicaps and their use for each difficulty level see :file:`ai/handicaps.h`.
 

--- a/docs/Coding/architecture.rst
+++ b/docs/Coding/architecture.rst
@@ -39,24 +39,28 @@ Localization files are located under :file:`translations`.
 There are a few additional folders that you will touch less often. The table below describes the complete
 structure of the repository:
 
-==================== ==========
-Folder               Usage
-==================== ==========
-:file:`ai`           Code for computer opponents.
-:file:`client`       Client code.
-:file:`cmake`        Build system support code.
-:file:`common`       Code dealing with the game state. Shared by the client, server, and tools.
-:file:`data`         Game assets.
-:file:`dependencies` External dependencies not found in package managers.
-:file:`dist`         Files related to distributing Freeciv21 for various operating systems.
-:file:`docs`         This documentation.
-:file:`scripts`      Useful scripts used by the maintainers.
-:file:`server`       Server code.
-:file:`tools`        Small game-related programs.
-:file:`translations` Localization.
-:file:`utility`      Utility classes and functions not found in Qt or other dependencies.
-==================== ==========
+.. _arch-directories:
+.. table:: Freeciv21 Code Repository Organization
+  :widths: auto
+  :align: left
+
+  ==================== ==========
+  Folder               Usage
+  ==================== ==========
+  :file:`ai`           Code for computer opponents.
+  :file:`client`       Client code.
+  :file:`cmake`        Build system support code.
+  :file:`common`       Code dealing with the game state. Shared by the client, server, and tools.
+  :file:`data`         Game assets.
+  :file:`dependencies` External dependencies not found in package managers.
+  :file:`dist`         Files related to distributing Freeciv21 for various operating systems.
+  :file:`docs`         This documentation.
+  :file:`scripts`      Useful scripts used by the maintainers.
+  :file:`server`       Server code.
+  :file:`tools`        Small game-related programs.
+  :file:`translations` Localization.
+  :file:`utility`      Utility classes and functions not found in Qt or other dependencies.
+  ==================== ==========
 
 .. note::
-
     Some folders do not follow this structure. Their contents should eventually be moved.

--- a/docs/Coding/logging.rst
+++ b/docs/Coding/logging.rst
@@ -26,20 +26,25 @@ system can be tweaked to show only the messages you want at run time, for instan
 `QLoggingCategory <https://doc.qt.io/qt-5/qloggingcategory.html#configuring-categories>`_. The following
 categories are currently defined:
 
-======================== ====================================
-Name                     Used for
-======================== ====================================
-``freeciv.stacktrace``   Stack traces in debug builds.
-``freeciv.assert``       Assertion errors.
-``freeciv.inputfile``    ``spec`` file parser.
-``freeciv.bugs``         When the code finds a bug in itself.
-``freeciv.timers``       Various timers.
-``freeciv.depr``         Deprecation warnings.
-``freeciv.cm``           Citizen manager messages.
-``freeciv.ruleset``      Ruleset issues.
-``freeciv.goto``         Path finding debug messages.
-``freeciv.graphics``     FPS counters.
-======================== ====================================
+.. _logging-parameters:
+.. table:: Logging Parameters
+  :widths: auto
+  :align: left
+
+  ======================== ====================================
+  Name                     Used for
+  ======================== ====================================
+  ``freeciv.stacktrace``   Stack traces in debug builds.
+  ``freeciv.assert``       Assertion errors.
+  ``freeciv.inputfile``    ``spec`` file parser.
+  ``freeciv.bugs``         When the code finds a bug in itself.
+  ``freeciv.timers``       Various timers.
+  ``freeciv.depr``         Deprecation warnings.
+  ``freeciv.cm``           Citizen manager messages.
+  ``freeciv.ruleset``      Ruleset issues.
+  ``freeciv.goto``         Path finding debug messages.
+  ``freeciv.graphics``     FPS counters.
+  ======================== ====================================
 
 For instance, one could disable stack traces and enable Go To ``debug`` message by setting:
 

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -8,6 +8,7 @@
 .. role:: wonder
 .. role:: advance
 
+
 Documentation Style Guide
 *************************
 
@@ -110,6 +111,10 @@ to alter is placed inside back-ticks.
   This is required for sphinx to recognize it. Also notice the use of the anchor in :literal:`:ref:` leaves
   the underscore off.
 * :literal:`:numref:` -- Create a cross-reference to a named figure.
+* :literal:`:table:` -- Create a named table reference. Place an anchor (e.g. :literal:`.. _My Anchor:`) above
+  to enable :literal:`:numref:`.
+* :literal:`:figure:` -- Create a named figure reference. Place an anchor (e.g. :literal:`.. _My Anchor:`)
+  above to enable :literal:`:numref:`.
 * :literal:`:emphasis:` -- Emphasis is used to :emphasis:`bring attention to something`.
 * :literal:`:file:` -- File is used for file names and paths such as :file:`~/.local/share/freeciv21/saves`.
 * :literal:`:guilabel:` -- GUI Label is used to bring attention to something on the screen like the

--- a/docs/Manuals/Game/city-dialog.rst
+++ b/docs/Manuals/Game/city-dialog.rst
@@ -29,6 +29,10 @@ production and citizen governor tabs (left), city citizen tile output (center), 
   City Dialog
 
 
+.. todo::
+  When the new city dialog in ``master`` branch gets closer to being completed, we will need to update this
+  page with new screen shots.
+
 Let us start at the top center as highlighted in :numref:`City Dialog Top Center`. In this segment of the
 dialog box is some general information about the city. The name of the city is in the header at the top
 center. If you click on the city name, a dialog box will appear and allow you to rename the city to something

--- a/docs/Manuals/Game/message-options.rst
+++ b/docs/Manuals/Game/message-options.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
-.. SPDX-FileCopyrightText: 2023 James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit

--- a/docs/Manuals/Game/shortcut-options.rst
+++ b/docs/Manuals/Game/shortcut-options.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
-.. SPDX-FileCopyrightText: 2023 James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit

--- a/docs/Manuals/Rulesets/Common/building_flags.rst
+++ b/docs/Manuals/Rulesets/Common/building_flags.rst
@@ -1,12 +1,12 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
 .. role:: improvement
 .. role:: wonder
 .. role:: advance
+
 
 Building Flags
 **************

--- a/docs/Manuals/Rulesets/Common/tech_adv_flags.rst
+++ b/docs/Manuals/Rulesets/Common/tech_adv_flags.rst
@@ -1,12 +1,12 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
 .. role:: improvement
 .. role:: wonder
 .. role:: advance
+
 
 Technology Advance Flags
 ************************

--- a/docs/Manuals/Rulesets/Common/unit_class_flags.rst
+++ b/docs/Manuals/Rulesets/Common/unit_class_flags.rst
@@ -1,12 +1,12 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
 .. role:: improvement
 .. role:: wonder
 .. role:: advance
+
 
 Unit Class Flags
 ****************

--- a/docs/Manuals/Rulesets/Common/unit_type_flags.rst
+++ b/docs/Manuals/Rulesets/Common/unit_type_flags.rst
@@ -1,12 +1,12 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
 .. role:: improvement
 .. role:: wonder
 .. role:: advance
+
 
 Unit Type Flags
 ***************

--- a/docs/Manuals/Rulesets/Common/unit_type_roles.rst
+++ b/docs/Manuals/Rulesets/Common/unit_type_roles.rst
@@ -1,12 +1,12 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 2022-2023 James Robertson <jwrober@gmail.com>
+..  SPDX-License-Identifier: GPL-3.0-or-later
+..  SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 .. Custom Interpretive Text Roles for longturn.net/Freeciv21
 .. role:: unit
 .. role:: improvement
 .. role:: wonder
 .. role:: advance
+
 
 Unit Type Role Flags
 ********************

--- a/docs/Manuals/modpack-installer.rst
+++ b/docs/Manuals/modpack-installer.rst
@@ -8,8 +8,7 @@ Using the Modpack Installer Utility
 ***********************************
 
 The modpack installer is a simple tool to download custom Freeciv21 content called :strong:`modpacks` from the
-Internet and automatically install them into the correct location to be used by the Freeciv21 game interface
-and server.
+Internet and automatically install them into the correct location to be used by Freeciv21.
 
 A :strong:`modpack` can consist of one or more of:
 

--- a/docs/Manuals/modpack-installer.rst
+++ b/docs/Manuals/modpack-installer.rst
@@ -1,15 +1,15 @@
-..
-    SPDX-License-Identifier: GPL-3.0-or-later
-    SPDX-FileCopyrightText: 1996-2021 Freeciv Contributors
-    SPDX-FileCopyrightText: 2022 James Robertson <jwrober@gmail.com>
-    SPDX-FileCopyrightText: 2022 louis94 <m_louis30@yahoo.com>
+.. SPDX-License-Identifier: GPL-3.0-or-later
+.. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+.. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
 
 Using the Modpack Installer Utility
 ***********************************
 
-The modpack installer is a simple tool to download custom Freeciv21 content called :strong:`modpacks` from
-the Internet, and automatically install them into the correct location to be used by the Freeciv21 client and
-server.
+The modpack installer is a simple tool to download custom Freeciv21 content called :strong:`modpacks` from the
+Internet and automatically install them into the correct location to be used by the Freeciv21 game interface
+and server.
 
 A :strong:`modpack` can consist of one or more of:
 
@@ -22,90 +22,99 @@ They can be installed using the modpack installer tool :file:`freeciv21-modpack-
 standard installation. There is also a command-line-only tool called :file:`freeciv21-modpack`, which is
 mainly useful for headless game servers.
 
-In standard Freeciv21 builds, when you start the graphical modpack installer, it will show a list of
-modpacks curated by the Freeciv21 developers and longturn.net community. You can select one and click
-:guilabel:`Install modpack`; the tool will download the files for the selected modpack, and any other
-modpacks it depends on, and install them ready for the main Freeciv21 programs to use.
+In standard Freeciv21 builds, when you start the graphical modpack installer, it will show a list of modpacks
+curated by the Freeciv21 developers and Longturn community. You can select one and click
+:guilabel:`Install modpack`. The tool will download the files for the selected modpack, any other modpacks it
+depends on, and install them ready for the main Freeciv21 programs to use.
 
-.. image:: /_static/images/gui-elements/modpack-installer.png
-    :align: center
-    :alt: Freeciv21 Modpack Installer Qt GUI application
+.. _Modpack GUI:
+.. figure:: /_static/images/gui-elements/modpack-installer.png
+  :align: center
+  :alt: Freeciv21 Modpack Installer GUI application
+  :figclass: align-center
+
+  Freeciv21 Modpack Installer GUI application
 
 
 You can also point the installer at modpacks or lists on other servers:
 
-* If someone has given you an individual modpack URL (ending in :literal:`.json`), you can paste it into the
+* If someone has given you an individual modpack URL (ending in :file:`.json`), you can paste it into the
   :guilabel:`Modpack URL` box, and when you click :guilabel:`Install modpack`, the modpack will immediately
   downloaded and install.
 
-.. note:: If you have been given a URL ending up :literal:`.modpack` or :literal:`.mpdl`,
-    that is probably for legacy Freeciv and not Freeciv21. These modpack files are not compatible with
-    Freeciv21.
+.. note::
+  If you have been given a URL ending up :file:`.modpack` or :file:`.mpdl`, that is probably for legacy
+  Freeciv and not Freeciv21. These modpack files are not compatible with Freeciv21.
 
-* If someone has given you a URL for a list of modpacks (also ending in :literal:`.json`) and you want to
+* If someone has given you a URL for a list of modpacks (also ending in :file:`.json`) and you want to
   browse them with the standard Freeciv21 modpack installer build, you need to start the tool with that URL
   on its command line, for instance:
 
 .. code-block:: sh
 
-    freeciv21-modpack --List https://example.com/3.1/my-modpacks.json
+    $ freeciv21-modpack --List https://example.com/3.1/my-modpacks.json
 
 
-.. note:: The capital letter in :literal:`--List`
+.. note::
+  The capital letter in :literal:`--List`
 
-    The tool has some other command-line options, but most users will not need to use them. Use
-    :literal:`--help` for a list of them.
+  The tool has some other command-line options, but most users will not need to use them. Use
+  :literal:`--help` for a list of them.
 
 Once you have installed a modpack, how you use it depends on the modpack type:
 
-* Scenarios (maps) should be listed under :guilabel:`Start scenario game` from the client start page, or
-  from the game server prompt via :literal:`/list scenarios`.
+* Scenarios (pre-defined maps) should be listed under :guilabel:`Start scenario game` from the
+:doc:`game start page </Getting/Manuals/start-screen>`, or from the game server prompt via
+:literal:`/list scenarios`.
 
-.. tip:: For network play, scenarios need only be installed on the game server.
+.. tip::
+  For network play, scenarios need only be installed on the game server.
 
-* Rulesets should appear on the :guilabel:`Ruleset` drop-down from the client's :guilabel:`Start new game`
-  page. On the game server, you can load a ruleset with :literal:`/read <name>` or failing that perhaps
-  :literal:`/rulesetdir <name>`.
+* Rulesets should appear on the :guilabel:`Ruleset` drop-down from the game's :guilabel:`Start new game`
+  page as shown in :numref:`Start New Game Dialog`. On the game server, you can load a ruleset with
+  :literal:`/read <name>` or failing that perhaps :literal:`/rulesetdir <name>`.
 
-* Tilesets should appear for selection in the local client options, in the appropriate topology-specific
+* Tilesets should appear for selection in the local interface options, in the appropriate topology-specific
   :guilabel:`Tileset` drop-down under :guilabel:`Graphics`.
 
-.. note:: Tilesets should be installed on the client machine.
+.. note::
+  Tilesets should be installed on the computer with the game interface.
 
-* Soundsets and musicsets should appear in the dropdowns on the :guilabel:`Sound` page of the local
-  client options.
+* Soundsets and musicsets should appear in the dropdowns on the :guilabel:`Sound` page of the interface
+  options.
 
-With standard Freeciv21 builds, modpacks get installed into a per-user area, not into the main Freeciv21
-installation. So you shouldn't need any special permissions to download them, and if you uninstall the
-Freeciv21 game, any modpacks you downloaded are likely to remain on your system. Conversely, if you delete
-downloaded modpacks by hand, the standard rulesets, tilesets, etc. supplied with Freeciv21 won't be touched.
+With standard Freeciv21 builds, modpacks get installed into a per-user area and not into the main Freeciv21
+installation. So you should not need any special permissions to download them. If you uninstall the Freeciv21
+game any modpacks you downloaded are likely to remain on your system. Conversely, if you delete downloaded
+modpacks by hand, the standard rulesets, tilesets, etc. supplied with Freeciv21 will not be touched.
 
 The precise location where files are downloaded to depends on your build and platform. For Unix systems, it
 is likely to be under the hidden :file:`~/.local/share/freeciv21` directory in your home directory. For
-Windows based sytems it will be in your user profile directory in a hidden :literal:`AppData` folder,
-typically, :file:`C:\\Users\\[MyUserName]\\AppData\\Roaming\\Freeciv21` It is likely to be near where the
-Freeciv21 client stores its saved games.
+Windows based sytems it will be in your user profile directory in a hidden :file:`AppData` folder, typically,
+:file:`C:\\Users\\[MyUserName]\\AppData\\Roaming\\freeciv21` It is likely to be near where the Freeciv21
+interface stores its saved games.
 
 Most modpacks are specific to a particular major version of Freeciv21; for instance, while a 3.0 ruleset or
 tileset can be used with all Freeciv21 3.0.x releases, it cannot be used as-is with any 3.1.x release. So,
 most modpacks are installed in a specific directory for the major version, such as
 :file:`~/.local/share/freeciv21/3.1/` on Unix.
 
-.. note:: The modpack installer displays which version it will install for at the top of its window.
+.. note::
+  The modpack installer displays which version it will install for at the top of its window.
 
-An exception to this is scenario maps; scenarios created for one version of Freeciv21 can usually be loaded
+An exception to this is scenario maps. Scenarios created for one version of Freeciv21 can usually be loaded
 in later versions, so they are installed in a version-independent location (typically
 :file:`~/.local/share/freeciv21/scenarios/` on Unix).
 
 Once a modpack is installed, there is no uninstall action, and if you remove the files by hand, the
-installer will still consider the modpack to be installed; the installer maintains its own database
+installer will still consider the modpack to be installed. The installer maintains its own database
 (:file:`.control/modpacks.db`) listing which modpack versions are installed, but does not keep track of
 which files were installed by which modpack. If the database gets out of sync with reality (or is deleted),
 it's harmless for already installed modpacks and the main Freeciv21 programs (which do not consult the
 database), but can confuse the modpack installer's dependency tracking later.
 
-Modpacks consist mostly of data files read by the Freeciv21 engine; they do not contain compiled binary code
-(and are thus platform-independent). Rulesets can contain code in the form of Lua scripts, but this is
+Modpacks consist mostly of data files read by the Freeciv21 engine. They do not contain compiled binary code
+and are thus platform-independent. Rulesets can contain code in the form of Lua scripts, but this is
 executed in a sandbox to prevent obvious security exploits. Modpacks are installed to a specific area and
 cannot overwrite arbitrary files on your system. Nevertheless, you should only install modpacks from sources
 you trust.

--- a/docs/Manuals/modpack-installer.rst
+++ b/docs/Manuals/modpack-installer.rst
@@ -64,15 +64,15 @@ You can also point the installer at modpacks or lists on other servers:
 Once you have installed a modpack, how you use it depends on the modpack type:
 
 * Scenarios (pre-defined maps) should be listed under :guilabel:`Start scenario game` from the
-:doc:`game start page </Getting/Manuals/start-screen>`, or from the game server prompt via
-:literal:`/list scenarios`.
+  :doc:`game start page </Manuals/Game/start-screen>`, or from the game server prompt via
+  :literal:`/list scenarios`.
 
 .. tip::
   For network play, scenarios need only be installed on the game server.
 
 * Rulesets should appear on the :guilabel:`Ruleset` drop-down from the game's :guilabel:`Start new game`
-  page as shown in :numref:`Start New Game Dialog`. On the game server, you can load a ruleset with
-  :literal:`/read <name>` or failing that perhaps :literal:`/rulesetdir <name>`.
+  page as shown in :numref:`Start New Game Dialog` in the :doc:`/Manuals/Game/index`. On the game server, you
+  can load a ruleset with :literal:`/read <name>` or failing that perhaps :literal:`/rulesetdir <name>`.
 
 * Tilesets should appear for selection in the local interface options, in the appropriate topology-specific
   :guilabel:`Tileset` drop-down under :guilabel:`Graphics`.


### PR DESCRIPTION
Part of #1250 

Also came back to `Coding` to include the `:table:` directive for `:numref:` and updated the style guide to call out the use of `:figure:` and `:table:`.