### PR TITLE
Fix borders for large tilesets

### DIFF
--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -5533,7 +5533,7 @@ void tileset_player_init(struct tileset *t, struct player *pplayer)
   if (player_has_color(t, pplayer)) {
     c = get_player_color(t, pplayer);
   }
-  QPixmap color(128, 64);
+  QPixmap color(t->normal_tile_width, t->normal_tile_height);
   color.fill(c);
 
   for (i = 0; i < EDGE_COUNT; i++) {


### PR DESCRIPTION
Border sprites were not colored properly for tilesets with very large sprites, like Vectron. Take the tileset sprite size into account.

Vectron after:
![image](https://github.com/longturn/freeciv21/assets/22327575/cd24b81c-0f06-4be8-815c-2b595a63eb7b)

Backport recommended