### PR TITLE
Bring stable rtd config to master level

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Cherry-pick changes to `.readthedocs.yml` present in `master` but not in `stable`. This should fix the build error in #2166.