### PR TITLE
Fix release.yaml to properly run when needed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
   update-autorevision:
     name: "Update AutoRevision"
     runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,6 +45,7 @@ jobs:
   update-archive:
     name: "Update Source Archive"
     runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We got a spurious AutoRevision PR this morning because of missing event names in `release.yaml`. No related issue.