### PR TITLE
Refactor encodings

### DIFF
--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -323,14 +323,7 @@ int client_main(int argc, char *argv[])
     init_ai(ai);
   }
 
-  init_nls();
-#ifdef ENABLE_NLS
-  (void) bindtextdomain("freeciv21-nations", get_locale_dir());
-#endif
-  init_character_encodings();
-#ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-nations", "UTF-8");
-#endif
+  init_nls("freeciv21-nations");
 
   QCommandLineParser parser;
   parser.addHelpOption();

--- a/client/client_main.cpp
+++ b/client/client_main.cpp
@@ -327,9 +327,9 @@ int client_main(int argc, char *argv[])
 #ifdef ENABLE_NLS
   (void) bindtextdomain("freeciv21-nations", get_locale_dir());
 #endif
-  init_character_encodings(gui_character_encoding, gui_use_transliteration);
+  init_character_encodings();
 #ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-nations", get_internal_encoding());
+  bind_textdomain_codeset("freeciv21-nations", "UTF-8");
 #endif
 
   QCommandLineParser parser;

--- a/client/connectdlg_common.h
+++ b/client/connectdlg_common.h
@@ -19,7 +19,7 @@ void client_kill_server(bool force);
 bool is_server_running();
 bool can_client_access_hack();
 
-void send_client_wants_hack(const char *filename);
+void send_client_wants_hack(const QString &filename);
 void send_save_game(const char *filename);
 
 void set_ruleset(const char *ruleset);

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -43,8 +43,6 @@ void real_science_report_dialog_update(void *);
 
 extern void city_font_update();
 
-const bool gui_use_transliteration = false;
-const char *const gui_character_encoding = "UTF-8";
 const char *client_string = "gui-qt";
 static fc_client *freeciv_qt;
 

--- a/client/options.cpp
+++ b/client/options.cpp
@@ -3794,7 +3794,6 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
     fc_strlcpy(name_buffer, OPTION_FILE_NAME, sizeof(name_buffer));
 #else
     int major, minor;
