### PR TITLE
Warn about non-transport FerryBoat units

### DIFF
--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -65,6 +65,7 @@
 #include "script_server.h"
 
 #include "ruleset.h"
+#include "unittype.h"
 
 // RULESET_SUFFIX already used, no leading dot here
 #define RULES_SUFFIX "ruleset"
@@ -2302,6 +2303,15 @@ static bool load_ruleset_units(struct section_file *file,
         u->city_size = 1;
         ok = false;
         break;
+      }
+
+      // L_FERRYBOAT makes the AI consider the unit as a transport.
+      // Ensure it can actually transport something.
+      if (utype_has_role(u, L_FERRYBOAT) && u->transport_capacity == 0) {
+        qCWarning(ruleset_category,
+                  "\"%s\": Unit %s has FerryBoat flag but cannot transport",
+                  filename, utype_rule_name(u));
+        BV_CLR(u->roles, L_FERRYBOAT - L_FIRST);
       }
     }
     unit_type_iterate_end;


### PR DESCRIPTION
The FerryBoat flag is only meaningful for units that can transport. Warn when the flag is set for non-transport units, and unset it. This prevents an assertion failure later on.

Closes #2238.