### PR TITLE
Document the use of database.lua

### DIFF
--- a/docs/Coding/fcdb.rst
+++ b/docs/Coding/fcdb.rst
@@ -5,33 +5,33 @@
 Authentication and Database Support (fcdb)
 ******************************************
 
-The Freeciv21 server allows the authentication of users, although by default it is not enabled, and anyone can
-connect with any username.
+The Freeciv21 server allows the authentication of users, although by default it is not configured, and anyone
+can connect with any username.
 
 In order to support authentication, the Freeciv21 server needs access to a database backend in which to store
 the credentials. To support different database backends, the database access code is written in Lua using
 luasql. In principle, luasql supports SQLite3, MySQL, and Postgres backends. However, the Freeciv21 server is
-only built with SQLite3.
+only built with SQLite3 and the provided :file:`database.lua` is also only programmed to support SQLite3.
 
 As well as storing and retrieving usernames and passwords, the supplied database access script logs the time
 and IP address of each attempted login, although this information is not used by the Freeciv21 server itself.
 
 To use the Freeciv21 database and authentication, the server must be installed properly, as it searches for
-:file:`database.lua` in the install location. The server cannot simply be run from a build directory if
-authentication is required.
+:file:`database.lua` in the :file:`$HOME/.config/freeciv21` directory. The server cannot simply be run from a
+build directory if authentication is required.
 
 Quick Setup: SQLite
 ===================
 
-The simplest setup is to use the SQLite backend, and this is probably the best option for new deployments. In
+The simplest setup is to use the SQLite3 backend, and this is probably the best option for new deployments. In
 this setup, the authentication data is stored in a simple file accessed directly by the Freeciv21 server.
 There is no need for a separate database server process.
 
 To set this up, first create a database configuration file called something like :file:`fc_auth.conf`, with
 the ``database`` key specifying where the database file is to live. It must be readable and writable by the
-Freeciv21 server. Here is an example:
+Freeciv21 server. A good default location is the user's :file:`$HOME` directory. Here is an example:
 
-.. code-block:: rst
+.. code-block:: ini
 
     [fcdb]
     backend="sqlite"
@@ -39,13 +39,32 @@ Freeciv21 server. Here is an example:
 
 
 For more information on the format of this file, see below. There are more settings available, but this file
-is entirely sufficient for a SQLite setup.
+is entirely sufficient for a SQLite3 setup.
+
+Now we need some software and Lua scripts installed on the server to support the SQLite3 database as well as
+storing passwords with MD5 hashes.
+
+.. code-block:: sh
+
+    $ sudo apt install luarocks
+    $ sudo luarocks --lua-version 5.3 install md5
+    $ sudo luarocks --lua-version 5.3 install luasql-sqlite3
+
+
+Lastly, we need to download the :file:`database.lua` script file.
+
+.. code-block:: sh
+
+    $ mkdir -p $HOME/.config/freeciv21
+    $ cd $HOME/.config/freeciv21
+    $ wget https://raw.githubusercontent.com/longturn/freeciv21/master/lua/database.lua
+
 
 Now start the server with:
 
 .. code-block:: sh
 
-    freeciv21-server --Database fc_auth.conf --auth --Newusers
+    $ freeciv21-server --Database ~/fc_auth.conf --auth --Newusers
 
 
 The first time you do this, you need to create the database file and its tables with the following server
@@ -96,18 +115,16 @@ This script is responsible for checking usernames, fetching passwords, and savin
 :code:`--Newusers` is enabled). It encapsulates access to the database backend, and hence the details of the
 table layout.
 
-The script lives in :file:`data/database.lua` in the source tree, and is installed to
-``CMAKE_INSTALL_PREFIX``. Depending on the options given to ``cmake`` at build time, this may be a location
-such as :file:`/usr/local/etc/freeciv21/database.lua.` Refer to :doc:`/Getting/compile` for more information
-on ``CMAKE_INSTALL_PREFIX``.
+The script lives in :file:`lua/database.lua` in the source tree. Instructions above place the file into
+:file:`$HOME/.config/freeciv21`.
 
-The supplied version supports basic authentication against a SQLite database. It supports configuration as
+The supplied version supports basic authentication against a SQLite3 database. It supports configuration as
 shown in the following example:
 
-.. code-block:: rst
+.. code-block:: ini
 
     [fcdb]
-    backend="sqllite"
+    backend="sqlite"
     host="localhost"
     user="Freeciv21"
     port="3306"


### PR DESCRIPTION
Leaves original `.cpp` finding code alone for backwards compat w/ LT.net server. Documents use of the `lua/database.lua` file, but does not attempt to ship the file in a package.

Closes #1908