### PR TITLE
Local sockets

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -468,7 +468,8 @@ int client_main(int argc, char *argv[])
   auto positional = parser.positionalArguments();
   if (positional.size() == 1) {
     url = QUrl(positional.constFirst());
-    if (!url.isValid() || url.scheme() != QStringLiteral("fc21")) {
+    // Supported schemes: fc21://, fc21+local://
+    if (!url.isValid() || (!url.scheme().startsWith("fc21"))) {
       // Try with the default protocol
       url = QUrl(QStringLiteral("fc21://") + positional.constFirst());
       // Still no luck

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -99,28 +99,18 @@ static void error_on_socket()
 }
 
 /**
-   Try to connect to a server:
-    - try to create a TCP socket to the given URL (default to
-      localhost:DEFAULT_SOCK_PORT).
-    - if successful:
-           - start monitoring the socket for packets from the server
-           - send a "login request" packet to the server
-       and - return 0
-    - if unable to create the connection, close the socket, put an error
-      message in ERRBUF and return the Unix error code (ie., errno, which
-      will be non-zero).
+ * Try to connect to a server:
+ *  - try to create a TCP socket to the given URL
+ *  - if successful:
+ *         - start monitoring the socket for packets from the server
+ *         - send a "login request" packet to the server
+ *     and - return 0
+ *  - if unable to create the connection, close the socket, put an error
+ *    message in ERRBUF and return the Unix error code (ie., errno, which
+ *    will be non-zero).
  */
 static int try_to_connect(const QUrl &url, char *errbuf, int errbufsize)
 {
-  // Apply defaults
-  auto url_copy = url;
-  if (url_copy.host().isEmpty()) {
-    url_copy.setHost(QStringLiteral("localhost"));
-  }
-  if (url_copy.port() <= 0) {
-    url_copy.setPort(DEFAULT_SOCK_PORT);
-  }
-
   connections_set_close_callback(client_conn_close_callback);
 
   // connection in progress? wait.

--- a/client/clinet.h
+++ b/client/clinet.h
@@ -11,15 +11,15 @@
 #pragma once
 
 // Forward declarations
-class QTcpSocket;
+class QIODevice;
 class QString;
 class QUrl;
 
 int connect_to_server(const QUrl &url, char *errbuf, int errbufsize);
 
-void make_connection(QTcpSocket *sock, const QString &username);
+void make_connection(QIODevice *sock, const QString &username);
 
-void input_from_server(QTcpSocket *sock);
+void input_from_server(QIODevice *sock);
 void disconnect_from_server();
 
 double try_to_autoconnect(const QUrl &url);

--- a/client/connectdlg_common.cpp
+++ b/client/connectdlg_common.cpp
@@ -200,7 +200,7 @@ bool client_start_server(const QString &user_name)
     return false;
   }
 
-  // Unique name for this game
+  // Generate a (random) unique name for the local socket
   auto uuid = QUuid::createUuid().toString(QUuid::WithoutBraces);
 
   // Set up the command-line parameters.

--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -274,7 +274,7 @@ enum client_pages fc_client::current_page() { return page; }
 /**
    Add notifier for server input
  */
-void fc_client::add_server_source(QTcpSocket *sock)
+void fc_client::add_server_source(QIODevice *sock)
 {
   connect(sock, &QIODevice::readyRead, this, &fc_client::server_input);
 
@@ -297,7 +297,7 @@ void fc_client::closeEvent(QCloseEvent *event)
  */
 void fc_client::server_input()
 {
-  if (auto *socket = dynamic_cast<QTcpSocket *>(sender())) {
+  if (auto *socket = dynamic_cast<QIODevice *>(sender())) {
     input_from_server(socket);
   }
 }

--- a/client/fc_client.h
+++ b/client/fc_client.h
@@ -111,7 +111,7 @@ public:
   ~fc_client() override;
   QWidget *pages[static_cast<int>(PAGE_GAME) + 2];
   void fc_main(QApplication *);
-  void add_server_source(QTcpSocket *socket);
+  void add_server_source(QIODevice *socket);
 
   enum client_pages current_page();
 

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -139,7 +139,7 @@ void sound_bell()
    This function is called after the client succesfully has connected
    to the server.
  */
-void add_net_input(QTcpSocket *sock) { king()->add_server_source(sock); }
+void add_net_input(QIODevice *sock) { king()->add_server_source(sock); }
 
 /**
    Stop waiting for any server network data.  See add_net_input().

--- a/client/include/gui_main_g.h
+++ b/client/include/gui_main_g.h
@@ -11,18 +11,10 @@
 #pragma once
 
 // Forward declarations
-class QTcpSocket;
-
-// utility
-#include "support.h" // bool type
-
-// common
-#include "fc_types.h"
+class QIODevice;
 
 void ui_main();
 void ui_exit();
-
-void insert_client_build_info(char *outbuf, size_t outlen);
 
 extern const char *client_string;
 

--- a/client/page_network.cpp
+++ b/client/page_network.cpp
@@ -444,12 +444,12 @@ void page_network::slot_connect()
 
   switch (connection_status) {
   case LOGIN_TYPE:
+    client_url().setScheme(QStringLiteral("fc21"));
     client_url().setUserName(ui.connect_login_edit->text());
     client_url().setHost(ui.connect_host_edit->text());
     client_url().setPort(ui.connect_port_edit->text().toInt());
 
-    if (connect_to_server(client_url(), errbuf, sizeof(errbuf)) != -1) {
-    } else {
+    if (connect_to_server(client_url(), errbuf, sizeof(errbuf)) < 0) {
       king->set_status_bar(QString::fromUtf8(errbuf));
       output_window_append(ftc_client, errbuf);
     }

--- a/client/qtg_cxxside.h
+++ b/client/qtg_cxxside.h
@@ -20,7 +20,7 @@ class QTcpSocket;
 
 void options_extra_init();
 void set_rulesets(int num_rulesets, QStringList rulesets);
-void add_net_input(QTcpSocket *sock);
+void add_net_input(QIODevice *sock);
 void remove_net_input();
 void real_conn_list_dialog_update(void *unused);
 void sound_bell();

--- a/common/networking/connection.h
+++ b/common/networking/connection.h
@@ -30,7 +30,8 @@
 #include "fc_types.h"
 
 // Forward declarations
-class QTcpSocket;
+class QIODevice;
+class QString;
 
 struct conn_pattern_list;
 struct genhash;
@@ -126,7 +127,7 @@ struct packet_header {
 ***********************************************************/
 struct connection {
   int id; /* used for server/client communication */
-  QTcpSocket *sock = nullptr;
+  QIODevice *sock = nullptr;
   bool used;
   bool established; // have negotiated initial packets
   struct packet_header packet_header;
@@ -259,9 +260,9 @@ struct connection {
 
 typedef void (*conn_close_fn_t)(struct connection *pconn);
 void connections_set_close_callback(conn_close_fn_t func);
-void connection_close(struct connection *pconn, const char *reason);
+void connection_close(struct connection *pconn, const QString &reason);
 
-int read_socket_data(QTcpSocket *sock, struct socket_packet_buffer *buffer);
+int read_socket_data(QIODevice *sock, struct socket_packet_buffer *buffer);
 void flush_connection_send_buffer_all(struct connection *pc);
 bool connection_send_data(struct connection *pconn,
                           const unsigned char *data, int len);

--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -172,6 +172,9 @@ int main(int argc, char *argv[])
        _("Listen for clients on ADDR."),
        // TRANS: Command-line argument
        _("ADDR")},
+      {QStringLiteral("local"), _("Listens to the local socket NAME"),
+       // TRANS: Command-line argument
+       _("NAME")},
       {{"d", _("debug")},
        // TRANS: Do not translate "fatal", "critical", "warning", "info" or
        //        "debug". It's exactly what the user must type.
@@ -249,7 +252,7 @@ int main(int argc, char *argv[])
 #endif // AI_MODULES
   });
   if (!ok) {
-    qFatal("Adding command line arguments failed.");
+    qCritical("Adding command line arguments failed.");
     exit(EXIT_FAILURE);
   }
 
@@ -286,14 +289,21 @@ int main(int argc, char *argv[])
   if (parser.isSet(QStringLiteral("identity"))) {
     srvarg.ranklog_filename = parser.value(QStringLiteral("identity"));
   }
+  if (parser.isSet(QStringLiteral("local"))) {
+    srvarg.local_addr = parser.value(QStringLiteral("local"));
+  }
   if (parser.isSet(QStringLiteral("port"))) {
+    if (!srvarg.local_addr.isEmpty()) {
+      qCritical(_("Cannot use --port with --local"));
+      exit(EXIT_FAILURE);
+    }
     bool conversion_ok;
     srvarg.port =
         parser.value(QStringLiteral("port")).toUInt(&conversion_ok);
     srvarg.user_specified_port = true;
     if (!conversion_ok) {
-      qFatal(_("Invalid port number %s"),
-             qUtf8Printable(parser.value("port")));
+      qCritical(_("Invalid port number %s"),
+                qUtf8Printable(parser.value("port")));
       exit(EXIT_FAILURE);
     }
   }
@@ -302,6 +312,10 @@ int main(int argc, char *argv[])
     // Check consistency
     if (!srvarg.bind_addr.setAddress(addr)) {
       qCritical(_("Not a valid IP address: %s"), qUtf8Printable(addr));
+      exit(EXIT_FAILURE);
+    }
+    if (!srvarg.local_addr.isEmpty()) {
+      qCritical(_("Cannot use --bind with --local"));
       exit(EXIT_FAILURE);
     }
   }
@@ -316,8 +330,8 @@ int main(int argc, char *argv[])
     srvarg.quitidle =
         parser.value(QStringLiteral("quitidle")).toUInt(&conversion_ok);
     if (!conversion_ok) {
-      qFatal(_("Invalid number %s"),
-             qUtf8Printable(parser.value("quitidle")));
+      qCritical(_("Invalid number %s"),
+                qUtf8Printable(parser.value("quitidle")));
       exit(EXIT_FAILURE);
     }
   }

--- a/server/connecthand.cpp
+++ b/server/connecthand.cpp
@@ -953,7 +953,7 @@ bool connection_delegate_restore(struct connection *pconn)
    Close a connection. Use this in the server to take care of delegation
  stuff (reset the username of the controlled connection).
  */
-void connection_close_server(struct connection *pconn, const char *reason)
+void connection_close_server(struct connection *pconn, const QString &reason)
 {
   // Restore possible delegations before the connection is closed.
   connection_delegate_restore(pconn);

--- a/server/connecthand.h
+++ b/server/connecthand.h
@@ -15,6 +15,8 @@
 
 #include "fc_types.h"
 
+class QString;
+
 struct connection;
 struct conn_list;
 struct packet_server_join_req;
@@ -42,4 +44,5 @@ bool connection_delegate_take(struct connection *pconn,
                               struct player *pplayer);
 bool connection_delegate_restore(struct connection *pconn);
 
-void connection_close_server(struct connection *pconn, const char *reason);
+void connection_close_server(struct connection *pconn,
+                             const QString &reason);

--- a/server/sernet.cpp
+++ b/server/sernet.cpp
@@ -367,7 +367,7 @@ int server_make_connection(QIODevice *new_sock, const QString &client_addr,
    Open server socket to be used to accept client connections
    and open a server socket for server LAN announcements.
  */
-optional_socket_server server_open_socket()
+std::optional<socket_server> server_open_socket()
 {
   // Local socket mode
   if (!srvarg.local_addr.isEmpty()) {

--- a/server/sernet.h
+++ b/server/sernet.h
@@ -30,9 +30,8 @@ struct connection;
 
 using socket_server =
     std::variant<std::unique_ptr<QTcpServer>, std::unique_ptr<QLocalServer>>;
-using optional_socket_server = std::optional<socket_server>;
 
-optional_socket_server server_open_socket();
+std::optional<socket_server> server_open_socket();
 void flush_packets();
 void incoming_client_packets(connection *pconn);
 void close_connections_and_socket();

--- a/server/sernet.h
+++ b/server/sernet.h
@@ -10,9 +10,14 @@
 **************************************************************************/
 #pragma once
 
+#include <memory>
+#include <optional>
+#include <variant>
+
 // Forward declarations
+class QIODevice;
+class QLocalServer;
 class QTcpServer;
-class QTcpSocket;
 class QString;
 
 struct connection;
@@ -23,13 +28,18 @@ struct connection;
 #define SERVER_LAN_TTL 1
 #define SERVER_LAN_VERSION 2
 
-QTcpServer *server_open_socket();
+using socket_server =
+    std::variant<std::unique_ptr<QTcpServer>, std::unique_ptr<QLocalServer>>;
+using optional_socket_server = std::optional<socket_server>;
+
+optional_socket_server server_open_socket();
 void flush_packets();
 void incoming_client_packets(connection *pconn);
 void close_connections_and_socket();
 void really_close_connections();
 void init_connections();
-int server_make_connection(QTcpSocket *new_sock, const QString &client_addr);
+int server_make_connection(QIODevice *new_sock, const QString &client_addr,
+                           const QString &ip_addr);
 void finish_unit_waits();
 void connection_ping(struct connection *pconn);
 void handle_conn_pong(struct connection *pconn);

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -25,7 +25,7 @@
 #include <QDir>
 #include <QFile>
 #include <QHostInfo>
-#include <QTcpServer>
+#include <QLocalSocket>
 #include <QTcpSocket>
 #include <QTimer>
 
@@ -129,7 +129,7 @@ void fc_interface_init_server()
 /**
    Server initialization.
  */
-std::pair<QTcpServer *, bool> srv_prepare()
+optional_socket_server srv_prepare()
 {
   // make sure it's initialized
   srv_init();
@@ -139,10 +139,9 @@ std::pair<QTcpServer *, bool> srv_prepare()
   con_log_init(srvarg.log_filename);
   // logging available after this point
 
-  auto *tcp_server = server_open_socket();
-  if (!tcp_server->isListening()) {
-    // Don't even try to start a game.
-    return std::make_pair(tcp_server, false);
+  auto server = server_open_socket();
+  if (!server) {
+    return std::nullopt;
   }
 
   con_flush();
@@ -166,7 +165,7 @@ std::pair<QTcpServer *, bool> srv_prepare()
 
     success = fcdb_init(qUtf8Printable(srvarg.fcdb_conf));
     if (!success) {
-      return std::make_pair(tcp_server, false);
+      return std::nullopt;
     }
   }
 
@@ -178,7 +177,7 @@ std::pair<QTcpServer *, bool> srv_prepare()
     if (testfilename.isEmpty()) {
       qFatal(_("Ruleset directory \"%s\" not found"),
              qUtf8Printable(srvarg.ruleset));
-      return std::make_pair(tcp_server, false);
+      return std::nullopt;
     }
     sz_strlcpy(game.server.rulesetdir, qUtf8Printable(srvarg.ruleset));
   }
@@ -202,11 +201,11 @@ std::pair<QTcpServer *, bool> srv_prepare()
         || !send_server_info_to_metaserver(META_INFO)) {
       con_write(C_FAIL, _("Not starting without explicitly requested "
                           "metaserver connection."));
-      return std::make_pair(tcp_server, false);
+      return std::nullopt;
     }
   }
 
-  return std::make_pair(tcp_server, true);
+  return server;
 }
 
 } // anonymous namespace
@@ -309,20 +308,27 @@ server::server()
 
   // Now init the old C API
   fc_interface_init_server();
-  bool success;
-  std::tie(m_tcp_server, success) = srv_prepare();
-  if (!success) {
+  auto server = srv_prepare();
+  if (!server) {
     // Could not listen on the specified port. Rely on the caller checking
     // our state and not starting the event loop.
     return;
   }
-  m_tcp_server->setParent(this);
-  connect(m_tcp_server, &QTcpServer::newConnection, this,
-          &server::accept_connections);
-  connect(m_tcp_server, &QTcpServer::acceptError,
-          [](QAbstractSocket::SocketError error) {
-            qCritical("Error accepting connection: %d", error);
-          });
+  m_server = std::move(*server);
+  if (std::holds_alternative<std::unique_ptr<QTcpServer>>(m_server)) {
+    auto &tcp = std::get<std::unique_ptr<QTcpServer>>(m_server);
+    connect(tcp.get(), &QTcpServer::newConnection, this,
+            &server::accept_tcp_connections);
+    connect(tcp.get(), &QTcpServer::acceptError,
+            [](QAbstractSocket::SocketError error) {
+              qCritical("Error accepting connection: %d", error);
+            });
+  } else if (std::holds_alternative<std::unique_ptr<QLocalServer>>(
+                 m_server)) {
+    auto &local = std::get<std::unique_ptr<QLocalServer>>(m_server);
+    connect(local.get(), &QLocalServer::newConnection, this,
+            &server::accept_local_connections);
+  }
 
   m_eot_timer = timer_new(TIMER_CPU, TIMER_ACTIVE);
 
@@ -421,18 +427,58 @@ void server::init_interactive()
 bool server::is_ready() const { return m_ready; }
 
 /**
+ * Server accepts connections over local socket:
+ * Low level socket stuff, and basic-initialize the connection struct.
+ */
+void server::accept_local_connections()
+{
+  // We know it's safe: this method is only called for local connections
+  auto &server = std::get<std::unique_ptr<QLocalServer>>(m_server);
+
+  // There may be several connections available.
+  while (server->hasPendingConnections()) {
+    auto *socket = server->nextPendingConnection();
+    socket->setParent(this);
+
+    if (server_make_connection(socket, QStringLiteral("local"),
+                               QStringLiteral("local"))
+        == 0) {
+      // Success making the connection, connect signals
+      connect(socket, &QIODevice::readyRead, this, &server::input_on_socket);
+      connect(socket, &QLocalSocket::errorOccurred, this,
+              &server::error_on_socket);
+
+      // Prevents quitidle from firing immediately
+      m_someone_ever_connected = true;
+
+      // Turn off the quitidle timeout if it's running
+      if (m_quitidle_timer != nullptr) {
+        m_quitidle_timer->stop();
+        m_quitidle_timer->deleteLater();
+        m_quitidle_timer = nullptr;
+      }
+    } else {
+      socket->deleteLater();
+    }
+  }
+}
+
+/**
    Server accepts connections from client:
    Low level socket stuff, and basic-initialize the connection struct.
  */
-void server::accept_connections()
+void server::accept_tcp_connections()
 {
 #ifdef Q_OS_WIN
   QMutexLocker lock(&s_stdin_mutex);
 #endif
 
+  // We know it's safe: this method is only called for TCP connections
+  auto &server = std::get<std::unique_ptr<QTcpServer>>(m_server);
+
   // There may be several connections available.
-  while (m_tcp_server->hasPendingConnections()) {
-    auto *socket = m_tcp_server->nextPendingConnection();
+  while (server->hasPendingConnections()) {
+    auto *socket = server->nextPendingConnection();
     socket->setParent(this);
 
     // Lookup the host name of the remote end.
@@ -462,9 +508,9 @@ void server::accept_connections()
       {
         // Use TolerantConversion so one connections from the same address on
         // IPv4 and IPv6 are rejected as well.
-        if (!socket->peerAddress().isEqual(
-                pconn->sock->peerAddress(),
-                QHostAddress::TolerantConversion)) {
+        if (const auto *other = qobject_cast<QTcpSocket *>(pconn->sock);
+            socket->peerAddress().isEqual(
+                other->peerAddress(), QHostAddress::TolerantConversion)) {
           continue;
         }
         if (++count >= game.server.maxconnectionsperhost) {
@@ -480,11 +526,14 @@ void server::accept_connections()
       conn_list_iterate_end;
 
       if (!success) {
+        socket->deleteLater();
         continue;
       }
     }
 
-    if (server_make_connection(socket, remote) == 0) {
+    if (server_make_connection(socket, remote,
+                               socket->peerAddress().toString())
+        == 0) {
       // Success making the connection, connect signals
       connect(socket, &QIODevice::readyRead, this, &server::input_on_socket);
       connect(socket, &QAbstractSocket::errorOccurred, this,
@@ -560,7 +609,7 @@ void server::error_on_socket()
   conn_list_iterate(game.all_connections, pconn)
   {
     if (pconn->sock == socket) {
-      connection_close_server(pconn, _("network exception"));
+      connection_close_server(pconn, socket->errorString());
       break;
     }
   }
@@ -580,7 +629,7 @@ void server::input_on_socket()
 #endif
 
   // Get the socket
-  auto *socket = dynamic_cast<QTcpSocket *>(sender());
+  auto *socket = dynamic_cast<QIODevice *>(sender());
   if (socket == nullptr) {
     return;
   }

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -129,7 +129,7 @@ void fc_interface_init_server()
 /**
    Server initialization.
  */
-optional_socket_server srv_prepare()
+std::optional<socket_server> srv_prepare()
 {
   // make sure it's initialized
   srv_init();

--- a/server/server.h
+++ b/server/server.h
@@ -19,8 +19,12 @@
 
 #pragma once
 
+#include "sernet.h"
+
 // Qt
+#include <QLocalServer>
 #include <QObject>
+#include <QTcpServer>
 
 #include <atomic>
 
@@ -73,7 +77,8 @@ private slots:
   // Low-level stuff
   void error_on_socket();
   void input_on_socket();
-  void accept_connections();
+  void accept_local_connections();
+  void accept_tcp_connections();
   void send_pings();
 
   // Higher-level stuff
@@ -116,7 +121,7 @@ private:
   bool m_interactive = false;
   QObject *m_stdin_notifier = nullptr; // Actual type is OS-dependent
 
-  QTcpServer *m_tcp_server = nullptr;
+  socket_server m_server = socket_server();
 
   civtimer *m_eot_timer = nullptr, *m_between_turns_timer = nullptr;
 

--- a/server/srv_main.h
+++ b/server/srv_main.h
@@ -32,7 +32,9 @@ struct server_arguments {
   bool metaconnection_persistent;
   QString identity_name;
   unsigned short int metaserver_port;
-  // address this server is to listen on (nullptr => INADDR_ANY)
+  // Address in case a local socket is used
+  QString local_addr;
+  // address this server is to listen on
   QHostAddress bind_addr;
   // this server's listen port
   int port;


### PR DESCRIPTION
This PR restores #888 (rolled back in #913). It introduces the ability to run a server on a "local" socket: a UNIX local domain socket on Linux and a named pipe on Windows. This should allow local games on Windows without annoying firewall interference.

Closes #1051.