### PR TITLE
Fix starting the client

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -347,7 +347,7 @@ int client_main(int argc, char *argv[])
         _("PROTO"),
         "IPv4"},
        {{"a", "autoconnect"}, _("Skip connect dialog.")},
-       {{"d", _("debug.")},
+       {{"d", _("debug")},
         // TRANS: Do not translate "fatal", "critical", "warning", "info" or
         //        "debug". It's exactly what the user must type.
         _("Set debug log level (fatal/critical/warning/info/debug)."),


### PR DESCRIPTION
The client wouldn't start because the "--debug" option had been renamed to "--debug." in one place but not everywhere. Revert the change.