### PR TITLE
Remove Manhattan distances from trade routes

### DIFF
--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -449,23 +449,22 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
                                        struct goods_type *pgood,
                                        const bool establish_trade)
 {
-  int md, rmd, trade2, max_trade_2;
+  int rmd, trade2, max_trade_2;
   int tb = 0, bonus = 0;
 
   if (pc2) {
-    md = map_distance(pc1->tile, pc2->tile);
     rmd = real_map_distance(pc1->tile, pc2->tile);
     trade2 = pc2->surplus[O_TRADE];
     max_trade_2 = max_trade_prod(pc2, seen_as);
   } else {
-    md = rmd = 10;
+    rmd = 10;
     trade2 = pc1->surplus[O_TRADE] * 0.75;
     max_trade_2 = max_trade_prod(pc1, seen_as) * 0.75;
   }
 
   if (game.info.caravan_bonus_style == CBS_CLASSIC) {
     // Should this be real_map_distance (rmd)?
-    tb = md + 10;
+    tb = rmd + 10;
     tb = (tb * (pc1->surplus[O_TRADE] + trade2)) / 24;
   } else if (game.info.caravan_bonus_style == CBS_LOGARITHMIC) {
     // Logarithmic bonus

--- a/common/traderoutes.cpp
+++ b/common/traderoutes.cpp
@@ -205,12 +205,12 @@ bool can_cities_trade(const struct city *pc1, const struct city *pc2)
 {
   /* If you change the logic here, make sure to update the help in
    * helptext_unit(). */
-  return (
-      pc1 && pc2 && pc1 != pc2
-      && (city_owner(pc1) != city_owner(pc2)
-          || map_distance(pc1->tile, pc2->tile) >= game.info.trademindist)
-      && (trade_route_type_trade_pct(cities_trade_route_type(pc1, pc2))
-          > 0));
+  return (pc1 && pc2 && pc1 != pc2
+          && (city_owner(pc1) != city_owner(pc2)
+              || real_map_distance(pc1->tile, pc2->tile)
+                     >= game.info.trademindist)
+          && (trade_route_type_trade_pct(cities_trade_route_type(pc1, pc2))
+              > 0));
 }
 
 /**
@@ -463,7 +463,6 @@ int get_caravan_enter_city_trade_bonus(const struct city *pc1,
   }
 
   if (game.info.caravan_bonus_style == CBS_CLASSIC) {
-    // Should this be real_map_distance (rmd)?
     tb = rmd + 10;
     tb = (tb * (pc1->surplus[O_TRADE] + trade2)) / 24;
   } else if (game.info.caravan_bonus_style == CBS_LOGARITHMIC) {


### PR DESCRIPTION
The Manhattan distance is `|deltaX| + |deltaY|`, which only makes sense when you can't move in diagonal. Since caravans can use the diagonal, the "Euclidian" (shortest path) distance is better suited for trade routes.

This introduces an incompatibility by changing (lowering) trade revenue for rulesets currently using CLASSIC. Since trade routes are usually OP, I don't think this is a big deal.

Closes #882.