### PR TITLE
Add a Fedora CI and review the dependency list

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,6 +279,43 @@ jobs:
           name: macOS-dmg
           path: Freeciv21-*.dmg
 
+  fedora:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    container: fedora:latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo dnf install -y \
+            git \
+            cmake \
+            ninja-build \
+            python \
+            gettext \
+            qt5-qtbase-devel \
+            qt5-qtsvg-devel \
+            kf5-karchive-devel \
+            lua-devel \
+            sqlite-devel \
+            SDL2_mixer-devel \
+            readline-devel \
+            zlib-devel \
+            libunwind-devel \
+            elfutils-libs \
+            python3-sphinx
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: |
+          cmake . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=/usr
+      - name: Build
+        run: |
+          cmake --build build
+      - name: Install
+        run: |
+          DESTDIR=$PWD/build/install cmake --build build --target install
+
   nix:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -301,8 +301,7 @@ jobs:
             readline-devel \
             zlib-devel \
             libunwind-devel \
-            elfutils-libs \
-            python3-sphinx
+            elfutils-libs
       - uses: actions/checkout@v3
       - name: Configure
         run: |

--- a/docs/Getting/compile.rst
+++ b/docs/Getting/compile.rst
@@ -165,7 +165,6 @@ following commands:
      cmake \
      ninja-build \
      python3 \
-     python3-pip \
      qtbase5-dev \
      libqt5svg5-dev \
      libkf5archive-dev \
@@ -193,6 +192,7 @@ RHEL, CentOS Stream) to install Freeciv21.
     cmake \
     ninja-build \
     python \
+    gettext \
     qt5-qtbase-devel \
     qt5-qtsvg-devel \
     kf5-karchive-devel \
@@ -203,9 +203,7 @@ RHEL, CentOS Stream) to install Freeciv21.
     zlib-devel \
     libunwind-devel \
     elfutils-libs \
-    python-pip \
-    python3-sphinx \
-    patch
+    python3-sphinx
 
 
 At this point, follow the steps in `Obtaining the Source Code`_ section below.


### PR DESCRIPTION
fter the debacle of 3.0 (https://github.com/longturn/freeciv21/issues/1895), I feel like it's a good idea to systematically check more environments. This introduces a check for the stable version of Fedora.