### PR TITLE
Add the tileset name to the "duplicate sprites" message

### DIFF
--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -1350,8 +1350,8 @@ static void scan_specfile(struct tileset *t, struct specfile *sf,
         if (!duplicates_ok) {
           for (k = 0; k < num_tags; k++) {
             if (t->sprite_hash->contains(tags[k])) {
-              qCritical("warning: already have a sprite for \"%s\".",
-                        tags[k]);
+              qCritical("warning: %s: already have a sprite for \"%s\".",
+                        t->name, tags[k]);
             }
             t->sprite_hash->insert(tags[k], ss);
           }
@@ -1402,7 +1402,8 @@ static void scan_specfile(struct tileset *t, struct specfile *sf,
     if (!duplicates_ok) {
       for (k = 0; k < num_tags; k++) {
         if (t->sprite_hash->contains(tags[k])) {
-          qCritical("warning: already have a sprite for \"%s\".", tags[k]);
+          qCritical("warning: %s: already have a sprite for \"%s\".",
+                    t->name, tags[k]);
         }
         t->sprite_hash->insert(tags[k], ss);
       }


### PR DESCRIPTION
Makes it easier to spot where they're coming from.

See #1931.