### PR TITLE
Fix picking a gender and init randomly

### DIFF
--- a/client/dialogs.h
+++ b/client/dialogs.h
@@ -156,7 +156,6 @@ private slots:
 private:
   int selected_nation;
   int selected_style;
-  int selected_sex;
   struct player *tplayer;
   int last_index;
 };


### PR DESCRIPTION
Picking a gender was not working because the radio buttons weren't synchronized with the internal variable holding the information. Discard the internal variable and use the buttons as the source of truth. Always make sure that one of the buttons is selected. Pick one randomly on startup, as choosing one would be offensive towards half of humankind.

Reported by Hawk on Discord.

Backport candidate.