### PR TITLE
NightStalker: make default chat color more neutral

### DIFF
--- a/data/themes/gui-qt/NightStalker/resource.qss
+++ b/data/themes/gui-qt/NightStalker/resource.qss
@@ -769,7 +769,7 @@ QTextEdit#scenarios_view {
 
 QTextEdit {
   background-color: #232323;
-  color: #54ff54;
+  color: #f8f8f8;
 }
 
 QFontListView {


### PR DESCRIPTION
When the turn and time are displayed next to messages, they use the default color. The saturated green we had earlier was clashing with message colors, in particular the ones in red. Switch to a slightly softened white to avoid this.

See commit f6d7d609b9a8c2a2445eac09b9f93e842da0644b.