### PR TITLE
Use the correct build directory for tests on mac

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,7 +250,7 @@ jobs:
           buildPreset: 'fullrelease-macos'
       - name: Test
         run: |
-          cmake --build build --target test
+          cmake --build build* --target test
       - name: Split Branch Name
         env:
           BRANCH: ${{github.ref_name}}


### PR DESCRIPTION
Since I don't know the full name, I'm just assuming it starts with build.

This fixes running tests in the CI on macOS.