### PR TITLE
Remove duplicate sprite error in trident and hex2t tilesets

### DIFF
--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -151,7 +151,7 @@ files =
   "misc/governments.spec",
   "misc/specialists.spec",
   "trident/buildings.spec",
-  "misc/wonders.spec",
+;  "misc/wonders.spec",
   "misc/flags.spec",
   "misc/shields.spec",
   "misc/cursors.spec",

--- a/data/hex2t.tilespec
+++ b/data/hex2t.tilespec
@@ -151,7 +151,6 @@ files =
   "misc/governments.spec",
   "misc/specialists.spec",
   "trident/buildings.spec",
-;  "misc/wonders.spec",
   "misc/flags.spec",
   "misc/shields.spec",
   "misc/cursors.spec",

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -153,7 +153,6 @@ files =
   "trident/grid.spec",
   "trident/roads.spec",
   "trident/buildings.spec",
-;  "misc/wonders.spec",
   "misc/space.spec",
   "misc/techs.spec",
   "misc/treaty.spec",

--- a/data/trident.tilespec
+++ b/data/trident.tilespec
@@ -153,7 +153,7 @@ files =
   "trident/grid.spec",
   "trident/roads.spec",
   "trident/buildings.spec",
-  "misc/wonders.spec",
+;  "misc/wonders.spec",
   "misc/space.spec",
   "misc/techs.spec",
   "misc/treaty.spec",


### PR DESCRIPTION
No related issue. Getting rid of some noise on the console.