### PR TITLE
Improve texts in the research view

### DIFF
--- a/client/text.cpp
+++ b/client/text.cpp
@@ -750,10 +750,14 @@ int get_bulbs_per_turn(int *pours, bool *pteam, int *ptheirs)
  */
 int turns_to_research_done(const struct research *presearch, int per_turn)
 {
-  if (per_turn > 0) {
-    return ceil(static_cast<double>(presearch->client.researching_cost
-                                    - presearch->bulbs_researched)
-                / per_turn);
+  // Can be negative if the tech cost went down due to tech leak.
+  int missing =
+      presearch->client.researching_cost - presearch->bulbs_researched;
+  if (missing <= per_turn) {
+    // Tech will be researched at TC.
+    return 1;
+  } else if (per_turn > 0) {
+    return std::ceil(static_cast<double>(missing) / per_turn);
   } else {
     return -1;
   }

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -917,35 +917,49 @@ const QString get_science_target_text()
 const QString get_science_goal_text(Tech_type_id goal)
 {
   const struct research *research = research_get(client_player());
-  int steps = research_goal_unknown_techs(research, goal);
-  int bulbs_needed = research_goal_bulbs_required(research, goal);
-  int turns;
-  int perturn = get_bulbs_per_turn(nullptr, nullptr, nullptr);
-  QString str, buf1, buf2, buf3;
-
   if (!research) {
     return QStringLiteral("-");
   }
 
+  if (!valid_advance_by_number(goal)) {
+    // No goal - act as if it were the current research
+    goal = research->researching;
+  }
+
+  int steps = research_goal_unknown_techs(research, goal);
+  int bulbs_needed = research_goal_bulbs_required(research, goal);
+  int perturn = get_bulbs_per_turn(nullptr, nullptr, nullptr);
+
   if (research_goal_tech_req(research, goal, research->researching)
       || research->researching == goal) {
     bulbs_needed -= research->bulbs_researched;
+    // Adjust for the actual cost of the current tech (e.g. due to tech leak)
+    bulbs_needed -=
+        research_goal_bulbs_required(research, research->researching);
+    bulbs_needed += research->client.researching_cost;
   }
 
+  int turns = -1;
+  if (bulbs_needed < perturn) {
+    turns = 1;
+  } else if (perturn > 0) {
+    turns = (bulbs_needed + perturn - 1) / perturn;
+  }
+
+  QString buf1, buf2, buf3;
   buf1 =
       QString(PL_("%1 step", "%1 steps", steps)).arg(QString::number(steps));
   buf2 = QString(PL_("%1 bulb", "%1 bulbs", bulbs_needed))
              .arg(QString::number(bulbs_needed));
-  if (perturn > 0) {
-    turns = (bulbs_needed + perturn - 1) / perturn;
+
+  if (turns >= 0) {
     buf3 = QString(PL_("%1 turn", "%1 turns", turns))
                .arg(QString::number(turns));
   } else {
     buf3 = QString(_("never"));
   }
-  str += QStringLiteral("(%1 - %2 - %3)").arg(buf1, buf2, buf3);
 
-  return str.trimmed();
+  return QStringLiteral("(%1 - %2 - %3)").arg(buf1, buf2, buf3);
 }
 
 /**

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -849,9 +849,9 @@ const QString science_dialog_text()
 
   if (game.info.tech_upkeep_style != TECH_UPKEEP_NONE) {
     // perturn is defined as: (bulbs produced) - upkeep
+    str += qendl();
     str += QString(_("Bulbs produced per turn: %1"))
-               .arg(QString::number(perturn + upkeep))
-           + qendl();
+               .arg(QString::number(perturn + upkeep));
     /* TRANS: keep leading space; appended to "Bulbs produced per turn: %d"
      */
     str += QString(_(" (needed for technology upkeep: %1)"))

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -870,7 +870,7 @@ const QString science_dialog_text()
    The "percent" value, if given, will be set to the completion percentage
    of the research target (actually it's a [0,1] scale not a percent).
  */
-const QString get_science_target_text(double *percent)
+const QString get_science_target_text()
 {
   struct research *research = research_get(client_player());
   QString str;
@@ -882,9 +882,6 @@ const QString get_science_target_text(double *percent)
   if (research->researching == A_UNSET) {
     str = QString(_("%1/- (never)"))
               .arg(QString::number(research->bulbs_researched));
-    if (percent) {
-      *percent = 0.0;
-    }
   } else {
     int total = research->client.researching_cost;
     int done = research->bulbs_researched;
@@ -904,10 +901,6 @@ const QString get_science_target_text(double *percent)
       // no forward progress -- no research, or tech loss disallowed
       str = QString(_("%1/%2 (never)"))
                 .arg(QString::number(done), QString::number(total));
-    }
-    if (percent) {
-      *percent = static_cast<double>(done) / static_cast<double>(total);
-      *percent = CLIP(0.0, *percent, 1.0);
     }
   }
 
@@ -1047,7 +1040,7 @@ const QString get_info_label_text_popup()
     str += QString(_("Researching %1: %2"))
                .arg(research_advance_name_translation(
                         presearch, presearch->researching),
-                    get_science_target_text(nullptr))
+                    get_science_target_text())
            + qendl();
     // perturn is defined as: (bulbs produced) - upkeep
     if (game.info.tech_upkeep_style != TECH_UPKEEP_NONE) {

--- a/client/text.h
+++ b/client/text.h
@@ -28,7 +28,7 @@ const QString unit_description(struct unit *punit);
 const QString get_airlift_text(const std::vector<unit *> &units,
                                const struct city *pdest);
 const QString science_dialog_text();
-const QString get_science_target_text(double *percent);
+const QString get_science_target_text();
 const QString get_science_goal_text(Tech_type_id goal);
 const QString get_info_label_text(bool moreinfo);
 const QString get_info_label_text_popup();

--- a/client/views/view_research.cpp
+++ b/client/views/view_research.cpp
@@ -373,8 +373,6 @@ void science_report::update_report()
   int total;
   int done = research->bulbs_researched;
   QVariant qvar, qres;
-  double not_used;
-  QString str;
   qlist_item item;
 
   if (research->researching != A_UNSET) {
@@ -389,8 +387,7 @@ void science_report::update_report()
   progress_label->setAlignment(Qt::AlignHCenter);
   info_label->setAlignment(Qt::AlignHCenter);
   info_label->setText(get_science_goal_text(research->tech_goal));
-  str = get_science_target_text(&not_used);
-  progress->setFormat(str);
+  progress->setFormat(get_science_target_text());
   progress->setMinimum(0);
   progress->setMaximum(total);
   progress->set_pixmap(static_cast<int>(research->researching));


### PR DESCRIPTION
Improve the following texts in the research view header following [a comment by Blauwal on Discord](https://discord.com/channels/378908274113904641/1106327029223272518/1132109288521867346):
* The bulb production details (top left): add a missing newline when tech upkeep is enabled
* The current status (top right in the progress bar): make it work better when tech leak and tech upkeep are used together
* The number of bulbs/turns required to reach the current goal (bottom right): make it less confusing by taking the real cost of the current tech into account

Some small code improvements here and there as well.

I think the risks of backporting this outweigh the benefits.