### PR TITLE
Force Qt to use FreeType on Windows

### DIFF
--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -41,10 +41,11 @@ if(WIN32 OR MSYS OR MINGW)
   # Custom command files to run the applications
   install(
     FILES
-    ${CMAKE_SOURCE_DIR}/dist/freeciv21-server.cmd
     ${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-client.ico
     ${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-modpack.ico
     ${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-server.ico
+    ${CMAKE_SOURCE_DIR}/dist/windows/freeciv21-server.cmd
+    ${CMAKE_SOURCE_DIR}/dist/windows/qt.conf
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT freeciv21)
 endif()

--- a/dist/freeciv21-server.cmd
+++ b/dist/freeciv21-server.cmd
@@ -1,3 +1,0 @@
-@echo off
-if not "%1" == "auto" set LANG=%1
-start "%~n0" /D . "%~dp0\freeciv21-server.exe" %2 %3 %4 %5 %6 %7 %8 %9

--- a/dist/windows/freeciv21-server.cmd
+++ b/dist/windows/freeciv21-server.cmd
@@ -1,0 +1,3 @@
+@echo off
+if not "%1" == "auto" set LANG=%1
+start "%~n0" /D . "%~dp0\freeciv21-server.exe" %2 %3 %4 %5 %6 %7 %8 %9

--- a/dist/windows/qt.conf
+++ b/dist/windows/qt.conf
@@ -1,0 +1,5 @@
+[Platforms]
+# We force FreeType on Windows because rendering Libertinus with DirectWrite
+# looks terrible.
+# Dark mode controls window title bars. 1 means follow the system default.
+WindowsArguments = fontengine=freetype,darkmode=1


### PR DESCRIPTION
Rendering of the Libertinus fonts was terrible with the (default) DirectWrite backend on Windows. Install a `qt.conf` file forcing Qt to use FreeType.

While reviewing Qt options I also found a way to make the window title bars dark if the user chose a dark theme. I enabled this as well.

Finally I moved files used for the Windows installer to dist/windows in an effort to organize that folder.