### PR TITLE
Fix issues introduced with the prevention of war declarations if they would break alliances

### DIFF
--- a/server/diplhand.h
+++ b/server/diplhand.h
@@ -24,6 +24,7 @@ struct connection;
 
 // FIXME: Should this be put in a ruleset somewhere?
 const int TURNS_LEFT = 16;
+const int TURNS_EXTEND_CEASEFIRE = 1;
 
 #define treaty_list_iterate(list, p)                                        \
   TYPED_LIST_ITERATE(struct Treaty, list, p)

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -746,22 +746,22 @@ void handle_diplomacy_cancel_pact(struct player *pplayer,
                                   int other_player_id,
                                   enum clause_type clause)
 {
-  handle_diplomacy_cancel_pact2(pplayer, other_player_id, clause,
-                                is_human(pplayer));
+  handle_diplomacy_cancel_pact_explicit(pplayer, other_player_id, clause,
+                                        is_human(pplayer));
 }
 
 /**
    A variant of handle_diplomacy_cancel_pact that allows the caller to
-   control if war declarations should be prevented to protect existing
-   alliances.
+   explicitely control if war declarations should be prevented to
+   protect existing alliances.
 
    protect_alliances is a flag, that, if set to true, will prevent war
      declarations if they would break existing alliances.
  */
-void handle_diplomacy_cancel_pact2(struct player *pplayer,
-                                   int other_player_id,
-                                   enum clause_type clause,
-                                   bool protect_alliances)
+void handle_diplomacy_cancel_pact_explicit(struct player *pplayer,
+                                           int other_player_id,
+                                           enum clause_type clause,
+                                           bool protect_alliances)
 {
   enum diplstate_type old_type;
   enum diplstate_type new_type;
@@ -954,8 +954,8 @@ void handle_diplomacy_cancel_pact2(struct player *pplayer,
                       player_name(pplayer), player_name(pplayer2));
         player_diplstate_get(other, pplayer)->has_reason_to_cancel = 1;
         player_update_last_war_action(other);
-        handle_diplomacy_cancel_pact2(other, player_number(pplayer),
-                                      CLAUSE_ALLIANCE, false);
+        handle_diplomacy_cancel_pact_explicit(other, player_number(pplayer),
+                                              CLAUSE_ALLIANCE, false);
       } else {
         /* We are in the same team as the agressor; we cannot break
          * alliance with him. We trust our team mate and break alliance
@@ -966,8 +966,8 @@ void handle_diplomacy_cancel_pact2(struct player *pplayer,
                       player_name(pplayer),
                       nation_plural_for_player(pplayer2),
                       player_name(pplayer2));
-        handle_diplomacy_cancel_pact2(other, player_number(pplayer2),
-                                      CLAUSE_ALLIANCE, false);
+        handle_diplomacy_cancel_pact_explicit(other, player_number(pplayer2),
+                                              CLAUSE_ALLIANCE, false);
       }
     }
   }

--- a/server/plrhand.cpp
+++ b/server/plrhand.cpp
@@ -933,7 +933,9 @@ static void handle_diplomacy_cancel_pact_internal(struct player *pplayer,
                 nation_plural_for_player(pplayer),
                 diplstate_type_translated_name(new_type));
 
-  // Check fall-out of a war declaration.
+  // Check fall-out of a war declaration. This is only relevant if an AI
+  // declares war or if we cut through the web of alliances after an AI
+  // has declared war.
   players_iterate_alive(other)
   {
     if (other != pplayer && other != pplayer2 && new_type == DS_WAR

--- a/server/plrhand.h
+++ b/server/plrhand.h
@@ -148,6 +148,11 @@ void send_delegation_info(const struct connection *pconn);
 
 struct player *player_by_user_delegated(const char *name);
 
+void handle_diplomacy_cancel_pact2(struct player *pplayer,
+                                   int other_player_id,
+                                   enum clause_type clause,
+                                   bool protect_alliances);
+
 // player colors
 void playercolor_init();
 void playercolor_free();

--- a/server/plrhand.h
+++ b/server/plrhand.h
@@ -148,10 +148,10 @@ void send_delegation_info(const struct connection *pconn);
 
 struct player *player_by_user_delegated(const char *name);
 
-void handle_diplomacy_cancel_pact2(struct player *pplayer,
-                                   int other_player_id,
-                                   enum clause_type clause,
-                                   bool protect_alliances);
+void handle_diplomacy_cancel_pact_explicit(struct player *pplayer,
+                                           int other_player_id,
+                                           enum clause_type clause,
+                                           bool protect_alliances);
 
 // player colors
 void playercolor_init();

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -914,7 +914,7 @@ static void update_diplomatics()
 
               if (extend_ceasefire) {
                 // Extend cease-fire by four turns
-                state->turns_left = 4;
+                state->turns_left = TURNS_EXTEND_CEASEFIRE;
                 break;
               }
             }

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -997,8 +997,8 @@ static void update_diplomatics()
                 if (cancel1) {
                   // Cancel the alliance.
                   to1->has_reason_to_cancel = 1;
-                  handle_diplomacy_cancel_pact2(plr3, player_number(plr1),
-                                                CLAUSE_ALLIANCE, false);
+                  handle_diplomacy_cancel_pact_explicit(
+                      plr3, player_number(plr1), CLAUSE_ALLIANCE, false);
 
                   // Avoid asymmetric turns_left for the armistice.
                   to1->auto_cancel_turn = game.info.turn;
@@ -1012,8 +1012,8 @@ static void update_diplomatics()
                 if (cancel2) {
                   // Cancel the alliance.
                   to2->has_reason_to_cancel = 1;
-                  handle_diplomacy_cancel_pact2(plr3, player_number(plr2),
-                                                CLAUSE_ALLIANCE, false);
+                  handle_diplomacy_cancel_pact_explicit(
+                      plr3, player_number(plr2), CLAUSE_ALLIANCE, false);
 
                   // Avoid asymmetric turns_left for the armistice.
                   to2->auto_cancel_turn = game.info.turn;

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -883,10 +883,15 @@ static void update_diplomatics()
              * both players to war. */
             break;
           case 0:
-            // Automatically extend cease-fires, if both parties share common
-            // allies. We only handle this if both parties are human, as AI
-            // doesn't know how to cancel alliances to enter war if desired
-            // and might get caught in an eternal cease-fire.
+            /* Automatically extend cease-fires, if both parties share
+             * common allies. We only handle this if both parties are
+             * human, as AI doesn't know how to cancel alliances to
+             * enter war if desired and might get caught in an eternal
+             * cease-fire.
+             *
+             * If we extend the cease-fire, this will done for each
+             * partie seperately, to avoid inconsistent remaining
+             * turns. */
             if (is_human(plr1) && is_human(plr2)) {
               bool extend_ceasefire = false;
 
@@ -901,12 +906,6 @@ static void update_diplomatics()
                         "your common ally %s convinces you to extend it for "
                         "another four turns."),
                       player_name(plr2), player_name(plr3));
