### PR TITLE
Stop disbanding units under UWT when bouncing them

### DIFF
--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -1375,7 +1375,14 @@ void bounce_unit(struct unit *punit, bool verbose, bounce_reason reason,
         packet.orders[i] = steps[i].order;
       }
 
+      // Disable unit wait time since this is a forced action
+      auto timestamp = punit->action_timestamp;
+      punit->action_timestamp = 0;
+
       handle_unit_orders(pplayer, &packet);
+
+      // Restore unit wait time
+      punit->action_timestamp = timestamp;
 
       if (punit->tile != punit_tile) {
         return;


### PR DESCRIPTION
When a unit affected by unit wait time was bounced, the generated move order was rejected by the move handling code. As a consequence, the unit ended up being disbanded.

This affected units doing terraforming work (e.g. turning land to ocean). This forced players to issue the terraforming orders at least UWT seconds before TC, which forced them to connect at specific times of the day. Since one of the goals of UWT is exactly to avoid this constraint around TC, adding a similar constraint around TC - UWT is the opposite of good.