### PR TITLE
Update vcpkgGitCommitId before Alpha.5 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,7 +197,7 @@ jobs:
       - uses: lukka/run-vcpkg@v10
         name: Install dependencies
         with:
-          vcpkgGitCommitId: c8696863d371ab7f46e213d8f5ca923c4aef2a00
+          vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure
@@ -235,7 +235,7 @@ jobs:
       - uses: lukka/run-vcpkg@v10
         name: Install dependencies
         with:
-          vcpkgGitCommitId: c8696863d371ab7f46e213d8f5ca923c4aef2a00
+          vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db
       - name: Build
         uses: lukka/run-cmake@v10
         with:


### PR DESCRIPTION
Part of release process to update and keep us current.