### PR TITLE
Add some protection measures for a players alliances

### DIFF
--- a/server/diplhand.h
+++ b/server/diplhand.h
@@ -24,6 +24,7 @@ struct connection;
 
 // FIXME: Should this be put in a ruleset somewhere?
 const int TURNS_LEFT = 16;
+const int TURNS_EXTEND_CEASEFIRE = 1;
 
 #define treaty_list_iterate(list, p)                                        \
   TYPED_LIST_ITERATE(struct Treaty, list, p)

--- a/server/plrhand.h
+++ b/server/plrhand.h
@@ -148,6 +148,11 @@ void send_delegation_info(const struct connection *pconn);
 
 struct player *player_by_user_delegated(const char *name);
 
+void handle_diplomacy_cancel_pact_explicit(struct player *pplayer,
+                                           int other_player_id,
+                                           enum clause_type clause,
+                                           bool protect_alliances);
+
 // player colors
 void playercolor_init();
 void playercolor_free();

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -957,8 +957,8 @@ static void update_diplomatics()
                 if (cancel1) {
                   // Cancel the alliance.
                   to1->has_reason_to_cancel = 1;
-                  handle_diplomacy_cancel_pact(plr3, player_number(plr1),
-                                               CLAUSE_ALLIANCE);
+                  handle_diplomacy_cancel_pact_explicit(
+                      plr3, player_number(plr1), CLAUSE_ALLIANCE, false);
 
                   // Avoid asymmetric turns_left for the armistice.
                   to1->auto_cancel_turn = game.info.turn;
@@ -972,8 +972,8 @@ static void update_diplomatics()
                 if (cancel2) {
                   // Cancel the alliance.
                   to2->has_reason_to_cancel = 1;
-                  handle_diplomacy_cancel_pact(plr3, player_number(plr2),
-                                               CLAUSE_ALLIANCE);
+                  handle_diplomacy_cancel_pact_explicit(
+                      plr3, player_number(plr2), CLAUSE_ALLIANCE, false);
 
                   // Avoid asymmetric turns_left for the armistice.
                   to2->auto_cancel_turn = game.info.turn;


### PR DESCRIPTION
This is a follow-up PR for #2214 and #2239.

Closes #2177.

In games with complex alliance systems, declaring war can have unintended consequences. To protect the user from cancelling alliances by accident:

* When declaring war would result in an alliance being cancelled, require the user to cancel the alliance first.
* When declaring war would force one of your team mates to cancel an existing alliance, require this alliance to be cancelled first.
* When a cease-fire running out would result in an alliance being cancelled, automatically lengthen the cease-fire until the alliance gets cancelled.

