### PR TITLE
More flexible partisans

### DIFF
--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -79,6 +79,7 @@ struct Building_Type {
 
 struct Unit_Type {
   int build_cost;
+  int pop_cost;
 
   const int item_number @ id;
 };

--- a/data/civ1/units.ruleset
+++ b/data/civ1/units.ruleset
@@ -306,8 +306,8 @@ flags         = "Missile", "Unreachable", "DoesntOccupyTile"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/civ2/units.ruleset
+++ b/data/civ2/units.ruleset
@@ -323,8 +323,8 @@ flags         = "Unreachable", "DoesntOccupyTile"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/civ2civ3/units.ruleset
+++ b/data/civ2civ3/units.ruleset
@@ -434,8 +434,8 @@ flags         = "Unreachable", "DoesntOccupyTile", "CanPillage", "Airliftable"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/classic/units.ruleset
+++ b/data/classic/units.ruleset
@@ -410,8 +410,8 @@ flags         = "Unreachable", "DoesntOccupyTile"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/experimental/units.ruleset
+++ b/data/experimental/units.ruleset
@@ -422,8 +422,8 @@ flags         = "Unreachable", "DoesntOccupyTile"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/granularity/units.ruleset
+++ b/data/granularity/units.ruleset
@@ -340,8 +340,8 @@ flags         = "TerrainSpeed"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/multiplayer/units.ruleset
+++ b/data/multiplayer/units.ruleset
@@ -410,8 +410,8 @@ flags         = "Unreachable", "DoesntOccupyTile"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/royale/units.ruleset
+++ b/data/royale/units.ruleset
@@ -446,8 +446,8 @@ flags         = "Unreachable", "DoesntOccupyTile", "CanPillage", "Airliftable"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/sandbox/units.ruleset
+++ b/data/sandbox/units.ruleset
@@ -438,8 +438,8 @@ flags         = "Unreachable", "DoesntOccupyTile", "CanPillage", "MediumWeight"
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/data/stub/units.ruleset
+++ b/data/stub/units.ruleset
@@ -324,8 +324,8 @@ flags         = ""
 ; "Explorer"              = unit to use for exploring
 ; "Hut"                   = can be found in a hut
 ; "HutTech"               = can be found in a hut, but its techs required
-; "Partisan"              = can be created as a partisan (only one unit can have this
-;                           flag), see end of this file for its tech requirements option
+; "Partisan"              = can be created as a partisan if the
+;                           Inspire_Partisans effect is enabled
 ; "DefendOk"              = AI hint: ok for defending with
 ; "DefendGood"            = AI hint: good for defending with
 ; "Ferryboat"             = AI hint: useful for ferrying

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -809,6 +809,14 @@ Has_Senate
 
 Inspire_Partisans
     Partisan units (defined in :file:`units.ruleset`) may spring up when this player's cities are taken.
+    The number of partisans created is a function of the city size.
+    When multiple unit types have the Partisan flag, the game tries to choose one the player can build. If
+    the player cannot build any, the first Partisan unit type is used. If the created partisans units have a
+    non-zero ``pop_cost``, the city will lose citizens accordingly.
+
+    Note that this effect can create units that the player could normally not build (because the tech hasn't
+    been researched or the ``NoBuild`` flag is set. It is your responsibility to set the appropriate
+    requirements to avoid creating advanced units if a city is conquered in the early game.
 
 .. _effect-happiness-to-gold:
 

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -814,9 +814,10 @@ Inspire_Partisans
     the player cannot build any, the first Partisan unit type is used. If the created partisans units have a
     non-zero ``pop_cost``, the city will lose citizens accordingly.
 
-    Note that this effect can create units that the player could normally not build (because the tech hasn't
-    been researched or the ``NoBuild`` flag is set. It is your responsibility to set the appropriate
-    requirements to avoid creating advanced units if a city is conquered in the early game.
+    .. note::
+        This effect can create units that the player could normally not build (because the tech hasn't
+        been researched or the ``NoBuild`` flag is set). It is your responsibility to set the appropriate
+        requirements to avoid creating advanced units if a city is conquered in the early game.
 
 .. _effect-happiness-to-gold:
 

--- a/server/scripting/api_server_edit.cpp
+++ b/server/scripting/api_server_edit.cpp
@@ -9,6 +9,8 @@
  */
 
 // utility
+#include "city.h"
+#include "cityturn.h"
 #include "fcintl.h"
 #include "rand.h"
 
@@ -277,6 +279,20 @@ void api_edit_create_city(lua_State *L, Player *pplayer, Tile *ptile,
 
   // TODO: Allow initial citizen to be of nationality other than owner
   create_city(pplayer, ptile, name, pplayer);
+}
+
+/**
+ * Resizes a city.
+ */
+void api_edit_resize_city(lua_State *L, City *pcity, int size,
+                          const char *reason)
+{
+  LUASCRIPT_CHECK_STATE(L);
+  LUASCRIPT_CHECK_ARG_NIL(L, pcity, 2, City);
+
+  LUASCRIPT_CHECK(L, size > 0 && size < MAX_CITY_SIZE, "Invalid city size");
+
+  city_change_size(pcity, size, city_owner(pcity), reason);
 }
 
 /**

--- a/server/scripting/api_server_edit.h
+++ b/server/scripting/api_server_edit.h
@@ -42,6 +42,8 @@ bool api_edit_change_terrain(lua_State *L, Tile *ptile, Terrain *pterr);
 
 void api_edit_create_city(lua_State *L, Player *pplayer, Tile *ptile,
                           const char *name);
+void api_edit_resize_city(lua_State *L, City *pcity, int size,
+                          const char *reason);
 Player *api_edit_create_player(lua_State *L, const char *username,
                                Nation_Type *pnation, const char *ai);
 void api_edit_change_gold(lua_State *L, Player *pplayer, int amount);

--- a/server/scripting/tolua_server.pkg
+++ b/server/scripting/tolua_server.pkg
@@ -121,6 +121,8 @@ module edit {
   void api_edit_create_city
     @ create_city (lua_State *L, Player *pplayer, Tile *ptile,
                    const char *name);
+  void api_edit_resize_city
+    @ resize_city (lua_State *L, City *pcity, int size, const char *reason);
   void api_edit_create_owned_extra
     @ create_owned_extra (lua_State *L, Tile *ptile,
                           const char *name, Player *pplayer);

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -1176,7 +1176,15 @@ void place_partisans(struct tile *pcenter, struct player *powner, int count,
                      int sq_radius)
 {
   struct tile *ptile = nullptr;
-  struct unit_type *u_type = get_role_unit(L_PARTISAN, 0);
+  struct unit_type *u_type = best_role_unit_for_player(powner, L_PARTISAN);
+  if (!u_type) {
+    // If the player cannot build any partisan, pick the first one
+    u_type = get_role_unit(L_PARTISAN, 0);
+  }
+  if (!u_type) {
+    // Cannot do anything.
+    return;
+  }
 
   while (count-- > 0
          && find_a_good_partisan_spot(pcenter, powner, u_type, sq_radius,


### PR DESCRIPTION
This PR adds flexibility to partisans and changes the default behavior when they cost population:

* Multiple partisan unit types are now supported. The game will pick one the player can build, or the first one if the player can't build any
* When partisan units cost population, the population is taken away from the conquered city (rationale: it's an exodus)

## Testing

In the ruleset you're playing:

* Lower or remove requirements for the `Inspire_Partisans` effect
* Add the `Partisan` flag to some normal unit, e.g. Musketeers
* Change your favorite Partisan unit's `pop_cost`

Then conquer a city. You should see partisans of an appropriate unit type appear and the city size be reduced accordingly if they cost population. The city should never be wiped out.