### PR TITLE
Remove "client" from the app name on Windows and in AppStream metadata

### DIFF
--- a/cmake/NSIS.template.in
+++ b/cmake/NSIS.template.in
@@ -199,7 +199,7 @@
   FunctionEnd
 
   Function RunFreeciv21
-    ExecShell "" "$SMPROGRAMS\${APPNAME}\${APPNAME} Client.lnk"
+    ExecShell "" "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk"
   FunctionEnd
 
   Function UninstallExisting
@@ -224,11 +224,11 @@
 
 
     ; Create Desktop Icon
-    CreateShortCut "$DESKTOP\${APPNAME} Client.lnk" "$INSTDIR\freeciv21-client.exe" "" "$INSTDIR\freeciv21-client.ico" 0
+    CreateShortCut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\freeciv21-client.exe" "" "$INSTDIR\freeciv21-client.ico" 0
 
     ; Create Start Menu Entries
     CreateDirectory "$SMPROGRAMS\${APPNAME}"
-    CreateShortCut "$SMPROGRAMS\${APPNAME}\${APPNAME} Client.lnk" "$INSTDIR\freeciv21-client.exe" "" "$INSTDIR\freeciv21-client.ico" 0
+    CreateShortCut "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk" "$INSTDIR\freeciv21-client.exe" "" "$INSTDIR\freeciv21-client.ico" 0
     CreateShortCut "$SMPROGRAMS\${APPNAME}\${APPNAME} Modpack Installer.lnk" "$INSTDIR\freeciv21-modpack-qt.exe" "" "$INSTDIR\freeciv21-modpack.ico" 0
     CreateShortCut "$SMPROGRAMS\${APPNAME}\${APPNAME} Server.lnk" "$INSTDIR\freeciv21-server.exe" "" "$INSTDIR\freeciv21-server.ico" 0
 

--- a/dist/net.longturn.freeciv21.metainfo.xml.in
+++ b/dist/net.longturn.freeciv21.metainfo.xml.in
@@ -3,8 +3,8 @@
     <id type="desktop">net.longturn.freeciv21</id>
     <metadata_license>CC0</metadata_license>
     <project_license>GPL-3.0+</project_license>
-    <name>Freeciv21 Client</name>
-    <summary>Freeciv21 Game Client</summary>
+    <name>Freeciv21</name>
+    <summary>Freeciv for the 21st Century</summary>
     <description>
       <!-- This description is in each of the metainfo files, README.md, about.rst, freeciv21-server.rst, and snapcraft.yaml -->
       <p>Freeciv21 is a free open source turn-based empire-building 4x strategy game, in which each player becomes the leader of a civilization. You compete against several opponents to build cities and use them to support a military and an economy. Players strive to complete an empire that survives all encounters with its neighbors to emerge victorious. Play begins at the dawn of history in 4,000 BCE.</p>


### PR DESCRIPTION
There is no need to use such a technical term in user-facing text. This also removes any need for translation.