### PR TITLE
Don't disable the present units list when investigating

### DIFF
--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -1019,7 +1019,6 @@ void city_dialog::update_disabled()
   ui.buy_button->setEnabled(can_edit);
   ui.cma_enable_but->setEnabled(can_edit);
   ui.production_combo_p->setEnabled(can_edit);
-  ui.present_units_list->setEnabled(can_edit);
   update_prod_buttons();
 }
 


### PR DESCRIPTION
This allows giving orders to one's own units in the city and scrolling through the unit list.

Closes #2302.
Closes #2286.