### PR TITLE
cmake: Fix the option to disable man pages

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,10 @@
 # CMakeLists for Freeciv21 Docs
 
-find_package(Sphinx QUIET)
+if(FREECIV_ENABLE_MANPAGES)
+  find_package(Sphinx REQUIRED)
+else()
+  find_package(Sphinx QUIET)
+endif()
 
 if(SPHINX_FOUND)
   message(STATUS "Sphinx Found, configuring.")
@@ -14,18 +18,19 @@ if(SPHINX_FOUND)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 COMMENT "Generating documentation with Sphinx")
 
-  # We only create man pages on Unix
+  # We only create man pages on Unix or if the user explicitly requested it.
   if((UNIX AND NOT APPLE) OR FREECIV_ENABLE_MANPAGES)
     option(FREECIV_ENABLE_MANPAGES "Enable manpages" ON)
 
-    if(FREECIV_ENABLE_MANPAGES)
-      add_custom_target(man-pages ALL
-                  COMMAND
-                  ${SPHINX_EXECUTABLE} -b man ${SPHINX_SOURCE} ${SPHINX_MAN}
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                  COMMENT "Generating manual pages with Sphinx")
-    endif()
+    add_custom_target(man-pages ALL
+          COMMAND
+          ${SPHINX_EXECUTABLE} -b man ${SPHINX_SOURCE} ${SPHINX_MAN}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+          COMMENT "Generating manual pages with Sphinx")
   endif()
 else()
   message(STATUS "Sphinx NOT Found.")
 endif()
+
+# Default to OFF, if FREECIV_ENABLE_MANPAGES is not set yet.
+option(FREECIV_ENABLE_MANPAGES "Enable manpages" OFF)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -29,5 +29,3 @@ if(SPHINX_FOUND)
 else()
   message(STATUS "Sphinx NOT Found.")
 endif()
-
-option(FREECIV_ENABLE_MANPAGES "Enable manpages" OFF)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -4,7 +4,6 @@ find_package(Sphinx QUIET)
 
 if(SPHINX_FOUND)
   message(STATUS "Sphinx Found, configuring.")
-  option(FREECIV_ENABLE_MANPAGES "Enable manpages" ON)
   set(SPHINX_SOURCE ${CMAKE_SOURCE_DIR}/docs)
   set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR})
   set(SPHINX_MAN ${CMAKE_CURRENT_BINARY_DIR}/man)
@@ -16,14 +15,19 @@ if(SPHINX_FOUND)
                 COMMENT "Generating documentation with Sphinx")
 
   # We only create man pages on Unix
-  if(UNIX AND NOT APPLE)
-    add_custom_target(man-pages ALL
-                COMMAND
-                ${SPHINX_EXECUTABLE} -b man ${SPHINX_SOURCE} ${SPHINX_MAN}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                COMMENT "Generating manual pages with Sphinx")
+  if((UNIX AND NOT APPLE) OR FREECIV_ENABLE_MANPAGES)
+    option(FREECIV_ENABLE_MANPAGES "Enable manpages" ON)
+
+    if(FREECIV_ENABLE_MANPAGES)
+      add_custom_target(man-pages ALL
+                  COMMAND
+                  ${SPHINX_EXECUTABLE} -b man ${SPHINX_SOURCE} ${SPHINX_MAN}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMENT "Generating manual pages with Sphinx")
+    endif()
   endif()
 else()
   message(STATUS "Sphinx NOT Found.")
-  option(FREECIV_ENABLE_MANPAGES "Enable manpages" OFF)
 endif()
+
+option(FREECIV_ENABLE_MANPAGES "Enable manpages" OFF)


### PR DESCRIPTION
Fxes the handling of the `FREECIV_ENABLE_MANPAGES` option, leveraging the fact, that an `option` call is a no-op if the value is already set.

We also allow users on non-Unix systems to build manpages (for whatever reason one may want to do that).

Closes #2155

This needs a thorough review as I am non-fluent in cmake and don't have non-Unix systems available to test.