### PR TITLE
Don't wait forever when trying to connect

### DIFF
--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -132,8 +132,8 @@ static int try_to_connect(const QUrl &url, char *errbuf, int errbufsize)
   }
 
   client.conn.sock->connectToHost(url.host(), url.port());
-  if (!client.conn.sock->waitForConnected(-1)) {
-    errbuf[0] = '\0';
+  if (!client.conn.sock->waitForConnected()) {
+    (void) fc_strlcpy(errbuf, _("Connection timed out."), errbufsize);
     return -1;
   }
   make_connection(client.conn.sock, url.userName());

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -132,7 +132,7 @@ static int try_to_connect(const QUrl &url, char *errbuf, int errbufsize)
   }
 
   client.conn.sock->connectToHost(url.host(), url.port());
-  if (!client.conn.sock->waitForConnected()) {
+  if (!client.conn.sock->waitForConnected(10)) {
     (void) fc_strlcpy(errbuf, _("Connection timed out."), errbufsize);
     return -1;
   }


### PR DESCRIPTION
This is one of the failure modes of bad connections. Fail to connect after 30s (Qt default). Related to #450.

To test, try to connect to an unused game port on LT.net.