### PR TITLE
Fix passing the clang-tidy output to Codacy

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -59,7 +59,9 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          run-clang-tidy -p build | ansifilter | ./codacy-clang-tidy >report.json
+          run-clang-tidy -header-filter=".*" -p build \
+            | ansifilter \
+            | ./codacy-clang-tidy >report.json
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -53,12 +53,13 @@ jobs:
 
       - name: Install Codacy Tools
         run: |
-          wget -O codacy-clang-tidy https://github.com/codacy/codacy-clang-tidy/releases/download/1.3.3/codacy-clang-tidy-linux-1.3.3
+          sudo apt install ansifilter
+          wget -O codacy-clang-tidy https://github.com/codacy/codacy-clang-tidy/releases/download/1.3.8/codacy-clang-tidy-linux-1.3.8
           chmod +x codacy-clang-tidy
 
       - name: Run clang-tidy
         run: |
-          run-clang-tidy -p build | ./codacy-clang-tidy >report.json
+          run-clang-tidy -p build | ansifilter | ./codacy-clang-tidy >report.json
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Also upgrade codacy-clang-tidy to 1.3.8.

I was growing a bit worried not to see anything from Codacy. Turns out it's been broken ever since we moved to Ubuntu 22.04 because Codacy can't parse the colored output produced by clang 14 (which is the default). Use `ansifilter` to remove it.
I expect this PR to generate dozens of new warnings.