### PR TITLE
Improve sizing and scrolling of the unit choice popup

### DIFF
--- a/client/unitselect.h
+++ b/client/unitselect.h
@@ -33,7 +33,7 @@ class units_select : public QMenu {
                             * iterate utile->units */
   QFont ufont;
   QFont info_font;
-  int row_count;
+  int column_count, row_count;
 
 public:
   units_select(struct tile *ptile, QWidget *parent = 0);


### PR DESCRIPTION
The unit selection popup for stacks in the open (and in allied cities) didn't behave very well with many units: its width remained fixed to 4 and it was showing at most 12 units -- quite a small stack for a serious attack. In addition, the last row was in some cases inaccessible due to a scrolling bug (maybe Wayland-specific; #2285).

Increase the base width of the menu to 5 units (a loaded Galleon), and further to 6 when there are more than 25 units. Show up to 36 units (four fully loaded Transports) at once before resorting to scrolling.

Fix the scrolling bug, which was related to scroll events with deltaY=0 being interpreted as scrolling upwards.

Closes #2285.

---

This was likely already a bug in 3.0, so we should consider backporting the fix if there is another dot release.