### PR TITLE
Always use angleDelta() for scrolling

### DIFF
--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -376,10 +376,7 @@ void map_view::resizeEvent(QResizeEvent *event)
  */
 void map_view::wheelEvent(QWheelEvent *event)
 {
-  auto delta = event->pixelDelta();
-  if (delta.isNull()) {
-    delta = event->angleDelta();
-  }
+  auto delta = event->angleDelta();
 
   if (event->modifiers() == Qt::NoModifier) {
     // Scrolling


### PR DESCRIPTION
Using pixelDelta() resulted in seemingly meaningless values on KWin/Wayland. Qt code uses angleDelta() exclusively, so I see no reason not to do the same.

Closes #2236.

Suggest to backport (if we do another stable)