-                  notify_player(
-                      plr2, nullptr, E_DIPLOMACY, ftc_server,
-                      _("The cease-fire with %s would have run out, but "
-                        "your common ally %s convinces you to extend it for "
-                        "another four turns."),
-                      player_name(plr1), player_name(plr3));
 
                   extend_ceasefire = true;
                 }
@@ -915,10 +914,8 @@ static void update_diplomatics()
 
               if (extend_ceasefire) {
                 // Extend cease-fire by four turns
-                state->turns_left += 4;
-                state2->turns_left += 4;
-
-                return;
+                state->turns_left = 4;
+                break;
               }
             }
 

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -903,8 +903,7 @@ static void update_diplomatics()
                   notify_player(
                       plr1, nullptr, E_DIPLOMACY, ftc_server,
                       _("The cease-fire with %s would have run out, but "
-                        "your common ally %s convinces you to extend it for "
-                        "another four turns."),
+                        "your common ally %s convinces you to extend it."),
                       player_name(plr2), player_name(plr3));
 
                   extend_ceasefire = true;


### PR DESCRIPTION
Commit ecd275d7a487c8859446fe53d0b94745930a95db introduced a change that prevents players from declaring war, if this would break existing alliances. There are two remaining issues:

* AI will  fail to declare war, if entangled in a web of alliances
* Cease-fires running out, will end in an "undefined" state if war can't be entered because of alliances

To fix this:
- [x] restore the old behavior for the AI
- [x] automatically extend cease-fires while the fragile diplomatic state is balanced by alliances 

Part of #2177