### PR TITLE
Add python3 to vcpkg.json to fix MacOS build

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "qt5-svg",
     "openssl",
     "lua",
+    "python3",
     {
       "name": "gettext",
       "features": [ "tools" ]


### PR DESCRIPTION
No related issue. Fixes MacOS CI for both master and stable. Adding to back-ports.