### PR TITLE
Ensure that the help dialog doesn't get bigger than the screen it is on

### DIFF
--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -174,19 +174,17 @@ void help_dialog::hideEvent(QHideEvent *event)
 void help_dialog::showEvent(QShowEvent *event)
 {
   Q_UNUSED(event)
-  QList<int> sizes;
 
   if (!king()->qt_settings.help_geometry.isNull()) {
     restoreGeometry(king()->qt_settings.help_geometry);
     splitter->restoreState(king()->qt_settings.help_splitter1);
+    // Make sure the size isn't larger than the screen
+    resize(size().boundedTo(screen()->availableSize()));
   } else {
-    QList<QScreen *> screens = QGuiApplication::screens();
-    QRect rect = screens[0]->availableGeometry();
-
+    auto rect = screen()->availableGeometry();
     resize(qMax((rect.width() * 3) / 4, 1280),
            qMax((rect.height() * 3) / 4, 800));
-    sizes << rect.width() / 10 << rect.width() / 3;
-    splitter->setSizes(sizes);
+    splitter->setSizes({rect.width() / 10, rect.width() / 3});
   }
 }
 


### PR DESCRIPTION
* When restoring, cap the size to the screen's available area
* When showing for the first time, use the current screen instead of the first one

To backport or not to backport?