### PR TITLE
Cherry-pick GitHub workflow commits for stable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ name: Release
 on:
   release:
     types: [published]
+  schedule:
+    - cron: "0 5 * * MON"
+  workflow_dispatch: {}
+
 jobs:
   update-autorevision:
     name: "Update AutoRevision"
@@ -74,6 +78,7 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+    if: github.event_name == 'release' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
             mingw-w64-i686-readline
             mingw-w64-i686-lua
             mingw-w64-i686-SDL2_mixer
-            mingw-w64-i686-qt5
+            mingw-w64-i686-qt5-base
             mingw-w64-i686-qt5-svg
             mingw-w64-i686-karchive-qt5
       - name: Configure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,8 @@ on:
 jobs:
   update-autorevision:
     name: "Update AutoRevision"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,7 +40,8 @@ jobs:
           delete-branch: true
   update-archive:
     name: "Update Source Archive"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fix the CI on stable and allow running it on demand.
This doesn't add Fedora nor FreeBSD.