### PR TITLE
Remove unused feature macros

### DIFF
--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -42,7 +42,6 @@ if(FREECIV_ENABLE_NLS)
       "Please see https://github.com/longturn/freeciv21/issues/383")
   endif()
 
-  set(FREECIV_HAVE_LIBINTL_H TRUE)
   set(ENABLE_NLS TRUE)
   if(UNIX)
     set(LOCALEDIR "${CMAKE_INSTALL_FULL_LOCALEDIR}")

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -11,10 +11,7 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-// ANSI
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 // utility
 #include "capability.h"

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -1178,8 +1178,7 @@ static bool read_init_script_real(struct connection *caller,
     real_filename = tilde_filename;
   }
 
-  log_testmatic_alt(LOG_NORMAL, _("Loading script file '%s'."),
-                    qUtf8Printable(real_filename));
+  qInfo(_("Loading script file '%s'."), qUtf8Printable(real_filename));
 
   if (QFile::exists(real_filename)
       && (script_file = fc_fopen(qUtf8Printable(real_filename), "r"))) {

--- a/utility/cmake_fc_config.h.in
+++ b/utility/cmake_fc_config.h.in
@@ -39,67 +39,6 @@
 /* bzlib.h available */
 #cmakedefine HAVE_BZLIB_H
 
-/* dlfcn.h available */
-#cmakedefine HAVE_DLFCN_H
-
-/* execinfo.h available */
-#cmakedefine HAVE_EXECINFO_H
-
-/* libcharset.h available */
-#cmakedefine HAVE_LIBCHARSET_H
-
-/* memory.h available */
-#cmakedefine HAVE_MEMORY_H
-
-
-/* strings.h available */
-#cmakedefine HAVE_STRINGS_H
-
-/* string.h available */
-#cmakedefine HAVE_STRING_H
-
-/* sys/file.h available */
-#cmakedefine HAVE_SYS_FILE_H
-
-/* sys/signal.h available */
-#cmakedefine HAVE_SYS_SIGNAL_H
-
-/* sys/stat.h available */
-#cmakedefine HAVE_SYS_STAT_H
-
-/* sys/termio.h available */
-#cmakedefine HAVE_SYS_TERMIO_H
-
-/* sys/utsname.h available */
-#cmakedefine HAVE_SYS_UTSNAME_H
-
-/* sys/wait.h available */
-#cmakedefine HAVE_SYS_WAIT_H
-
-/* termios.h available */
-#cmakedefine HAVE_TERMIOS_H
-
-/* libintl.h available */
-#cmakedefine HAVE_LIBINTL_H
-
-/* backtrace() available */
-#cmakedefine HAVE_BACKTRACE
-
-/* strcasecoll() available */
-#cmakedefine HAVE_STRCASECOLL
-
-/* strcasestr() available */
-#cmakedefine HAVE_STRCASESTR
-
-/* stricoll() available */
-#cmakedefine HAVE_STRICOLL
-
-/* _setjmp() available */
-#cmakedefine HAVE__SETJMP
-
-/* _strcoll() available */
-#cmakedefine HAVE__STRCOLL
-
 /* _stricoll() available */
 #cmakedefine HAVE__STRICOLL
 
@@ -108,8 +47,6 @@
 
 /* Custom path to CA cert bundle */
 #cmakedefine CUSTOM_CACERT_PATH
-
-/***** Previously freeciv_config.h *****/
 
 /* bzip2 compression is available in KArchive */
 #cmakedefine FREECIV_HAVE_BZ2
@@ -123,26 +60,11 @@
 /* Max number of AI modules */
 #cmakedefine FREECIV_AI_MOD_LAST ${FREECIV_AI_MOD_LAST}
 
-/* C11 static assert supported */
-#cmakedefine FREECIV_C11_STATIC_ASSERT
-
-/* qstrlen() in static assert supported */
-#cmakedefine FREECIV_STATIC_STRLEN
-
-/* C++11 static assert supported */
-#cmakedefine FREECIV_CXX11_STATIC_ASSERT
-
-/* Testmatic integration enabled */
-#cmakedefine FREECIV_TESTMATIC
-
 /* Metaserver URL */
 #cmakedefine FREECIV_META_URL "${FREECIV_META_URL}"
 
 /* Native language support enabled */
 #cmakedefine FREECIV_ENABLE_NLS
-
-/* libintl.h available */
-#cmakedefine FREECIV_HAVE_LIBINTL_H
 
 /* Windows build */
 #cmakedefine FREECIV_MSWINDOWS 1

--- a/utility/fcintl.h
+++ b/utility/fcintl.h
@@ -23,7 +23,6 @@
 /* Include libintl.h only if nls enabled.
  * It defines some wrapper macros that
  * we don't want defined when nls is disabled. */
-#ifdef FREECIV_HAVE_LIBINTL_H
 #include <libintl.h>
 
 // MSYS libintl redefines asprintf/vasprintf as macros, and this clashes with
@@ -34,8 +33,6 @@
 
 #ifdef vasprintf
 #undef vasprintf
-#endif
-
 #endif
 
 // Core freeciv

--- a/utility/log.h
+++ b/utility/log.h
@@ -64,14 +64,6 @@ const QString &log_get_level();
   }
 #endif
 
-#ifdef FREECIV_TESTMATIC
-#define log_testmatic(message, ...) qCritical(message, ##__VA_ARGS__)
-#else
-#define log_testmatic(message, ...) ((void) 0)
-#endif
-
-#define log_testmatic_alt(lvl, ...) log_testmatic(__VA_ARGS__)
-
 // Used by game debug command
 #define log_test qInfo
 #define log_packet qDebug


### PR DESCRIPTION
I went through the process of evaluating all [feature macros](https://github.com/longturn/freeciv21/wiki/Feature-macros) once again. The large number removed macros shows how much refactoring work has been happening since the last time we looked at this in 2020.

Closes #2103.