### PR TITLE
Fix image saving for nonexistent pictures location

### DIFF
--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -2795,11 +2795,11 @@ void mr_menu::save_image()
 
           auto path = QStandardPaths::writableLocation(
               QStandardPaths::PicturesLocation);
-          if (path.isEmpty()) {
+          if (path.isEmpty() || !QDir(path).exists()) {
             path = QStandardPaths::writableLocation(
                 QStandardPaths::HomeLocation);
           }
-          if (path.isEmpty()) {
+          if (path.isEmpty() || !QDir(path).exists()) {
             path = freeciv_storage_dir();
           }
           img_name =


### PR DESCRIPTION
Saving a map to image fails, if the storage location described by QStandardPaths::PicturesLocation does not exist. Use the fallbacks already defined in the code, if the image would be saved in a nonexistent location.

Alternative solutions:

1. Make the location configurable in "Interface Options -> Map Image"
2. Open a "Save as..." dialog every time a map is saved
3. Create the location, if it does not exist (I'd prefer if no directories are created without my knowledge)  

In my experience the home directory is a sane fallback, especially as the full path to the image is displayed after saving. But this might be considered a workaround until a better solution ist implemented. Failing to save the image without showing the user a reason is definitely annoying and unexpected.  