### PR TITLE
Fix displaying message turn and timestamp

### DIFF
--- a/common/featured_text.cpp
+++ b/common/featured_text.cpp
@@ -698,11 +698,11 @@ ft_offset_t text_tag_stop_offset(const struct text_tag *ptag)
    Return the foreground color suggested by this text tag.  This requires
    the tag type to be TTT_COLOR.  Returns nullptr on error, "" if unset.
  */
-const char *text_tag_color_foreground(const struct text_tag *ptag)
+QString text_tag_color_foreground(const struct text_tag *ptag)
 {
   if (ptag->type != TTT_COLOR) {
     qCritical("text_tag_color_foreground(): incompatible tag type.");
-    return nullptr;
+    return QStringLiteral();
   }
 
   return ptag->color.foreground;
@@ -712,11 +712,11 @@ const char *text_tag_color_foreground(const struct text_tag *ptag)
    Return the background color suggested by this text tag.  This requires
    the tag type to be TTT_COLOR.  Returns nullptr on error, "" if unset.
  */
-const char *text_tag_color_background(const struct text_tag *ptag)
+QString text_tag_color_background(const struct text_tag *ptag)
 {
   if (ptag->type != TTT_COLOR) {
     qCritical("text_tag_color_background(): incompatible tag type.");
-    return nullptr;
+    return QStringLiteral();
   }
 
   return ptag->color.background;

--- a/common/featured_text.h
+++ b/common/featured_text.h
@@ -12,6 +12,8 @@
       \____/        ********************************************************/
 #pragma once
 
+#include <QString>
+
 /*
  * Some words about the featured text module.
  *
@@ -218,8 +220,8 @@ ft_offset_t text_tag_start_offset(const struct text_tag *ptag);
 ft_offset_t text_tag_stop_offset(const struct text_tag *ptag);
 
 // Specific TTT_COLOR text tag type functions.
-const char *text_tag_color_foreground(const struct text_tag *ptag);
-const char *text_tag_color_background(const struct text_tag *ptag);
+QString text_tag_color_foreground(const struct text_tag *ptag);
+QString text_tag_color_background(const struct text_tag *ptag);
 
 // Specific TTT_LINK text tag type functions.
 enum text_link_type text_tag_link_type(const struct text_tag *ptag);


### PR DESCRIPTION
The previous code was doing some dark magic to obtain an ok-looking result, but the generated HTML closing tags weren't in the correct order. In addition, it was neglecting any leftover out of any tags. This was working fine because most message content is enclosed within a color tag, but hid the timestamps that are not located inside a tag.

Simplify the implementation by merging the HTML tags together (in the correct order!) as they are generated. This way applying them becomes a simple string insertion task.

Also use the opportunity to refactor some related code slightly. We should eventually write a simple direct featured-text-to-HTML converter instead of using the intermediate "tags" step (whose architecture is a copy of Gtk's rich text functions and doesn't play well with Qt's).

Closes #1942.