-    struct stat buf;
 
     name = freeciv_storage_dir();
     if (name.isEmpty()) {
@@ -3813,7 +3812,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
         fc_snprintf(name_buffer, sizeof(name_buffer),
                     "%s/freeciv-client-rc-%d.%d", qUtf8Printable(name),
                     major, minor);
-        if (0 == fc_stat(name_buffer, &buf)) {
+        if (QFileInfo::exists(name_buffer)) {
           if (MAJOR_NEW_OPTION_FILE_NAME != major
               || MINOR_NEW_OPTION_FILE_NAME != minor) {
             qInfo(_("Didn't find '%s' option file, "
@@ -3837,7 +3836,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
       fc_snprintf(name_buffer, sizeof(name_buffer),
                   "%s/.freeciv-client-rc-%d.%d",
                   qUtf8Printable(QDir::homePath()), major, minor);
-      if (0 == fc_stat(name_buffer, &buf)) {
+      if (QFileInfo::exists(name_buffer)) {
         qInfo(_("Didn't find '%s' option file, "
                 "loading from '%s' instead."),
               get_current_option_file_name()
@@ -3854,7 +3853,7 @@ static const char *get_last_option_file_name(bool *allow_digital_boolean)
     // Try with the old one.
     fc_snprintf(name_buffer, sizeof(name_buffer), "%s/%s",
                 qUtf8Printable(name), OLD_OPTION_FILE_NAME);
-    if (0 == fc_stat(name_buffer, &buf)) {
+    if (QFileInfo::exists(name_buffer)) {
       qInfo(_("Didn't find '%s' option file, "
               "loading from '%s' instead."),
             get_current_option_file_name(), OLD_OPTION_FILE_NAME);

--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -1666,6 +1666,7 @@ static struct tileset *tileset_read_toplevel(const QString &tileset_name,
     qCCritical(tileset_category, "Tileset \"%s\" invalid: %s", t->name,
                secfile_error());
     tileset_stop_read(t, file, sections, layer_order);
+    return nullptr;
   }
 
   tstr = secfile_lookup_str(file, "tilespec.type");

--- a/server/scripting/script_server.cpp
+++ b/server/scripting/script_server.cpp
@@ -118,19 +118,18 @@ bool script_server_unsafe_do_string(struct connection *caller,
 bool script_server_load_file(const char *filename, char **buf)
 {
   FILE *ffile;
-  struct stat stats;
   char *buffer;
 
-  fc_stat(filename, &stats);
+  QFileInfo stats(filename);
   ffile = fc_fopen(filename, "r");
 
   if (ffile != nullptr) {
     int len;
 
-    buffer = new char[stats.st_size + 1];
-    len = fread(buffer, 1, stats.st_size, ffile);
+    buffer = new char[stats.size() + 1];
+    len = fread(buffer, 1, stats.size(), ffile);
 
-    if (len == stats.st_size) {
+    if (len == stats.size()) {
       buffer[len] = '\0';
 
       *buf = buffer;

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -204,9 +204,9 @@ void srv_init()
   has_been_srv_init = true;
 
   // init character encodings.
-  init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);
+  init_character_encodings();
 #ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-nations", get_internal_encoding());
+  bind_textdomain_codeset("freeciv21-nations", "UTF-8");
 #endif
 
   // Initialize callbacks.

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -22,7 +22,6 @@
 // utility
 #include "bitvector.h"
 #include "bugs.h"
-#include "fciconv.h"
 #include "fcintl.h"
 #include "log.h"
 #include "rand.h"
@@ -168,10 +167,7 @@ void srv_init()
   i_am_server(); // Tell to libfreeciv that we are server
 
   // NLS init
-  init_nls();
-#ifdef ENABLE_NLS
-  (void) bindtextdomain("freeciv21-nations", get_locale_dir());
-#endif
+  init_nls("freeciv21-nations");
 
   // We want this before any AI stuff
   timing_log_init();
@@ -202,12 +198,6 @@ void srv_init()
 
   // mark as initialized
   has_been_srv_init = true;
-
-  // init character encodings.
-  init_character_encodings();
-#ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-nations", "UTF-8");
-#endif
 
   // Initialize callbacks.
   game.callbacks.unit_deallocate = identity_number_release;

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -650,7 +650,7 @@ int main(int argc, char **argv)
   QCoreApplication::setApplicationVersion(freeciv21_version());
 
   init_nls();
-  init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);
+  init_character_encodings();
 
   QCommandLineParser parser;
   parser.addHelpOption();

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -650,7 +650,6 @@ int main(int argc, char **argv)
   QCoreApplication::setApplicationVersion(freeciv21_version());
 
   init_nls();
-  init_character_encodings();
 
   QCommandLineParser parser;
   parser.addHelpOption();

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -40,7 +40,6 @@ void load_install_info_lists(struct fcmp_params *fcmp)
 {
   char main_db_filename[500];
   char scenario_db_filename[500];
-  struct stat buf;
 
   fc_snprintf(main_db_filename, sizeof(main_db_filename),
               "%s/" DATASUBDIR "/" FCMP_CONTROLD "/mp.db",
@@ -56,14 +55,14 @@ void load_install_info_lists(struct fcmp_params *fcmp)
               "%s/scenarios/" FCMP_CONTROLD "/modpacks.db",
               qUtf8Printable(fcmp->inst_prefix));
 
-  if (fc_stat(main_db_filename, &buf)) {
+  if (QFileInfo::exists(main_db_filename)) {
     create_mpdb(main_db_filename, false);
     load_install_info_list(main_ii_filename);
   } else {
     open_mpdb(main_db_filename, false);
   }
 
-  if (fc_stat(scenario_db_filename, &buf)) {
+  if (QFileInfo::exists(scenario_db_filename)) {
     create_mpdb(scenario_db_filename, true);
     load_install_info_list(scenario_ii_filename);
   } else {

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -76,10 +76,9 @@ void load_install_info_lists(struct fcmp_params *fcmp)
 void fcmp_init()
 {
   init_nls();
-  init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);
-
+  init_character_encodings();
   fc_srand(time(nullptr)); /* Needed at least for Windows version of
-                           netfile_get_section_file() */
+                              netfile_get_section_file() */
 }
 
 /**

--- a/tools/fcmp/modinst.cpp
+++ b/tools/fcmp/modinst.cpp
@@ -16,7 +16,6 @@
 #include <sys/stat.h>
 
 // utility
-#include "fciconv.h"
 #include "fcintl.h"
 #include "log.h"
 #include "rand.h"
@@ -76,7 +75,6 @@ void load_install_info_lists(struct fcmp_params *fcmp)
 void fcmp_init()
 {
   init_nls();
-  init_character_encodings();
   fc_srand(time(nullptr)); /* Needed at least for Windows version of
                               netfile_get_section_file() */
 }

--- a/tools/ruledit/ruledit.cpp
+++ b/tools/ruledit/ruledit.cpp
@@ -69,16 +69,7 @@ int main(int argc, char **argv)
 
   log_init();
 
-  init_nls();
-
-#ifdef ENABLE_NLS
-  (void) bindtextdomain("freeciv21-ruledit", get_locale_dir());
-#endif
-
-  init_character_encodings();
-#ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-ruledit", "UTF-8");
-#endif
+  init_nls("freeciv21-ruledit");
 
   // Initialize command line arguments.
   re_parse_cmdline(app);

--- a/tools/ruledit/ruledit.cpp
+++ b/tools/ruledit/ruledit.cpp
@@ -75,9 +75,9 @@ int main(int argc, char **argv)
   (void) bindtextdomain("freeciv21-ruledit", get_locale_dir());
 #endif
 
-  init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);
+  init_character_encodings();
 #ifdef ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-ruledit", get_internal_encoding());
+  bind_textdomain_codeset("freeciv21-ruledit", "UTF-8");
 #endif
 
   // Initialize command line arguments.

--- a/tools/ruleup.cpp
+++ b/tools/ruleup.cpp
@@ -109,7 +109,6 @@ int main(int argc, char **argv)
   log_init();
 
   init_nls();
-  init_character_encodings();
 
   rup_parse_cmdline(app);
 

--- a/tools/ruleup.cpp
+++ b/tools/ruleup.cpp
@@ -109,8 +109,7 @@ int main(int argc, char **argv)
   log_init();
 
   init_nls();
-
-  init_character_encodings(FC_DEFAULT_DATA_ENCODING, false);
+  init_character_encodings();
 
   rup_parse_cmdline(app);
 

--- a/utility/fciconv.cpp
+++ b/utility/fciconv.cpp
@@ -23,19 +23,6 @@
 #include <QLocale>
 #include <QTextStream>
 
-/**
-   Must be called during the initialization phase of server and client to
-   initialize the character encodings to be used.
-
-   Pass an internal encoding of nullptr to use the local encoding internally.
- */
-void init_character_encodings()
-{
-#ifdef FREECIV_ENABLE_NLS
-  bind_textdomain_codeset("freeciv21-core", "UTF-8");
-#endif
-}
-
 char *data_to_internal_string_malloc(const char *text)
 {
   return qstrdup(text);

--- a/utility/fciconv.h
+++ b/utility/fciconv.h
@@ -13,20 +13,12 @@
 /*
   Technical details:
 
-  - There are three encodings used by freeciv: the data encoding, the
-    internal encoding, and the local encoding.  Each is a character set
-    (like utf-8 or latin1).  Each string in the code must be in one of these
-    three encodings; to cut down on bugs always document whenever you have
-    a string in anything other than the internal encoding and never make
-    global variables hold anything other than the internal encoding; the
-    local and data encodings should only be used locally within the code
-    and always documented as such.
-
-  - The data_encoding is used in all data files and network transactions.
-    This is always UTF-8.
-
-  - The internal_encoding is used internally within freeciv.  This is always
-    UTF-8.
+  - There are two encodings used by freeciv: the data encoding and the system
+    encoding.  The data encoding corresponds to all data files and the
+    network protocal. It is always UTF-8.  The system may use any encoding it
+    likes, and a conversion from UTF-8 may be needed, for instance when
+    printing to the terminal.  Thankfully, Qt abstracts much of this away for
+    us. Use QString whenever possible and avoid this header.
 
   - The local_encoding is the one supported on the command line, which is
     generally the value listed in the $LANG environment variable.  This is
@@ -54,13 +46,9 @@
   - Everything in the client is also in UTF-8.
 
   - Everything printed to the command line must be converted into the
-    "local encoding" which may be anything as defined by the system.  Using
-    fc_fprintf is generally the easiest way to print to the command line
-    in which case all strings passed to it should be in the internal
-    encoding.
+    "local encoding" which may be anything as defined by the system.  Qt's
+    logging functions (qInfo and similar) do this for us.
 */
-
-void init_character_encodings();
 
 [[deprecated]] char *data_to_internal_string_malloc(const char *text);
 [[deprecated]] char *internal_to_data_string_malloc(const char *text);

--- a/utility/fciconv.h
+++ b/utility/fciconv.h
@@ -60,20 +60,15 @@
     encoding.
 */
 
-#define FC_DEFAULT_DATA_ENCODING "UTF-8"
+void init_character_encodings();
 
-void init_character_encodings(const char *internal_encoding,
-                              bool use_transliteration);
+[[deprecated]] char *data_to_internal_string_malloc(const char *text);
+[[deprecated]] char *internal_to_data_string_malloc(const char *text);
+[[deprecated]] char *internal_to_local_string_malloc(const char *text);
+[[deprecated]] char *local_to_internal_string_malloc(const char *text);
 
-const char *get_internal_encoding();
-
-char *data_to_internal_string_malloc(const char *text);
-char *internal_to_data_string_malloc(const char *text);
-char *internal_to_local_string_malloc(const char *text);
-char *local_to_internal_string_malloc(const char *text);
-
-char *local_to_internal_string_buffer(const char *text, char *buf,
-                                      size_t bufsz);
+[[deprecated]] char *
+local_to_internal_string_buffer(const char *text, char *buf, size_t bufsz);
 
 #define fc_printf(...) fc_fprintf(stdout, __VA_ARGS__)
 void fc_fprintf(FILE *stream, const char *format, ...)

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -861,13 +861,27 @@ static void autocap_update(void)
 
   capitalization_opt_in(ac_enabled);
 }
+
+namespace /* anonymous */ {
+/**
+ * Binds a text domain for use in freeciv21, and sets its encoding to UTF-8.
+ */
+static void bind_text_domain_and_encoding(const char *name)
+{
+  bindtextdomain("freeciv21-core", get_locale_dir());
+  bind_textdomain_codeset("freeciv21-core", "UTF-8");
+}
+} // anonymous namespace
 #endif // FREECIV_ENABLE_NLS
 
 /**
-   Setup for Native Language Support, if configured to use it.
-   (Call this only once, or it may leak memory.)
+ * Setup for Native Language Support, if configured to use it.
+ * (Call this only once, or it may leak memory.)
+ *
+ * The freeciv21-core text domain is always set up and bound. You can pass an
+ * additional domain to bind.
  */
-void init_nls()
+void init_nls(const char *extra_text_domain)
 {
   /*
    * Setup the cached locale numeric formatting information. Defaults
@@ -882,9 +896,15 @@ void init_nls()
   setup_langname(); // Makes sure LANG env variable has been set
 #endif              // FREECIV_MSWINDOWS
 
-  (void) setlocale(LC_ALL, "");
-  (void) bindtextdomain("freeciv21-core", get_locale_dir());
-  (void) textdomain("freeciv21-core");
+  setlocale(LC_ALL, "");
+
+  // Set up the core text domain.
+  bind_text_domain_and_encoding("freeciv21-core");
+  textdomain("freeciv21-core");
+
+  if (extra_text_domain) {
+    bind_text_domain_and_encoding(extra_text_domain);
+  }
 
   /* Don't touch the defaults when LC_NUMERIC == "C".
      This is intended to cater to the common case where:

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -642,7 +642,7 @@ QVector<QString> *fileinfolist(const QStringList &dirs, const char *suffix)
     dir.setNameFilters({QStringLiteral("*") + QString::fromUtf8(suffix)});
     for (auto name : dir.entryList()) {
       name.truncate(name.length() - qstrlen(suffix));
-      files->append(name.toUtf8().data());
+      files->append(name);
     }
   }
   std::sort(files->begin(), files->end());

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -141,7 +141,7 @@ QFileInfoList find_files_in_path(const QStringList &path,
                                  const QString &pattern, bool nodups);
 QString fileinfoname(const QStringList &dirs, const QString &filename);
 
-void init_nls();
+void init_nls(const char *extra_text_domain = nullptr);
 void free_nls();
 char *setup_langname();
 

--- a/utility/support.cpp
+++ b/utility/support.cpp
@@ -288,25 +288,6 @@ int fc_remove(const char *filename)
 }
 
 /**
-   Wrapper function for stat() with filename conversion to local
-   encoding on Windows.
- */
-int fc_stat(const char *filename, struct stat *buf)
-{
-#ifdef FREECIV_MSWINDOWS
-  int result;
-  char *filename_in_local_encoding =
-      internal_to_local_string_malloc(filename);
-
-  result = stat(filename_in_local_encoding, buf);
-  free(filename_in_local_encoding);
-  return result;
-#else  // FREECIV_MSWINDOWS
-  return stat(filename, buf);
-#endif // FREECIV_MSWINDOWS
-}
-
-/**
    Returns last error code.
  */
 fc_errno fc_get_errno()

--- a/utility/support.cpp
+++ b/utility/support.cpp
@@ -269,25 +269,6 @@ FILE *fc_fopen(const char *filename, const char *opentype)
 }
 
 /**
-   Wrapper function for remove() with filename conversion to local
-   encoding on Windows.
- */
-int fc_remove(const char *filename)
-{
-#ifdef FREECIV_MSWINDOWS
-  int result;
-  char *filename_in_local_encoding =
-      internal_to_local_string_malloc(filename);
-
-  result = remove(filename_in_local_encoding);
-  free(filename_in_local_encoding);
-  return result;
-#else  // FREECIV_MSWINDOWS
-  return remove(filename);
-#endif // FREECIV_MSWINDOWS
-}
-
-/**
    Returns last error code.
  */
 fc_errno fc_get_errno()

--- a/utility/support.h
+++ b/utility/support.h
@@ -123,7 +123,6 @@ int fc_strcoll(const char *str0, const char *str1);
 int fc_stricoll(const char *str0, const char *str1);
 
 FILE *fc_fopen(const char *filename, const char *opentype);
-int fc_remove(const char *filename);
 
 fc_errno fc_get_errno();
 const char *fc_strerror(fc_errno err);

--- a/utility/support.h
+++ b/utility/support.h
@@ -124,7 +124,6 @@ int fc_stricoll(const char *str0, const char *str1);
 
 FILE *fc_fopen(const char *filename, const char *opentype);
 int fc_remove(const char *filename);
-int fc_stat(const char *filename, struct stat *buf);
 
 fc_errno fc_get_errno();
 const char *fc_strerror(fc_errno err);


### PR DESCRIPTION
This PR tries to sanitize the handling of character encodings:
* Remove support for non-utf-8 internal and data encodings.
* Remove all calls to the C file API and replace them with native Qt APIs. This should prevent path encoding issues like #565.

### Checks

I checked the following under `wine` for files with accents in the name:

* Reading serv files (from the server prompt, with the `-r` option, and from the client)
* Finding tilespec file
* Handling UTF-8 ruleset files (Royale's Ħal Saflieni Hypogeum)

I couldn't check the following because the file names don't have accents in my setup:

* Removing the test file used for cmdlevel hack
* Finding and using the client settings file and modpack DB 