### PR TITLE
Allow reopening investigated cities

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -1172,9 +1172,7 @@ void control_mouse_cursor(struct tile *ptile)
     if (nullptr != punit && unit_owner(punit) == client_player()) {
       // Set mouse cursor to select a unit.
       mouse_cursor_type = CURSOR_SELECT;
-    } else if (nullptr != pcity
-               && can_player_see_city_internals(client.conn.playing,
-                                                pcity)) {
+    } else if (nullptr != pcity && pcity->client.full) {
       // Set mouse cursor to select a city.
       mouse_cursor_type = CURSOR_SELECT;
     } else {
@@ -2544,8 +2542,7 @@ void do_map_click(struct tile *ptile, enum quickselect_type qtype)
       unit_focus_set_and_select(qunit);
       maybe_goto = gui_options->keyboardless_goto;
     }
-  } else if (nullptr != pcity
-             && can_player_see_city_internals(client.conn.playing, pcity)) {
+  } else if (nullptr != pcity && pcity->client.full) {
     // Otherwise use popups.
     popup_city_dialog(pcity);
   } else if (!near_pcity && unit_list_size(ptile->units) == 0

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -688,6 +688,7 @@ void handle_city_info(const struct packet_city_info *packet)
         || (gui_options->draw_city_trade_routes && trade_routes_changed);
   }
 
+  pcity->client.full = true;
   sz_strlcpy(pcity->name, packet->name);
 
   // check data
@@ -1154,6 +1155,8 @@ void handle_city_short_info(const struct packet_city_short_info *packet)
     memset(pcity->feel, 0, sizeof(pcity->feel));
     memset(pcity->specialists, 0, sizeof(pcity->specialists));
   }
+
+  pcity->client.full = false;
 
   pcity->specialists[DEFAULT_SPECIALIST] = packet->size;
   city_size_set(pcity, packet->size);

--- a/common/city.h
+++ b/common/city.h
@@ -423,6 +423,7 @@ struct city {
 
     struct {
       /* Only used at the client (the server is omniscient; ./client/). */
+      bool full; // Did we get a full city info packet (owner or investigate)
       bool occupied;
       int walls;
       bool happy;


### PR DESCRIPTION
The client was already remembering information about investigated cities, but there was no way of seeing it once out of the city screen. Allow reopening the city screen by clicking on the city.

Closes #2059.

Could be backported even though it's technically a new feature, it was so simple...