### PR TITLE
Change the default background color for Classic

### DIFF
--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -32,22 +32,18 @@ QMainWindow, minimap_panel {
 /* Help dialog tile output 3 labels */
 *[foodlab="true"] {
   background:#00ee01;
-  color: black;
 }
 
 *[shieldlab="true"] {
   background: #e4e4e4;
-  color: black;
 }
 
 *[ecolab="true"] {
   background: #eeee12;
-  color: black;
 }
 
 *[doomchat="true"] {
   background-color: white;
-  color: black;
   border: 1px solid #c3b48e;
 }
 
@@ -87,7 +83,6 @@ resize_widget
 }
 
 QPushButton, QToolButton {
-  color: black;
   border-image: url(LittleFingerbutton-default.png) 3 3 3 3;
   border-top: 3px transparent;
   border-bottom: 3px transparent;
@@ -115,11 +110,7 @@ QDialogButtonBox {
   button-layout: 3;
 }
 
-QLabel {
- color: black;
-}
-
-QTableWidget {
+QTableView {
   alternate-background-color: #e0d2b2;
   background-color: #e7d6b0;
   border-top: 1px solid #c3b48e;
@@ -128,12 +119,11 @@ QTableWidget {
   border-right: 1px solid #c3b48e;
   border-radius: 1px;
   padding: 2 3px;
-  color: black;
   selection-color: white;
   selection-background-color:  #c3b48e;
 }
 
-QTableWidget::item:selected {
+QTableView::item:selected {
   border: none;
   padding: 0 0;
   background: #c3b48e;
@@ -142,7 +132,6 @@ QTableWidget::item:selected {
 
 QHeaderView::section {
   background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #efddb5, stop: 1 #e7d6b0);
-  color: black;
   border: 1px solid #c3b48e;
 }
 
@@ -150,7 +139,6 @@ QLineEdit {
   background-color: #e7ddba;
   border: 1px solid #c3b48e;
   border-radius: 2px;
-  color: black;
 }
 
 QTabWidget {
@@ -158,7 +146,6 @@ QTabWidget {
 }
 
 QSpinBox {
-  color: black;
   background-color: #e0cfaa;
   selection-background-color: none;
 }
@@ -168,7 +155,6 @@ QLineEdit:disabled, QComboBox:disabled, QSpinBox:disabled , QComboBox:disabled{
 }
 
 QComboBox {
-  color: black;
   border-image: url(LittleFingercombo-normal.png) 3 3 3 3;
   background-color: #e5d7a1;
   text-align: left;
@@ -241,13 +227,11 @@ QMenuBar {
 QMenuBar::item {
   spacing: 3px;
   padding: 1px 4px;
-  color: black;
   background: transparent;
   border-radius: none
 }
 
 QMenuBar::item:selected {
-  color: black;
   background: #b6a785;
 }
 
@@ -260,7 +244,6 @@ QMenu {
   border:none;
 }
 QMenu::item {
-  color: black;
   background: rgba(222,203,152, 100);
   padding: 3px 20px 3px 25px;
   border: 1px solid transparent;
@@ -271,7 +254,6 @@ QMenu::item:disabled {
 }
 
 QMenu::item:selected {
-  color: black;
   background-color: #b6a785;
   border: 1px solid grey;
   border-radius: 3px;
@@ -308,10 +290,6 @@ QComboBox QAbstractItemView{
   border: 1px outset #f5dfa7;
   border-radius: 3px;
   selection-background-color: white;
-}
-
-QRadioButton {
-  color: black;
 }
 
 QRadioButton::indicator {
@@ -368,7 +346,6 @@ QTabBar::tab {
   border-right: 1px solid #c3b48e;
   border-top-right-radius: 15;
   border-top-left-radius: 5;
-  color: black;
   padding: 5px;
   min-width: 80px;
 }
@@ -385,7 +362,6 @@ QTabBar::tab:first {
   border-right: 1px solid #c3b48e;
   border-top-right-radius: 15;
   border-top-left-radius: 5;
-  color:black;
   padding:5px;
 }
 
@@ -397,7 +373,6 @@ QTabBar::tab::selected {
   border-right: 2px solid #c3b48e;
   border-top-right-radius: 15;
   border-top-left-radius: 5;
-  color: black;
   padding:5px;
 }
 
@@ -430,7 +405,6 @@ QTreeView {
   border-right: 1px solid #c3b48e;
   border-radius: 1px;
   padding: 2 3px;
-  color: black;
   selection-color: white;
   selection-background-color:  #c3b48e;
 }
@@ -457,7 +431,6 @@ QToolTip {
 }
 
 QCheckBox {
-  color: black;
   background: #e1cea1;
   spacing: 5px;
 }
@@ -492,15 +465,10 @@ QCheckBox::indicator:checked:hover {
 }
 
 QGroupBox {
-  color: black;
   background-color: #e1cea1;
   border: 1px solid #c3b48e;
   border-radius: 5px;
   margin-top: 2ex;
-}
-
-QComboBox:hover {
-  color: black;
 }
 
 city_dialog QScrollArea QWidget {
@@ -541,7 +509,6 @@ QCheckBox:disabled, QRadioButton:disabled {
 
 QTextEdit {
   background-color: #efddb5;
-  color: black;
 }
 
 QScrollBar:vertical {
@@ -625,7 +592,6 @@ QScrollBar::handle:vertical {
 }
 
 QTreeWidget {
-  color: black;
   background-color: #efddb5;
   border: none;
 }
@@ -636,7 +602,6 @@ QTreeWidget::item:selected {
 }
 
 QFontListView {
-  color: black;
   background-color: #e7ddba;
 }
 
@@ -677,23 +642,19 @@ research_diagram {
 help_widget QTextBrowser
 {
   background-image:url(LittleFingerpattern.png);
-  color: black;
 }
 
 help_widget QWidget
 {
   background: transparent;
-  color: black;
 }
 
 help_widget QScrollArea QFrame {
   background: transparent;
-  color: black;
 }
 
 help_widget QScrollArea {
   background-image:url(LittleFingerpattern.png);
-  color: black;
 }
 
 units_select {
@@ -743,7 +704,6 @@ message_widget QListWidget
 }
 
 message_widget QListWidget::item:hover {
-  color: black;
   background-color: rgba(180, 160, 120, 225);
 }
 
@@ -837,14 +797,12 @@ message_widget QScrollBar::sub-line:vertical {
 
 hud_message_box, hud_input_box {
   background-color: transparent;
-  color: black;
   selection-background-color: rgba(231, 214, 176, 220);
   alternate-background-color: rgba(131, 114, 76 ,220);
   border: 2px solid black;
 }
 
 hud_message_box QPushButton {
-  color: black;
   background: rgb(231, 214, 176);
   border-top: 3px solid #c3b48e;
   border-bottom: 3px solid #c3b48e;
@@ -855,7 +813,6 @@ hud_message_box QPushButton {
 }
 
 hud_input_box QPushButton {
-  color: black;
   background: rgb(231, 214, 176);
   border-top: 3px solid #c3b48e;
   border-bottom: 3px solid #c3b48e;

--- a/data/themes/gui-qt/Classic/resource.qss
+++ b/data/themes/gui-qt/Classic/resource.qss
@@ -664,7 +664,13 @@ units_select {
   border: 1px solid black;
 }
 
-chat_widget QLabel
+chat_widget, message_widget
+{
+  border: 1px solid #c3b48e;
+}
+
+chat_widget QLabel,
+message_widget QLabel
 {
   color: white;
 }
@@ -729,15 +735,18 @@ QProgressBar {
 }
 
 info_tile {
-color: #ffecba;
+  color: #ffecba;
   border: 1px solid black;
   background-color: rgba(0, 0, 0);
 }
 
 freeciv--report_widget {
-  color: #ffecba;
-  border: 1px solid #ffecba;
   background-color: rgba(0, 0, 0);
+  border: 1px solid #ffecba;
+}
+
+freeciv--report_widget QLabel {
+  color: #ffecba;
 }
 
 unit_item, impr_item {

--- a/data/themes/gui-qt/Classic/theme.conf
+++ b/data/themes/gui-qt/Classic/theme.conf
@@ -21,7 +21,7 @@ ToolTipText = #FCFCFC
 PlaceholderText = #232627
 Foreground = #232627
 WindowText = #232627
-Background = #EFF0F1
+Background = #f1deaf
 
 [color_mapping]
 ; Colors used in the chat. Chosen to have a contrast ratio > 5 on black, as


### PR DESCRIPTION
Use a yellowish color instead of gray. This works better with other widgets.

Closes #1981.

No backport needed, I don't think the issue is present in 3.0.