### PR TITLE
Fix dereference after null check in ratesdlg.cpp

### DIFF
--- a/client/ratesdlg.cpp
+++ b/client/ratesdlg.cpp
@@ -87,9 +87,12 @@ national_budget_dialog::national_budget_dialog(QWidget *parent)
  */
 void national_budget_dialog::refresh()
 {
-  const int max = client.conn.playing
-                      ? get_player_bonus(client.conn.playing, EFT_MAX_RATES)
-                      : 100;
+  if (!client.conn.playing) {
+    // The budget dialog doesn't make sense without a player
+    return;
+  }
+
+  const int max = get_player_bonus(client.conn.playing, EFT_MAX_RATES);
 
   // Trans: Government - max rate (of taxes) x%
   m_info->setText(QString(_("%1 - max rate: %2%"))


### PR DESCRIPTION
Closes #2072.
Coverity CID 1528901.

This affects the national budget dialog when there is no player (global observer). I haven't been able to fire it up in this case, but better safe than sorry.