### PR TITLE
Give the main window a title

### DIFF
--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -73,6 +73,8 @@ fc_client::fc_client() : QMainWindow(), current_file(QLatin1String(""))
   QApplication::setFont(fcFont::instance()->getFont(fonts::default_font));
   QString path;
 
+  setWindowTitle(_("Freeciv21"));
+
   central_wdg = new QWidget;
   central_layout = new QStackedLayout;
 


### PR DESCRIPTION
The main window title had been `freeciv21-client` for a while. Now it's `Freeciv21`:
![image](https://github.com/longturn/freeciv21/assets/22327575/3ce87d35-459f-43a6-bcd9-fb21a393ff62)

Suggesting to backport.