### PR TITLE
Fix map sharing

### DIFF
--- a/common/vision.cpp
+++ b/common/vision.cpp
@@ -62,11 +62,6 @@ bool vision_reveal_tiles(struct vision *vision, bool reveal_tiles)
 }
 
 /**
-   Frees vision site structure.
- */
-void vision_site_destroy(struct vision_site *psite) { delete[] psite; }
-
-/**
    Returns the basic structure.
  */
 struct vision_site *vision_site_new(int identity, struct tile *location,

--- a/common/vision.h
+++ b/common/vision.h
@@ -130,7 +130,6 @@ struct vision_site {
 };
 
 #define vision_site_owner(v) ((v)->owner)
-void vision_site_destroy(struct vision_site *psite);
 struct vision_site *vision_site_new(int identity, struct tile *location,
                                     struct player *owner);
 struct vision_site *vision_site_new_from_city(const struct city *pcity);

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -2128,7 +2128,7 @@ bool send_city_suppression(bool now)
 static void package_dumb_city(struct player *pplayer, struct tile *ptile,
                               struct packet_city_short_info *packet)
 {
-  struct vision_site *pdcity = map_get_player_city(ptile, pplayer);
+  const vision_site *pdcity = map_get_player_city(ptile, pplayer);
 
   fc_assert_ret(pdcity != nullptr);
   packet->id = pdcity->identity;
@@ -2693,18 +2693,15 @@ bool update_dumb_city(struct player *pplayer, struct city *pcity)
  */
 void reality_check_city(struct player *pplayer, struct tile *ptile)
 {
-  struct vision_site *pdcity = map_get_player_city(ptile, pplayer);
+  auto playtile = map_get_player_tile(ptile, pplayer);
 
-  if (pdcity) {
+  if (playtile->site && playtile->site->location == ptile) {
     struct city *pcity = tile_city(ptile);
 
-    if (!pcity || pcity->id != pdcity->identity) {
-      struct player_tile *playtile = map_get_player_tile(ptile, pplayer);
-
-      dlsend_packet_city_remove(pplayer->connections, pdcity->identity);
-      fc_assert_ret(playtile->site == pdcity);
+    if (!pcity || pcity->id != playtile->site->identity) {
+      dlsend_packet_city_remove(pplayer->connections,
+                                playtile->site->identity);
       playtile->site = nullptr;
-      vision_site_destroy(pdcity);
     }
   }
 }
@@ -2714,15 +2711,12 @@ void reality_check_city(struct player *pplayer, struct tile *ptile)
  */
 void remove_dumb_city(struct player *pplayer, struct tile *ptile)
 {
-  struct vision_site *pdcity = map_get_player_city(ptile, pplayer);
+  auto playtile = map_get_player_tile(ptile, pplayer);
 
-  if (pdcity) {
-    struct player_tile *playtile = map_get_player_tile(ptile, pplayer);
-
-    dlsend_packet_city_remove(pplayer->connections, pdcity->identity);
-    fc_assert_ret(playtile->site == pdcity);
+  if (playtile->site && playtile->site->location == ptile) {
+    dlsend_packet_city_remove(pplayer->connections,
+                              playtile->site->identity);
     playtile->site = nullptr;
-    vision_site_destroy(pdcity);
   }
 }
 

--- a/server/diplomats.cpp
+++ b/server/diplomats.cpp
@@ -378,9 +378,8 @@ void spy_send_sabotage_list(struct connection *pc, struct unit *pdiplomat,
     improvement_iterate_end;
   } else {
     // Can't see hidden buildings.
-    struct vision_site *plrcity;
-
-    plrcity = map_get_player_city(city_tile(pcity), unit_owner(pdiplomat));
+    const vision_site *plrcity =
+        map_get_player_city(city_tile(pcity), unit_owner(pdiplomat));
 
     if (!plrcity) {
       // Must know city to remember visible buildings.

--- a/server/maphand.h
+++ b/server/maphand.h
@@ -25,10 +25,10 @@ struct section_file;
 struct conn_list;
 
 struct player_tile {
-  struct vision_site *site;    // nullptr for no vision site
-  struct extra_type *resource; // nullptr for no resource
-  struct terrain *terrain;     // nullptr for unknown tiles
-  struct player *owner;        // nullptr for unowned
+  std::unique_ptr<vision_site> site; // nullptr for no vision site
+  struct extra_type *resource;       // nullptr for no resource
+  struct terrain *terrain;           // nullptr for unknown tiles
+  struct player *owner;              // nullptr for unowned
   struct player *extras_owner;
   bv_extras extras;
 

--- a/server/savegame/savegame2.cpp
+++ b/server/savegame/savegame2.cpp
@@ -4635,9 +4635,7 @@ static void sg_load_player_vision(struct loaddata *loading,
     } else {
       // Error loading the data.
       log_sg("Skipping seen city %d for player %d.", i, plrno);
-      if (pdcity != nullptr) {
-        vision_site_destroy(pdcity);
-      }
+      delete pdcity;
     }
   }
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -6728,9 +6728,7 @@ static void sg_load_player_vision(struct loaddata *loading,
     } else {
       // Error loading the data.
       log_sg("Skipping seen city %d for player %d.", i, plrno);
-      if (pdcity != nullptr) {
-        vision_site_destroy(pdcity);
-      }
+      delete pdcity;
     }
   }
 
@@ -6972,7 +6970,7 @@ static void sg_save_player_vision(struct savedata *saving,
   i = 0;
   whole_map_iterate(&(wld.map), ptile)
   {
-    struct vision_site *pdcity = map_get_player_city(ptile, plr);
+    const vision_site *pdcity = map_get_player_city(ptile, plr);
     char impr_buf[B_LAST + 1];
     char buf[32];
 

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -3386,7 +3386,7 @@ player *mapimg_server_tile_city(const struct tile *ptile,
   }
 
   if (knowledge && pplayer) {
-    struct vision_site *pdcity = map_get_player_city(ptile, pplayer);
+    const vision_site *pdcity = map_get_player_city(ptile, pplayer);
 
     if (pdcity) {
       return pdcity->owner;

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -4336,7 +4336,7 @@ static bool maybe_cancel_patrol_due_to_enemy(struct unit *punit)
   {
     struct unit *penemy = is_non_allied_unit_tile(ptile, pplayer);
 
-    struct vision_site *pdcity = map_get_player_site(ptile, pplayer);
+    const vision_site *pdcity = map_get_player_site(ptile, pplayer);
 
     if ((penemy && can_player_see_unit(pplayer, penemy))
         || (pdcity && !pplayers_allied(pplayer, vision_site_owner(pdcity))


### PR DESCRIPTION
Sharing maps between players was fundamentally broken. The server records the last turn in which a player saw a tile. This information is only updated when the player stops seeing a tile, and not when it just keeps seeing it because the tile is within its vision range.

The following map sharing bugs existed:
* Tiles seen by the giving player were not sent if the receiving player had last viewed them after the giving player;
* Cities were only updated when destroyed. Renamed or growing cities were not updated.

This commit fixes both bugs. The core logic in `really_give_tile_info_from_player_to_player` was completely overhauled to make it easier to follow and more correct. In addition, `player_tile.site` was turned to a `unique_ptr` to facilitate bookkeeping.

Closes #2045

Testing: Before the patch:
* Watch the occupied city indicator in a city. Move units in and out while giving your map to another player. See the indicator not being updated for the other player.
* Same with city renaming.
* If you are patient enough, repeat with city growth, terrain alterations, etc.

After the patch, the other player should always get the information at the time of signing the treaty.

Not suggesting to backport since the bugs had been there for a very long time.