### PR TITLE
LAN announcements using DNS-SD

### DIFF
--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -121,6 +121,19 @@ set(FREECIV_HAVE_BZ2 ${KArchive_HAVE_BZIP2})
 set(FREECIV_HAVE_LZMA ${KArchive_HAVE_LZMA})
 set(FREECIV_HAVE_ZSTD ${KArchive_HAVE_ZSTD})
 
+# Local server discovery
+if (NOT EMSCRIPTEN)
+  find_package(KF5DNSSD)
+  set(ENABLE_DNSSD ${KF5DNSSD_FOUND})
+  if (KF5DNSSD_FOUND)
+    message(STATUS "Building with DNS-SD support enabled")
+  else()
+    message(STATUS "KDNSSD not found - DNS-SD support disabled")
+  endif()
+else()
+  message(STATUS "DNS-SD not supported on Emscripten")
+endif()
+
 find_package(ZLIB REQUIRED) # Network protocol code
 
 # Some systems don't have a well-defined root user

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -90,6 +90,12 @@ target_include_directories(server PUBLIC ${CMAKE_SOURCE_DIR}/ai/classic)
 target_link_libraries(server PUBLIC Qt5::Core Qt5::Network server_gen)
 target_link_libraries(server PRIVATE Readline::readline)
 
+if (ENABLE_DNSSD)
+  set_source_files_properties(
+      sernet.cpp PROPERTIES COMPILE_DEFINITIONS ENABLE_DNSSD)
+  target_link_libraries(server PRIVATE KF5::DNSSD)
+endif()
+
 add_subdirectory(advisors)
 add_subdirectory(generator)
 add_subdirectory(savegame)


### PR DESCRIPTION
Use Kde's DNS-SD library to provide functionality equivalent to the UDP-based LAN announcement. This implements server-side support only. Client-side support will be added later. The CI and documentation are not implemented either.

Given all the missing pieces, I consider this patch proof-of-concept quality. To test it, spawn a server and run `avahi-discover` on any machine in the local network. I would still like feedback on whether it's working or not (with the equivalent of `libkf5dnssd-dev` installed).

vcpkg doesn't have a `kf5dnssd` package yet, so we'd need to add it.