### PR TITLE
Fix crash in layer_terrain

### DIFF
--- a/client/tileset/layer_terrain.cpp
+++ b/client/tileset/layer_terrain.cpp
@@ -786,7 +786,12 @@ int layer_terrain::terrain_group(const terrain *pterrain) const
     return -1;
   }
 
-  return m_terrain_info.at(terrain_index(pterrain)).group->number;
+  auto group = m_terrain_info.at(terrain_index(pterrain)).group;
+  if (!group) {
+    return -1;
+  }
+
+  return group->number;
 }
 
 namespace /* anonymous */ {


### PR DESCRIPTION
Check that there is a group before trying to dereference it. The user may not have provided one.

Closes #2017.