### PR TITLE
fcmp: Fix bogus "query failed" message

### DIFF
--- a/tools/fcmp/download.cpp
+++ b/tools/fcmp/download.cpp
@@ -318,6 +318,7 @@ const char *download_modpack(const QUrl &url, const struct fcmp_params *fcmp,
           return msg;
         }
       }
+      delete[] inst_ver;
     }
   }
 

--- a/tools/fcmp/mpcli.cpp
+++ b/tools/fcmp/mpcli.cpp
@@ -73,6 +73,8 @@ static void setup_modpack_list(const QString &name, const QUrl &url,
   if (!notes.isEmpty()) {
     qInfo() << _("Comment=") << notes;
   }
+
+  delete[] tmp;
 }
 
 /**

--- a/tools/fcmp/mpdb.cpp
+++ b/tools/fcmp/mpdb.cpp
@@ -274,15 +274,18 @@ const char *mpdb_installed_version(const char *name, enum modpack_type type)
   }
 
   if (ret == SQLITE_ROW) {
-    version = qstrdup((const char*)sqlite3_column_text(stmt, 2));
+    version = qstrdup((const char *) sqlite3_column_text(stmt, 2));
   }
 
   if (ret != SQLITE_DONE && ret != SQLITE_ROW) {
-    qCritical("Query to get installed version for \"%s\" failed. (%d)", name, ret);
+    qCritical("Query to get installed version for \"%s\" failed. (%d)", name,
+              ret);
   }
 
   if (int errcode = sqlite3_finalize(stmt); errcode != SQLITE_OK) {
-    qCritical("Finalizing query to get installed version for \"%s\" failed. (%d)", name, ret);
+    qCritical(
+        "Finalizing query to get installed version for \"%s\" failed. (%d)",
+        name, ret);
   }
 
   return version;

--- a/tools/fcmp/mpdb.cpp
+++ b/tools/fcmp/mpdb.cpp
@@ -115,7 +115,7 @@ static int mpdb_query(sqlite3 *handle, const char *query)
     ret = sqlite3_finalize(stmt);
   }
 
-  if (ret != SQLITE_OK) {
+  if (ret != SQLITE_OK && ret != SQLITE_ROW) {
     qCritical("Query \"%s\" failed. (%d)", query, ret);
   }
 

--- a/tools/fcmp/mpdb.cpp
+++ b/tools/fcmp/mpdb.cpp
@@ -116,7 +116,8 @@ static int mpdb_query(sqlite3 *handle, const char *query)
   }
 
   if (int errcode = sqlite3_finalize(stmt); errcode != SQLITE_OK) {
-    qCritical("Finalizing query \"%s\" returned error. (%d)", query, ret);
+    qCritical("Finalizing query \"%s\" returned error. (%d)", query,
+              errcode);
   }
 
   return ret;
@@ -285,7 +286,7 @@ const char *mpdb_installed_version(const char *name, enum modpack_type type)
   if (int errcode = sqlite3_finalize(stmt); errcode != SQLITE_OK) {
     qCritical(
         "Finalizing query to get installed version for \"%s\" failed. (%d)",
-        name, ret);
+        name, errcode);
   }
 
   return version;

--- a/tools/fcmp/mpgui_qt.cpp
+++ b/tools/fcmp/mpgui_qt.cpp
@@ -307,7 +307,6 @@ void mpgui::refresh_list_versions()
   for (int i = 0; i < mpcount; i++) {
     QString name_str;
     int type_int;
-    const char *new_inst;
     enum modpack_type type;
     QByteArray name_bytes;
 
@@ -315,13 +314,12 @@ void mpgui::refresh_list_versions()
     type_int = mplist_table->item(i, ML_TYPE)->text().toInt();
     type = (enum modpack_type) type_int;
     name_bytes = name_str.toUtf8();
-    new_inst = mpdb_installed_version(name_bytes.data(), type);
 
-    if (new_inst == nullptr) {
-      new_inst = _("Not installed");
-    }
+    auto tmp = mpdb_installed_version(qUtf8Printable(name_bytes), type);
+    QString new_inst = tmp ? tmp : _("Not installed");
+    delete[] tmp;
 
-    mplist_table->item(i, ML_COL_INST)->setText(QString::fromUtf8(new_inst));
+    mplist_table->item(i, ML_COL_INST)->setText(new_inst);
   }
 
   mplist_table->resizeColumnsToContents();
@@ -352,6 +350,7 @@ void mpgui::setup_list(const QString &name, const QUrl &url,
 
   const char *tmp = mpdb_installed_version(qUtf8Printable(name), type);
   QString inst_str = tmp ? tmp : _("Not installed");
+  delete[] tmp;
 
   QString type_nbr;
   QTableWidgetItem *item;


### PR DESCRIPTION
When the modpack installer updates an already installed modpack, it emits a bogus critical message that a query failed with error code 100.

Error code 100 is `SQLITE_ROW` and is not really an error, but signals that a data row has been successfully read. `SQLITE_ROW` is also an expected return value in `mpdb_update_modpack`.

Change the check for failed queries to ignore `SQLITE_ROW`.