### PR TITLE
view_units: Fix find, disband and upgrade buttons

### DIFF
--- a/client/views/view_units.cpp
+++ b/client/views/view_units.cpp
@@ -392,12 +392,12 @@ void units_view::selection_changed(const QItemSelection &sl,
     qvar = itm->data(Qt::UserRole);
     uid = qvar.toInt();
     selected = cid_decode(uid);
-    counter = ui.units_widget->item(curr_row, 3)->text().toInt();
+    counter = ui.units_widget->item(curr_row, 4)->text().toInt();
     if (counter > 0) {
       ui.disband_but->setDisabled(false);
       ui.find_but->setDisabled(false);
     }
-    upg = ui.units_widget->item(curr_row, 1)->text();
+    upg = ui.units_widget->item(curr_row, 2)->text();
     if (upg != "-") {
       ui.upg_but->setDisabled(false);
     }


### PR DESCRIPTION
The checks whether the find, disband and upgrade buttons should be enabled reference the wrong columns in the table.

This commit fixes the column references.

Reported by Corbeau on Discord.

***Screenshots demonstrating the fix***


| Before  | After |
| ------ | ----- |
| ![find broken](https://github.com/longturn/freeciv21/assets/1199257/440c32e0-d9bf-402a-8d0a-a4758870ba94) | ![find fixed](https://github.com/longturn/freeciv21/assets/1199257/bfc6716a-5883-455b-99b7-01b5c3e44cbc) |
| ![none broken](https://github.com/longturn/freeciv21/assets/1199257/5d843339-c624-4283-a129-29e3d392dec0) | ![none fixed](https://github.com/longturn/freeciv21/assets/1199257/5ad3a4f8-3d83-4480-aace-1228358c589b) |
| ![upgrade broken](https://github.com/longturn/freeciv21/assets/1199257/4665196a-e7a8-40b1-9682-0fbe2fb1bc7b) | ![upgrade fixed](https://github.com/longturn/freeciv21/assets/1199257/d25fe559-0291-4025-8cbe-807591d9ea11) |

