### PR TITLE
Minor typo fix

### DIFF
--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
        // TRANS: Command-line argument
        _("ID")},
       {{"s", "saves"},
-       _("Sage games to directory DIR"),
+       _("Save games to directory DIR"),
        // TRANS: Command-line argument
        _("DIR")},
       {{"t", "timetrack"},


### PR DESCRIPTION
freeciv-server help text has a typo for -s, --save flag, "Sage games to directory DIR". Pull request changes "Sage" to "Save"