### PR TITLE
Docs: pin sphinx to <7.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+sphinx<7.2  # See #2023
 sphinx_rtd_theme
 sphinx_last_updated_by_git


### PR DESCRIPTION
This is a short-term solution for #2023. In the long run, upstream issues should be fixed:
* https://github.com/sphinx-doc/sphinx/issues/11643
* https://github.com/mgeier/sphinx-last-updated-by-git/pull/57

Closes #2023.

Backport recommended.