### PR TITLE
Allow tilesets to specify a default zoom level

### DIFF
--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -326,6 +326,7 @@ struct tileset {
   int full_tile_width, full_tile_height;
   int unit_tile_width, unit_tile_height;
   int small_sprite_width, small_sprite_height;
+  double preferred_scale;
 
   int max_upkeep_height;
 
@@ -637,6 +638,14 @@ int tileset_num_city_colors(const struct tileset *t)
 bool tileset_use_hard_coded_fog(const struct tileset *t)
 {
   return FOG_AUTO == t->fogstyle;
+}
+
+/**
+ * Returns the preferred scale (zoom level) of the tileset.
+ */
+double tileset_preferred_scale(const struct tileset *t)
+{
+  return t->preferred_scale;
 }
 
 /**
@@ -1852,6 +1861,10 @@ static struct tileset *tileset_read_toplevel(const QString &tileset_name,
     tileset_stop_read(t, file, fname, sections, layer_order);
     return nullptr;
   }
+
+  t->preferred_scale = secfile_lookup_int_def_min_max(
+                           file, 100, 1, 1000, "tilespec.preferred_scale")
+                       / 100.;
 
   t->select_step_ms = secfile_lookup_int_def_min_max(
       file, 100, 1, 10000, "tilespec.select_step_ms");

--- a/client/tileset/tilespec.h
+++ b/client/tileset/tilespec.h
@@ -329,6 +329,7 @@ int tileset_citybar_offset_y(const struct tileset *t);
 int tileset_tilelabel_offset_y(const struct tileset *t);
 int tileset_num_city_colors(const struct tileset *t);
 bool tileset_use_hard_coded_fog(const struct tileset *t);
+double tileset_preferred_scale(const struct tileset *t);
 
 int tileset_num_cardinal_dirs(const struct tileset *t);
 int tileset_num_index_cardinals(const struct tileset *t);

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -243,7 +243,7 @@ void map_view::zoom_in() { set_scale(1.2 * scale()); }
 /**
  * Resets the zoom level.
  */
-void map_view::zoom_reset() { set_scale(1); }
+void map_view::zoom_reset() { set_scale(tileset_preferred_scale(tileset)); }
 
 /**
  * Zooms out by 20%.
@@ -258,13 +258,17 @@ double map_view::scale() const { return m_renderer->scale(); }
 /**
  * Sets the map scale.
  */
-void map_view::set_scale(double scale)
+void map_view::set_scale(double scale, bool animate)
 {
   m_scale_animation->stop();
-  m_scale_animation->setDuration(gui_options->smooth_center_slide_msec);
   m_scale_animation->setEndValue(scale);
-  m_scale_animation->setCurrentTime(0);
-  m_scale_animation->start();
+  if (animate) {
+    m_scale_animation->setDuration(gui_options->smooth_center_slide_msec);
+    m_scale_animation->setCurrentTime(0);
+    m_scale_animation->start();
+  } else {
+    set_scale_now(scale);
+  }
 }
 
 /**
@@ -629,10 +633,10 @@ void tileset_changed(void)
   // Refresh the tileset debugger if it exists
   if (auto debugger = queen()->mapview_wdg->debugger();
       debugger != nullptr) {
-    // When not zoomed in, unscaled_tileset is null
-    // When zoomed in, unscaled_tileset is not null and holds the log
     debugger->refresh(tileset);
   }
+
+  queen()->mapview_wdg->set_scale(tileset_preferred_scale(tileset), false);
 
   update_unit_info_label(get_units_in_focus());
   popdown_city_dialog();

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -76,7 +76,7 @@ public slots:
   void zoom_in();
   void zoom_reset();
   void zoom_out();
-  void set_scale(double scale);
+  void set_scale(double scale, bool animate = true);
 
   void show_debugger();
   void hide_debugger();

--- a/data/amplio2.tilespec
+++ b/data/amplio2.tilespec
@@ -18,6 +18,9 @@ summary = _("Large isometric tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 96
 normal_tile_height = 48

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -18,6 +18,9 @@ summary = _("Small hex tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 40
 normal_tile_height = 72

--- a/data/hexemplio.tilespec
+++ b/data/hexemplio.tilespec
@@ -20,6 +20,9 @@ summary = _("Large iso-hex tileset, similar to Amplio.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 126
 normal_tile_height = 64

--- a/data/isophex.tilespec
+++ b/data/isophex.tilespec
@@ -18,6 +18,9 @@ summary = _("Small iso-hex tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 64
 normal_tile_height = 32

--- a/data/isotrident.tilespec
+++ b/data/isotrident.tilespec
@@ -18,6 +18,9 @@ summary = _("Isometric tileset based on Trident tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 64
 normal_tile_height = 32

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -17,6 +17,9 @@ summary = _("Small overhead tileset.")
 ; TODO: add more overall information fields on tiles,
 ; eg, authors, colors, etc.
 
+; The preferred scaling factor (zoom level), in percents
+preferred_scale = 100
+
 ; Basic tile sizes:
 normal_tile_width  = 30
 normal_tile_height = 30

--- a/docs/Modding/Tilesets/graphics.rst
+++ b/docs/Modding/Tilesets/graphics.rst
@@ -105,6 +105,7 @@ the :code:`[tilespec]` section. Currently options include:
 
 * :code:`priority` : When user does not specify tileset, the game automatically loads available compatible
   tileset with highest priority.
+* :code:`preferred_scale` : The preferred scaling factor (zoom level), in percents.
 * :code:`normal_tile_width` : The width of terrain tiles.
 * :code:`normal_tile_height` : The height of terrain tiles.
 * :code:`unit_width` : Unit sprite width. Default is always ok, setting is provided just for symmetry with


### PR DESCRIPTION
This is used to render the tileset by default and when the user resets the zoom. Useful to emulate HiDpi.

Vectron will use this.