### PR TITLE
Add +duplicates_ok to tilespec files

### DIFF
--- a/data/alio.tilespec
+++ b/data/alio.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Alio"

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Amplio2"

--- a/data/cimpletoon.tilespec
+++ b/data/cimpletoon.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Cimpletoon"

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Hex-2"

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Hexemplio"

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Isophex"

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "MacroIsoTrident"

--- a/data/toonhex.tilespec
+++ b/data/toonhex.tilespec
@@ -2,7 +2,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Toonhex"

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -1,7 +1,7 @@
 [tilespec]
 
 ; Format and options of this tilespec file:
-options = "+Freeciv-tilespec-Devel-2019-Jul-03"
+options = "+Freeciv-tilespec-Devel-2019-Jul-03 +duplicates_ok"
 
 ; A simple name for the tileset specified by this file:
 name = "Trident"


### PR DESCRIPTION
When opening the client from command line, we get a lot of noise of errors that isn't needed. Added `+duplicate_ok` cap string to the tilespec files we ship.

No related issue.