### PR TITLE
Add redundant city names

### DIFF
--- a/client/repodlgs_common.cpp
+++ b/client/repodlgs_common.cpp
@@ -37,6 +37,9 @@ void get_economy_report_data(struct improvement_entry *entries,
   *num_entries_used = 0;
   *total_cost = 0;
   *total_income = 0;
+  QStringList redundant_cities;
+  redundant_cities.clear();
+  QString str;
 
   if (nullptr == client.conn.playing) {
     return;
@@ -53,6 +56,7 @@ void get_economy_report_data(struct improvement_entry *entries,
           cost += city_improvement_upkeep(pcity, pimprove);
           if (is_improvement_redundant(pcity, pimprove)) {
             redundant++;
+            redundant_cities.append(pcity->name);
           }
         }
       }
@@ -62,11 +66,19 @@ void get_economy_report_data(struct improvement_entry *entries,
         continue;
       }
 
+      if (redundant == 0) {
+        str = (_("None"));
+      } else {
+        // Convert the string list we built to a standard string for display.
+        str = redundant_cities.join(", ");
+      }
+
       entries[*num_entries_used].type = pimprove;
       entries[*num_entries_used].count = count;
       entries[*num_entries_used].redundant = redundant;
       entries[*num_entries_used].total_cost = cost;
       entries[*num_entries_used].cost = cost / count;
+      entries[*num_entries_used].city_names = str;
       (*num_entries_used)++;
 
       /* Currently there is no building expense under anarchy.  It's

--- a/client/repodlgs_common.h
+++ b/client/repodlgs_common.h
@@ -13,12 +13,15 @@
 
 #pragma once
 
+#include <QString>
+
 /*
  * Structure of data for the Economics View. See get_economy_report_data()
  */
 struct improvement_entry {
   struct impr_type *type;
   int count, redundant, cost, total_cost;
+  QString city_names;
 };
 
 /*

--- a/client/views/view_economics.cpp
+++ b/client/views/view_economics.cpp
@@ -35,7 +35,8 @@ eco_report::eco_report() : QWidget()
 
   QStringList slist;
   slist << _("Type") << Q_("?Building or Unit type:Name") << _("Redundant")
-        << _("Count") << _("Cost") << _("Total Upkeep");
+        << _("Count") << _("Cost") << _("Total Upkeep")
+        << _("Redundant Cities");
 
   ui.eco_widget->setColumnCount(slist.count());
   ui.eco_widget->setHorizontalHeaderLabels(slist);
@@ -92,7 +93,7 @@ void eco_report::update_report()
     cid id = cid_encode_building(pimprove);
 
     ui.eco_widget->insertRow(i);
-    for (j = 0; j < 6; j++) {
+    for (j = 0; j < 7; j++) {
       item = new QTableWidgetItem;
       switch (j) {
       case 0: {
@@ -124,6 +125,9 @@ void eco_report::update_report()
         item->setTextAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
         item->setData(Qt::DisplayRole, pentry->total_cost);
         break;
+      case 6:
+        item->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        item->setData(Qt::DisplayRole, pentry->city_names);
       }
       ui.eco_widget->setItem(i, j, item);
     }
@@ -136,7 +140,7 @@ void eco_report::update_report()
     cid id = cid_encode_unit(putype);
 
     ui.eco_widget->insertRow(i + max_row);
-    for (j = 0; j < 6; j++) {
+    for (j = 0; j < 7; j++) {
       item = new QTableWidgetItem;
       switch (j) {
       case 0: {
@@ -170,6 +174,9 @@ void eco_report::update_report()
         item->setTextAlignment(Qt::AlignVCenter | Qt::AlignHCenter);
         item->setData(Qt::DisplayRole, pentry->total_cost);
         break;
+      case 6:
+        item->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        item->setText(_("Not Applicable"));
       }
       ui.eco_widget->setItem(max_row + i, j, item);
     }


### PR DESCRIPTION
Part of #1238. List the names of cities where the redundant improvement resides. Does not offer a quick link at this time, but at least gives you the some more information. Units are never redundant, they are upgradeable, which is shown on the units view.