### PR TITLE
Fix use-after-free in do_attack

### DIFF
--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -4134,8 +4134,7 @@ static bool do_attack(struct unit *punit, struct tile *def_tile,
     /* Now that dead defender is certainly no longer listed as unit
      * supported by the city, we may even remove the city
      * (if it shrinks from size 1) */
-    auto pcity = tile_city(def_tile);
-    if (pdefender->hp <= 0) {
+    if (auto pcity = tile_city(def_tile); pcity != nullptr) {
       unit_attack_civilian_casualties(punit, pcity, paction, "attack");
     }
     if (unit_is_alive(winner_id)) {


### PR DESCRIPTION
The patch cf7e1bd2bc0d457bd17b7c10438fd73387112614 had been applied improperly. Follow upstream code.

Closes #2183.

Backport candidate.