### PR TITLE
Fix updating the old transport when switching ships

### DIFF
--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -603,7 +603,7 @@ static bool do_unit_board(struct player *act_player, struct unit *act_unit,
                           const struct action *paction)
 {
   if (unit_transported(act_unit)) {
-    unit_transport_unload(act_unit);
+    unit_transport_unload_send(act_unit);
   }
 
   // Load the unit and send out info to clients.
@@ -673,7 +673,7 @@ static bool do_unit_embark(struct player *act_player, struct unit *act_unit,
 
   if (unit_transported(act_unit)) {
     // Assumed to be legal.
-    unit_transport_unload(act_unit);
+    unit_transport_unload_send(act_unit);
   }
 
   // Do it.


### PR DESCRIPTION
The old transporter needs to be updated when a transported unit switches to another transport, otherwise its "loaded" status may be wrong on the client side.

Closes #1883.
Backport candidate.