### PR TITLE
Fix typo: vity => city

### DIFF
--- a/data/helpdata.txt
+++ b/data/helpdata.txt
@@ -1412,7 +1412,7 @@ Main Map (Keys):\n\
 "), _("\
 Main Map (Mouse):\n\
 =================\n\
-  Left-click on vity:            Open city dialog\n\
+  Left-click on city:            Open city dialog\n\
   Left-click on unit:            Select a single unit\n\
                                  (cancels any current activity if \"clear\n\
                                  Unit orders on selection\" is set)\n\


### PR DESCRIPTION
Fixes a typo in the help for the controls