### PR TITLE
Automatically cancel the current activity in goto

### DIFF
--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -101,6 +101,7 @@ bool vertex::comparable(const vertex &other) const
  */
 void vertex::fill_probe(unit &probe) const
 {
+  probe.activity = ACTIVITY_IDLE; // Else it doesn't want to move.
   probe.tile = location;
   probe.transporter = loaded;
   probe.client.transported_by = loaded ? loaded->id : -1;


### PR DESCRIPTION
It's common to select sentried or fortified units and initiate a goto. Currently this requires a click on the units to unset any activity they may have. Do this automatically in the path finder.

Closes #2272.