### PR TITLE
Don't give a free tech when inciting a city

### DIFF
--- a/server/diplomats.cpp
+++ b/server/diplomats.cpp
@@ -1125,9 +1125,6 @@ bool diplomat_incite(struct player *pplayer, struct unit *pdiplomat,
   pcity->shield_stock = 0;
   nullify_prechange_production(pcity);
 
-  // You get a technology advance, too!
-  steal_a_tech(pplayer, cplayer, A_UNSET);
-
   // this may cause a diplomatic incident
   action_consequence_success(paction, pplayer, cplayer, ctile, clink);
 


### PR DESCRIPTION
This makes inciting way too powerful, allowing "tech trading" in games where it ought to be disabled.

Closes #1944.