### PR TITLE
Rewrite drawing of citizen sprites to use multiple rows

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1455,7 +1455,7 @@ void city_dialog::update_buy_button()
    Fill a pixmap with citizen sprites
  */
 void city_dialog::fill_citizens_pixmap(QPixmap *pixmap, QPainter *painter,
-                                       citizen_category *categories,
+                                       const citizen_category *categories,
                                        int num_citizens)
 {
   int sprite_width = tileset_small_sprite_width(tileset);
@@ -1525,32 +1525,14 @@ void city_dialog::update_citizens()
 
     lab_table[i]->setPixmap(*citizen_pixmap);
     lab_table[i]->updateGeometry();
-
-    switch (i) {
-    case FEELING_BASE:
-      lab_table[i]->setToolTip(text_happiness_cities(pcity));
-      break;
-
-    case FEELING_LUXURY:
-      lab_table[i]->setToolTip(text_happiness_luxuries(pcity));
-      break;
-
-    case FEELING_EFFECT:
-      lab_table[i]->setToolTip(text_happiness_buildings(pcity));
-      break;
-
-    case FEELING_NATIONALITY:
-      lab_table[i]->setToolTip(text_happiness_nationality(pcity));
-      break;
-
-    case FEELING_MARTIAL:
-      lab_table[i]->setToolTip(text_happiness_units(pcity));
-      break;
-
-    default:
-      break;
-    }
   }
+
+  lab_table[FEELING_BASE]->setToolTip(text_happiness_cities(pcity));
+  lab_table[FEELING_LUXURY]->setToolTip(text_happiness_luxuries(pcity));
+  lab_table[FEELING_EFFECT]->setToolTip(text_happiness_buildings(pcity));
+  lab_table[FEELING_NATIONALITY]->setToolTip(
+      text_happiness_nationality(pcity));
+  lab_table[FEELING_MARTIAL]->setToolTip(text_happiness_units(pcity));
 }
 
 /**

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -9,6 +9,7 @@
 **************************************************************************/
 #pragma once
 
+#include "city.h"
 #include "fc_types.h"
 
 // Qt
@@ -25,6 +26,8 @@
 #include <qobjectdefs.h>
 // gui-qt
 #include "dialogs.h"
+
+#define CITIZENS_PER_ROW 20
 
 class QAction;
 class QCheckBox;
@@ -251,9 +254,12 @@ public:
 private:
   struct city *pcity{nullptr};
   int type;
+  QSize get_pixmap_size() const;
 
 protected:
   void mousePressEvent(QMouseEvent *event) override;
+  QSize minimumSizeHint() const override;
+  QSize sizeHint() const override;
 };
 
 class city_info : public QWidget {
@@ -298,6 +304,8 @@ private:
   void update_building();
   void update_info_label();
   void update_buy_button();
+  void fill_citizens_pixmap(QPixmap *pixmap, QPainter *painter,
+                            citizen_category *categories, int num_citizens);
   void update_citizens();
   void update_improvements();
   void update_units();

--- a/client/citydlg.h
+++ b/client/citydlg.h
@@ -305,7 +305,8 @@ private:
   void update_info_label();
   void update_buy_button();
   void fill_citizens_pixmap(QPixmap *pixmap, QPainter *painter,
-                            citizen_category *categories, int num_citizens);
+                            const citizen_category *categories,
+                            int num_citizens);
   void update_citizens();
   void update_improvements();
   void update_units();

--- a/client/citydlg.ui
+++ b/client/citydlg.ui
@@ -64,11 +64,11 @@
         </item>
         <item>
          <widget class="city_label" name="citizens_label">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="text">
            <string>citizens</string>
@@ -407,6 +407,12 @@
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
       <property name="spacing">
        <number>0</number>
@@ -430,6 +436,12 @@
         </property>
         <property name="documentMode">
          <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <widget class="QWidget" name="tab_2">
          <attribute name="title">
@@ -596,6 +608,12 @@
                 <bool>true</bool>
                </property>
                <widget class="QWidget" name="scrollAreaWidgetContents">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="geometry">
                  <rect>
                   <x>0</x>
@@ -617,6 +635,12 @@
                  </item>
                  <item row="0" column="1">
                   <widget class="city_label" name="lab_table1">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>TextLabel</string>
                    </property>
@@ -634,6 +658,12 @@
                  </item>
                  <item row="1" column="1">
                   <widget class="city_label" name="lab_table2">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>TextLabel</string>
                    </property>
@@ -651,6 +681,12 @@
                  </item>
                  <item row="2" column="1">
                   <widget class="city_label" name="lab_table3">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>lab_table3</string>
                    </property>
@@ -668,6 +704,12 @@
                  </item>
                  <item row="3" column="1">
                   <widget class="city_label" name="lab_table4">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>TextLabel</string>
                    </property>
@@ -685,6 +727,12 @@
                  </item>
                  <item row="4" column="1">
                   <widget class="city_label" name="lab_table5">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>TextLabel</string>
                    </property>
@@ -702,6 +750,12 @@
                  </item>
                  <item row="5" column="1">
                   <widget class="city_label" name="lab_table6">
+                   <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                    <property name="text">
                     <string>TextLabel</string>
                    </property>


### PR DESCRIPTION
Several things in this PR:
- Citizens are now drawn in multiple rows, where amount per row is controlled via `CITIZENS_PER_ROW`
- Fixed specialist rotating code so the correct specialist is picked even for large cities
- Add size hinting to `city_label` and several other places to prevent them being squished by the unit list when a city has too many units in it

Given that I don't really know C++, this is on a best-effort basis, but hopefully it's at least a bit helpful.

Fixes #2041 
Could partially work for #1904 as well, since that's caused by too many citizens in the second tab