### PR TITLE
Don't display unknown diplomatic relations as war

### DIFF
--- a/client/views/view_nations.cpp
+++ b/client/views/view_nations.cpp
@@ -558,6 +558,13 @@ void plr_widget::nation_selected(const QItemSelection &sl,
       if (other == pplayer || is_barbarian(other)) {
         continue;
       }
+      if (!BV_ISSET(pplayer->client.visible, NI_DIPLOMACY)
+          && !BV_ISSET(other->client.visible, NI_DIPLOMACY)) {
+        // We don't know anything about diplomatic relations between these
+        // players
+        continue;
+      }
+
       state = player_diplstate_get(pplayer, other);
       if (static_cast<int>(state->type) == i) {
         if (!added) {


### PR DESCRIPTION
The diplomatic status between two nations the current player has no contact with is usually not known by the client. The server sends "war" in this case (it should arguably not send anything at all). It also sets the NI_DIPLOMACY bit in client.visible to false to tell the client that this information is not available. However, the client ignores this and just displays "war".

Make the client ignore diplomatic relations between two players when the NI_DIPLOMACY bit is false for both players -- that is, when no information is available. This prevents the client from displaying invalid data.

Discovered during LeagueB2.
Backport candidate (I confirmed that `stable` already has the `NationalIntelligence` feature that this patch requires)