### PR TITLE
Fix and modernize listener<>

### DIFF
--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -47,7 +47,6 @@
 
 static bool is_plain_public_message(const QString &s);
 
-FC_CPP_DECLARE_LISTENER(chat_listener)
 QStringList chat_listener::history = QStringList();
 
 namespace {

--- a/client/chatline.h
+++ b/client/chatline.h
@@ -27,12 +27,10 @@ class QPaintEvent;
 class QPainter;
 class QPushButton;
 class QUrl;
-class chat_listener;
 
 void set_chat_colors(const QHash<QString, QString> &colors);
 QString apply_tags(QString str, const struct text_tag_list *tags,
                    QColor bg_color);
-template <> std::set<chat_listener *> listener<chat_listener>::instances;
 /***************************************************************************
   Listener for chat. See listener<> for information about how to use it
 ***************************************************************************/

--- a/client/listener.h
+++ b/client/listener.h
@@ -27,13 +27,6 @@
   };
   ~~~~~
 
-  The listener needs some static data. Declaring it is as simple as putting
-  a macro in some source file:
-
-  ~~~~~{.cpp}
-  FC_CPP_DECLARE_LISTENER(foo_listener)
-  ~~~~~
-
   Then, you call the listeners from the implementation of the C interface:
 
   ~~~~~{.cpp}
@@ -104,7 +97,7 @@ public:
 
 private:
   // All instances of type_t that have called listen().
-  static std::set<listener<type_t> *> instances;
+  inline static std::set<listener<type_t> *> instances{};
 
 protected:
   explicit listener();
@@ -116,14 +109,6 @@ public:
   template <class _member_fct_, class... _args_>
   static void invoke(_member_fct_ function, _args_ &&...args);
 };
-
-/***************************************************************************
-  Macro to declare the static data needed by listener<> classes
-***************************************************************************/
-#define FC_CPP_DECLARE_LISTENER(_type_)                                     \
-  template <>                                                               \
-  std::set<listener<_type_> *> listener<_type_>::instances =                \
-      std::set<listener<_type_> *>();
 
 /***************************************************************************
   Constructor

--- a/client/map_updates_handler.cpp
+++ b/client/map_updates_handler.cpp
@@ -9,8 +9,6 @@
 #include "options.h"
 #include "tileset/tilespec.h"
 
-FC_CPP_DECLARE_LISTENER(freeciv::map_updates_handler)
-
 namespace freeciv {
 
 /**


### PR DESCRIPTION
Commit d1f50af71316b3ab817f0438aecd0a639a93af63 broke the listener<> template in a subtle way: the destructor wouldn't remove listeners from the set because dynamic_cast to a derived type returns nullptr in a destructor. This caused a segfault upon saving map images.

In order to solve both the warning that lead to the commit and the new bug, change the set of instances to hold listener<A>* instead of A*, and use dynamic_cast in invoke since the A objects are still valid there.

While I was there, I changed invoke() to be a variadic template. It wasn't one because the code originally had to support C++03.