### PR TITLE
Add a weekly FreeBSD CI run

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -323,10 +323,13 @@ jobs:
             elfutils-libs
       - uses: actions/checkout@v3
       - name: Configure
+        # Set ALWAYS_ROOT because the container user is root and creating an
+        # unpriviledged user would be too much work.
         run: |
           cmake . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_INSTALL_PREFIX=/usr
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DALWAYS_ROOT=YES
       - name: Build
         run: |
           cmake --build build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -337,6 +337,56 @@ jobs:
         run: |
           DESTDIR=$PWD/build/install cmake --build build --target install
 
+  freebsd:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+    - uses: actions/checkout@v4
+    # This has to be executed in a single step because freebsd-vm fails if run
+    # twice.
+    - name: Build, test, and install on FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        # qmake is required by /usr/local/lib/cmake/Qt5Core/Qt5CoreConfig.cmake
+        run: |
+          set -e
+          pkg install -y \
+            git \
+            cmake \
+            ninja \
+            gettext \
+            qt5-buildtools \
+            qt5-qmake \
+            qt5-network \
+            qt5-svg \
+            qt5-testlib \
+            qt5-widgets \
+            kf5-karchive \
+            lua53 \
+            sqlite3 \
+            sdl2_mixer \
+            readline \
+            zlib-ng \
+            libunwind \
+            elfutils
+
+          # Create an unpriviledged user to run tests as, otherwise the server
+          # refuses to start (and rightfully so)
+          pw user add -n action -m
+
+          # Create a script with the commands to run
+          cat >build-and-test.sh <<EOF
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=/usr
+          cmake --build build
+          cmake --build build --target test
+          DESTDIR=$PWD/build/install cmake --build build --target install
+          EOF
+
+          chmod +x build-and-test.sh
+          su action -c 'sh build-and-test.sh'
+
   nix:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/server/civserver.cpp
+++ b/server/civserver.cpp
@@ -20,6 +20,8 @@
 #include <cstdlib>
 #ifdef FREECIV_MSWINDOWS
 #include <windows.h>
+#else
+#include <unistd.h> // SIGHUP, SIGPIPE
 #endif
 
 // Qt

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -27,8 +27,10 @@
 #include <windows.h>
 #ifdef HAVE_DIRECT_H
 #include <direct.h>
-#endif // HAVE_DIRECT_H
-#endif // FREECIV_MSWINDOWS
+#endif              // HAVE_DIRECT_H
+#else               // FREECIV_MSWINDOWS
+#include <unistd.h> // getuid, geteuid
+#endif              // FREECIV_MSWINDOWS
 
 // Qt
 #include <QCoreApplication>


### PR DESCRIPTION
This PR fixes build errors on FreeBSD and adds a weekly CI run to ensure it doesn't break in the future. While debugging FreeBSD, I understood the cause of the test errors on Fedora and also included a fix/workaround for that (FreeBSD got a different solution).

I did a full CI run [in my local](https://github.com/lmoureaux/freeciv21/actions/runs/7361897765) (before squashing debug commits into a nice history, but the code was identical)