### PR TITLE
Guess the default username only after loading options

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -508,8 +508,12 @@ int client_main(int argc, char *argv[])
   configure_fonts();
   init_themes();
 
+  options_load();
+
   // Set default username
-  (void) user_username(gui_options->default_user_name, MAX_LEN_NAME);
+  if (!is_valid_username(gui_options->default_user_name)) {
+    (void) user_username(gui_options->default_user_name, MAX_LEN_NAME);
+  }
   if (!is_valid_username(gui_options->default_user_name)) {
     char buf[sizeof(gui_options->default_user_name)];
 
@@ -522,8 +526,6 @@ int client_main(int argc, char *argv[])
                   (int) fc_rand(10000));
     }
   }
-
-  options_load();
 
   // initialization
   game.all_connections = conn_list_new();


### PR DESCRIPTION
Loading options resets them to their defaults, so we can only override them after they are loaded. This has the side-effect of using a default username if the user sets it to something invalid (which is good because Freeciv21 is unusable without a username).

Closes #1898.