### PR TITLE
Prevent negative action chance in diplomat battles

### DIFF
--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -4387,8 +4387,8 @@ static struct act_prob ap_dipl_battle_win(const struct unit *pattacker,
   }
 
   // Convert to action probability
-  out.min = chance * ACTPROB_VAL_1_PCT;
-  out.max = chance * ACTPROB_VAL_1_PCT;
+  out.min = std::max(ACTPROB_VAL_MIN, chance * ACTPROB_VAL_1_PCT);
+  out.max = std::min(ACTPROB_VAL_MAX, chance * ACTPROB_VAL_1_PCT);
 
   return out;
 }


### PR DESCRIPTION
The win probability could become negative or larger than one when Spy_Resistant effects were involved. Clip the probability between 0 and 1.

I think this is the only way #2035 can possibly have occurred so I would close it after this PR is merged.
Closes #2035.