### PR TITLE
add .flatpak-builder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ build.ninja
 
 # Build directories
 /build*
+.flatpak-builder
 
 # IDE files
 .cache


### PR DESCRIPTION
Update `.gitignore` to be ready for flatpak support down the road.