### PR TITLE
Fix disembarking without losing MP through adjacent transport

### DIFF
--- a/common/map.cpp
+++ b/common/map.cpp
@@ -759,19 +759,9 @@ int tile_move_cost_ptrs(const struct civ_map *nmap, const struct unit *punit,
 
   } else if (!is_native_tile_to_class(pclass, t2)
              || !is_native_tile_to_class(pclass, t1)) {
-    if (tile_city(t1) == nullptr) {
-      /* Loading to/disembarking from transport. */
-
-      // UTYF_IGTER units get move benefit.
-      return (utype_has_flag(punittype, UTYF_IGTER) ? MOVE_COST_IGTER
-                                                    : SINGLE_MOVE);
-    } else {
-      /* Entering/leaving port. */
-
-      // UTYF_IGTER units get move benefit.
-      return (utype_has_flag(punittype, UTYF_IGTER) ? MOVE_COST_IGTER
-                                                    : SINGLE_MOVE);
-    }
+    // UTYF_IGTER units get move benefit.
+    return (utype_has_flag(punittype, UTYF_IGTER) ? MOVE_COST_IGTER
+                                                  : SINGLE_MOVE);
   }
 
   cost = tile_terrain(t2)->movement_cost * SINGLE_MOVE;

--- a/common/path.h
+++ b/common/path.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <unit.h>
+#include "unit.h"
 
 #include <vector>
 

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -645,7 +645,7 @@ static bool do_disembark(struct player *act_player, struct unit *act_unit,
   fc_assert_ret_val(tgt_tile, false);
   fc_assert_ret_val(paction, false);
 
-  unit_move(act_unit, tgt_tile, move_cost, nullptr, false, false);
+  unit_move(act_unit, tgt_tile, move_cost, nullptr, true, false);
 
   return true;
 }

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2522,7 +2522,7 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
             /* FIXME: Shouldn't unit_move_handling() be used here? This is
              * the unit escaping by moving itself. It should therefore
              * respect movement rules. */
-            unit_move(vunit, dsttile, move_cost, nullptr, false, false);
+            unit_move(vunit, dsttile, move_cost, nullptr, true, false);
             num_escaped[player_index(vplayer)]++;
             escaped = true;
             unitcount--;


### PR DESCRIPTION
Say we have two transports A and B next to the coast C, with a land
unit in A. Consider the following orders for the land unit:

1. Unload from A to B->tile
2. Move from B->tile to C

This sequence should not succeed because the unit should still be loaded
after the first step. However, in practice the unit was not loaded after
step 1, resulting in an invalid state that confused ORDER_MOVED. Do the
same when bumping units after a transport is killed.

The fix to that is obviously to load the unit after step 1. There is a
catch though: this is (and has always been) done without considering
action enablers. It might be possible to exploit this to bypass loading
rules.

Path finding support is also included in this PR.
Backport candidate.