### PR TITLE
Fix bugs affecting blabber of *BSD

### DIFF
--- a/client/audio/audio.cpp
+++ b/client/audio/audio.cpp
@@ -609,6 +609,11 @@ void audio_set_volume(double volume)
  */
 void audio_shutdown()
 {
+  // Already shut down
+  if (selected_plugin < 0) {
+    return;
+  }
+
   // avoid infinite loop at end of game
   audio_stop();
 
@@ -624,6 +629,9 @@ void audio_shutdown()
     secfile_destroy(ms_tagfile);
     ms_tagfile = nullptr;
   }
+
+  // Mark shutdown
+  selected_plugin = -1;
 }
 
 /**

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -658,6 +658,8 @@ void client_exit()
     options_save(log_option_save_msg);
   }
 
+  audio_shutdown();
+
   overview_free();
   tileset_free(tileset);
 

--- a/client/listener.h
+++ b/client/listener.h
@@ -140,7 +140,7 @@ template <class _type_> void listener<_type_>::listen()
 {
   // If you get an error here, your listener likely doesn't inherit from the
   // listener<> correctly. See the class documentation.
-  instances.insert(static_cast<type_t *>(this));
+  instances.insert(dynamic_cast<type_t *>(this));
 }
 
 /***************************************************************************
@@ -148,7 +148,7 @@ template <class _type_> void listener<_type_>::listen()
 ***************************************************************************/
 template <class _type_> listener<_type_>::~listener()
 {
-  instances.erase(static_cast<type_t *>(this));
+  instances.erase(dynamic_cast<type_t *>(this));
 }
 
 /***************************************************************************

--- a/server/advisors/advdata.cpp
+++ b/server/advisors/advdata.cpp
@@ -680,7 +680,7 @@ struct adv_data *adv_data_get(struct player *pplayer, bool *caller_closes)
 }
 
 /**
-   Allocate memory for advisor data. Save to call multiple times.
+   Allocate memory for advisor data. Safe to call multiple times.
  */
 void adv_data_init(struct player *pplayer)
 {
@@ -691,7 +691,7 @@ void adv_data_init(struct player *pplayer)
   }
   adv = pplayer->server.adv;
 
-  adv->government_want = nullptr;
+  adv->government_want.clear();
 
   adv->dipl.adv_dipl_slots = new adv_dipl *[MAX_NUM_PLAYER_SLOTS]();
   player_slots_iterate(pslot)
@@ -724,9 +724,7 @@ void adv_data_default(struct player *pplayer)
   fc_assert_ret(adv != nullptr);
 
   adv->govt_reeval = 0;
-  if (!adv->government_want) {
-    adv->government_want = new adv_want[government_count() + 1]();
-  }
+  adv->government_want.resize(government_count());
 
   adv->wonder_city = 0;
 
@@ -746,8 +744,7 @@ void adv_data_close(struct player *pplayer)
 
   adv_data_phase_done(pplayer);
 
-  delete[] adv->government_want;
-  adv->government_want = nullptr;
+  adv->government_want.clear();
   if (adv->dipl.adv_dipl_slots != nullptr) {
     players_iterate(aplayer)
     {

--- a/server/advisors/advdata.h
+++ b/server/advisors/advdata.h
@@ -111,7 +111,7 @@ struct adv_data {
   int infra_priority;
 
   // Government data
-  adv_want *government_want;
+  std::vector<adv_want> government_want;
   short govt_reeval;
 
   // Goals

--- a/tools/fcmp/mpdb.cpp
+++ b/tools/fcmp/mpdb.cpp
@@ -164,8 +164,8 @@ void create_mpdb(const char *filename, bool scenario_db)
 
   if (ret == SQLITE_OK) {
     ret = mpdb_query(*handle,
-                     "create table modpacks (name VARCHAR(60) NOT nullptr, "
-                     "type VARCHAR(32), version VARCHAR(32) NOT nullptr);");
+                     "create table modpacks (name VARCHAR(60) NOT null, "
+                     "type VARCHAR(32), version VARCHAR(32) NOT null);");
   }
 
   if (ret == SQLITE_OK) {


### PR DESCRIPTION
All bugs could have been spotted by running with ASan more often:

1. The wrong type of cast was used in the `listener` destructor. ASan warned about it.
2. `NULL` had been changed to `nullptr` in SQL code. #2128 
3. A use-after-free condition was present when shutting down audio. #2132 
4. Advisor data wasn't resized properly when switching tileset.

All commits are backport candidates.