### PR TITLE
Add a few missing includes in headers

### DIFF
--- a/ai/default/ailog.h
+++ b/ai/default/ailog.h
@@ -12,6 +12,9 @@
 // utility
 #include "support.h"
 
+// common
+#include "tech.h"
+
 // Qt
 #include <QLoggingCategory>
 

--- a/ai/default/aiplayer.h
+++ b/ai/default/aiplayer.h
@@ -14,6 +14,7 @@
 
 // common
 #include "player.h"
+#include "unit.h"
 
 struct player;
 struct ai_plr;

--- a/ai/default/daieffects.h
+++ b/ai/default/daieffects.h
@@ -9,6 +9,8 @@
 **************************************************************************/
 #pragma once
 
+#include "fc_types.h"
+
 adv_want dai_effect_value(struct player *pplayer, struct government *gov,
                           const struct adv_data *adv,
                           const struct city *pcity, const bool capital,

--- a/common/clientutils.h
+++ b/common/clientutils.h
@@ -10,6 +10,8 @@
 **************************************************************************/
 #pragma once
 
+#include <QString>
+
 struct extra_type;
 struct tile;
 struct unit;


### PR DESCRIPTION
As spotted by `clazy` and `clang-tidy`. This covers `ai` and `common/c*`.
No associated issue.