### PR TITLE
Fix fileinfoname for non-ASCII characters

### DIFF
--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -92,8 +92,6 @@ static QStringList scenario_dir_names = {};
 
 static char *mc_group = nullptr;
 
-Q_GLOBAL_STATIC(QString, realfile);
-
 /**
    An AND function for fc_tristate.
  */
@@ -657,48 +655,22 @@ QVector<QString> *fileinfolist(const QStringList &dirs, const char *suffix)
    Returns a filename to access the specified file from a
    directory by searching all specified directories for the file.
 
-   If the specified 'filename' is empty, the returned string contains
-   the effective path.  (But this should probably only be used for
-   debug output.)
-
    Returns an empty string if the specified filename cannot be found
    in any of the data directories.
  */
 QString fileinfoname(const QStringList &dirs, const QString &filename)
 {
-  if (dirs.isEmpty()) {
-    return QString();
-  }
-
-  if (filename.isEmpty()) {
-    bool first = true;
-
-    realfile->clear();
-    for (const auto &dirname : dirs) {
-      if (first) {
-        *realfile += QStringLiteral("/%1").arg(dirname);
-        first = false;
-      } else {
-        *realfile += QStringLiteral("%1").arg(dirname);
-      }
-    }
-
-    return *realfile;
-  }
-
   for (const auto &dirname : dirs) {
-    struct stat buf; // see if we can open the file or directory
-
-    *realfile = QStringLiteral("%1/%2").arg(dirname, filename);
-    if (fc_stat(qUtf8Printable(*realfile), &buf) == 0) {
-      return *realfile;
+    QString path = dirname + QLatin1String("/") + filename;
+    if (QFileInfo::exists(path)) {
+      return path;
     }
   }
 
   qDebug("Could not find readable file \"%s\" in data path.",
          qUtf8Printable(filename));
 
-  return nullptr;
+  return QString();
 }
 
 /**


### PR DESCRIPTION
There was an encoding issue in fileinfoname() that prevented finding files with special characters in the path when the system encoding wasn't UTF-8 (fc_stat would fail as if the file didn't exist because it always received the path in UTF-8). Rewrite the function using only charset-independent Qt APIs.

(I'll want to test the installer in Wine for a final cross-check once actions finish running)

Backport candidate.

Closes #565.