### PR TITLE
Fix the macOS CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,7 +235,7 @@ jobs:
           brew link gettext --force
       - uses: actions/setup-python@v5  # Workaround for #2069
         with:
-        python-version: '3.11'
+          python-version: '3.11'
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,6 +235,9 @@ jobs:
           # Contains the proper fix for #2069
           # See https://github.com/microsoft/vcpkg/pull/28084
           vcpkgGitCommitId: cf4ebef2294e164875ce17d7937f44d3e3ea156e
+      - on: failure()
+        name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Build
         uses: lukka/run-cmake@v10
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,15 +233,16 @@ jobs:
             ninja \
             pkg-config
           brew link gettext --force
+      - uses: actions/setup-python@v5  # Workaround for #2069
+        with:
+        python-version: '3.11'
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies
         with:
-          # Contains the proper fix for #2069
-          # See https://github.com/microsoft/vcpkg/pull/28084
-          vcpkgGitCommitId: cf4ebef2294e164875ce17d7937f44d3e3ea156e
-      - if: failure()
-        name: Setup tmate session
+          vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db
+      - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
+        # if: failure()
       - name: Build
         uses: lukka/run-cmake@v10
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,12 +225,13 @@ jobs:
           brew update
           # Remove the bloat installed by default to avoid conflicts
           brew remove --force $(brew list)
-          # Overwrite GitHub's Python symlinks
+          # Make sure to overwrite existing symlinks
           brew install --overwrite \
             cmake \
-            ninja \
+            create-dmg \
             gettext \
-            create-dmg
+            ninja \
+            pkg-config
           brew link gettext --force
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -213,7 +213,7 @@ jobs:
   os_x:
     name: "macOS"
     runs-on: macos-latest
-    needs: clang-format
+    # needs: clang-format
     env:
       VCPKG_BUILD_TYPE: release
     steps:
@@ -223,7 +223,8 @@ jobs:
       - name: Install build tools
         run: |
           brew update
-          brew install \
+          # Overwrite GitHub's Python symlinks
+          brew install --overwrite \
             cmake \
             ninja \
             gettext \
@@ -558,6 +559,7 @@ jobs:
 
   clang-format:
     name: clang-format Code Formatter
+    needs: os_x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -222,8 +222,10 @@ jobs:
           fetch-depth: 0
       - name: Install build tools
         run: |
+          brew update
+          # Remove the bloat installed by default to avoid conflicts
+          brew remove --force $(brew list)
           # Overwrite GitHub's Python symlinks
-          brew update --overwrite
           brew install --overwrite \
             cmake \
             ninja \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,13 +229,12 @@ jobs:
             gettext \
             create-dmg
           brew link gettext --force
-      - uses: actions/setup-python@v5  # Workaround for #2069
-        with:
-          python-version: '3.11'
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies
         with:
-          vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db
+          # Contains the proper fix for #2069
+          # See https://github.com/microsoft/vcpkg/pull/28084
+          vcpkgGitCommitId: cf4ebef2294e164875ce17d7937f44d3e3ea156e
       - name: Build
         uses: lukka/run-cmake@v10
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -213,7 +213,7 @@ jobs:
   os_x:
     name: "macOS"
     runs-on: macos-latest
-    # needs: clang-format
+    needs: clang-format
     env:
       VCPKG_BUILD_TYPE: release
     steps:
@@ -240,9 +240,6 @@ jobs:
         name: Install dependencies
         with:
           vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        # if: failure()
       - name: Build
         uses: lukka/run-cmake@v10
         with:
@@ -563,7 +560,6 @@ jobs:
 
   clang-format:
     name: clang-format Code Formatter
-    needs: os_x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -222,8 +222,8 @@ jobs:
           fetch-depth: 0
       - name: Install build tools
         run: |
-          brew update
           # Overwrite GitHub's Python symlinks
+          brew update --overwrite
           brew install --overwrite \
             cmake \
             ninja \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,7 +235,7 @@ jobs:
           # Contains the proper fix for #2069
           # See https://github.com/microsoft/vcpkg/pull/28084
           vcpkgGitCommitId: cf4ebef2294e164875ce17d7937f44d3e3ea156e
-      - on: failure()
+      - if: failure()
         name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
       - name: Build


### PR DESCRIPTION
The macOS CI stopped working, seemingly because multiple Python versions are installed simultaneously. We forced the Python version in response to #2069. There is now a proper fix for #2069 in upstream vcpkg. Update the vcpkg version so we can use it.