### PR TITLE
freeciv21-manual: Remove broken image links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Freeciv21 contributors are listed below in alphabetical order:
 
+- blabber (Tobias Rehbein)
 - DobbyK
 - ilkkachu (Ilkka Virta)
 - jwrober (James Robertson)

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -72,8 +72,6 @@ struct tag_types {
   const char *title_end;
   const char *sect_title_begin;
   const char *sect_title_end;
-  const char *image_begin;
-  const char *image_end;
   const char *item_begin;
   const char *item_end;
   const char *subitem_begin;
@@ -101,12 +99,6 @@ struct tag_types html_tags = {
 
     // section title end
     "</h3>",
-
-    // image begin
-    "<img src=\"",
-
-    // image end
-    ".png\">",
 
     // item begin
     "<div class='item' id='%s%d'>\n",
@@ -141,12 +133,6 @@ struct tag_types wiki_tags = {
 
     // section title end
     "===",
-
-    // image begin
-    "[[Image:",
-
-    // image end
-    ".png]]",
 
     // item begin
     "----\n<!-- %s %d -->\n",
@@ -332,8 +318,7 @@ static bool manual_command(struct tag_types *tag_info)
       fprintf(doc, _("%sFreeciv21 %s terrain help (%s)%s\n\n"),
               tag_info->title_begin, freeciv21_version(), game.control.name,
               tag_info->title_end);
-      fprintf(doc, "<table><tr bgcolor=#9bc3d1><th colspan=2>%s</th>",
-              _("Terrain"));
+      fprintf(doc, "<table><tr bgcolor=#9bc3d1><th>%s</th>", _("Terrain"));
       fprintf(doc, "<th>F/P/T</th><th>%s</th>", _("Resources"));
       fprintf(doc, "<th>%s<br/>%s</th>", _("Move cost"), _("Defense bonus"));
       fprintf(doc, "<th>%s<br/>%s<br/>%s<br/>%s<br/>%s<br/>%s<br/>(%s)</th>",
@@ -367,19 +352,15 @@ static bool manual_command(struct tag_types *tag_info)
           continue;
         }
 
-        fprintf(doc, "<tr><td>%s%s%s</td><td>%s</td>", tag_info->image_begin,
-                pterrain->graphic_str, tag_info->image_end,
-                terrain_name_translation(pterrain));
+        fprintf(doc, "<tr><td>%s</td>", terrain_name_translation(pterrain));
         fprintf(doc, "<td>%d/%d/%d</td>\n", pterrain->output[O_FOOD],
                 pterrain->output[O_SHIELD], pterrain->output[O_TRADE]);
 
         fprintf(doc, "<td><table width=\"100%%\">\n");
         for (r = pterrain->resources; *r; r++) {
           fprintf(doc,
-                  "<tr><td>%s%s%s</td><td>%s</td>"
-                  "<td align=\"right\">%d/%d/%d</td></tr>\n",
-                  tag_info->image_begin, (*r)->graphic_str,
-                  tag_info->image_end, extra_name_translation(*r),
+                  "<tr><td>%s</td><td align=\"right\">%d/%d/%d</td></tr>\n",
+                  extra_name_translation(*r),
                   (*r)->data.resource->output[O_FOOD],
                   (*r)->data.resource->output[O_SHIELD],
                   (*r)->data.resource->output[O_TRADE]);
@@ -477,7 +458,7 @@ static bool manual_command(struct tag_types *tag_info)
       }
 
       fprintf(doc,
-              "<table>\n<tr bgcolor=#9bc3d1><th colspan=2>%s</th>"
+              "<table>\n<tr bgcolor=#9bc3d1><th>%s</th>"
               "<th>%s<br/>%s</th><th>%s<br/>%s</th><th>%s</th></tr>\n\n",
               _("Name"), _("Cost"), _("Upkeep"), _("Requirement"),
               _("Obsolete by"), _("More info"));
@@ -496,11 +477,10 @@ static bool manual_command(struct tag_types *tag_info)
                           nullptr);
 
         fprintf(doc,
-                "<tr><td>%s%s%s</td><td>%s</td>\n"
+                "<tr><td>%s</td>\n"
                 "<td align=\"center\"><b>%d</b><br/>%d</td>\n<td>",
-                tag_info->image_begin, pimprove->graphic_str,
-                tag_info->image_end, improvement_name_translation(pimprove),
-                pimprove->build_cost, pimprove->upkeep);
+                improvement_name_translation(pimprove), pimprove->build_cost,
+                pimprove->upkeep);
 
         requirement_vector_iterate(&pimprove->reqs, req)
         {


### PR DESCRIPTION
Look mom, low hanging fruits!

This pull request removes images completely from the generated HTML as proposed by @jwrober in https://github.com/longturn/freeciv21/issues/1974#issuecomment-1641101883_

Closes #1974.