### PR TITLE
Unset client.conn.playing on disconnect

### DIFF
--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -55,7 +55,8 @@
 static void close_socket_nomessage(struct connection *pc)
 {
   connection_common_close(pc);
-  remove_net_input();
+  pc->playing = nullptr;
+
   popdown_races_dialog();
 
   set_client_state(C_S_DISCONNECTED);

--- a/client/gui_main.cpp
+++ b/client/gui_main.cpp
@@ -147,13 +147,6 @@ void sound_bell()
 void add_net_input(QIODevice *sock) { king()->add_server_source(sock); }
 
 /**
-   Stop waiting for any server network data.  See add_net_input().
-
-   This function is called if the client disconnects from the server.
- */
-void remove_net_input() {}
-
-/**
    Set one of the unit icons (specified by idx) in the information area
    based on punit.
 

--- a/client/qtg_cxxside.h
+++ b/client/qtg_cxxside.h
@@ -20,7 +20,6 @@ class QTcpSocket;
 void options_extra_init();
 void set_rulesets(int num_rulesets, QStringList rulesets);
 void add_net_input(QIODevice *sock);
-void remove_net_input();
 void real_conn_list_dialog_update(void *unused);
 void sound_bell();
 


### PR DESCRIPTION
Since it's used everywhere in the client code to determine the current player, keeping it set to a dangling value triggers various assertions.

Closes #2195.
Backport candidate