### PR TITLE
Fix wrapping redundant cities in the economics view

### DIFF
--- a/client/repodlgs_common.cpp
+++ b/client/repodlgs_common.cpp
@@ -37,8 +37,6 @@ void get_economy_report_data(struct improvement_entry *entries,
   *num_entries_used = 0;
   *total_cost = 0;
   *total_income = 0;
-  QStringList redundant_cities;
-  redundant_cities.clear();
   QString str;
 
   if (nullptr == client.conn.playing) {
@@ -48,14 +46,14 @@ void get_economy_report_data(struct improvement_entry *entries,
   improvement_iterate(pimprove)
   {
     if (is_improvement(pimprove)) {
-      int count = 0, redundant = 0, cost = 0;
+      QStringList redundant_cities;
+      int count = 0, cost = 0;
       city_list_iterate(client.conn.playing->cities, pcity)
       {
         if (city_has_building(pcity, pimprove)) {
           count++;
           cost += city_improvement_upkeep(pcity, pimprove);
           if (is_improvement_redundant(pcity, pimprove)) {
-            redundant++;
             redundant_cities.append(pcity->name);
           }
         }
@@ -66,7 +64,7 @@ void get_economy_report_data(struct improvement_entry *entries,
         continue;
       }
 
-      if (redundant == 0) {
+      if (redundant_cities.isEmpty()) {
         str = (_("None"));
       } else {
         // Convert the string list we built to a standard string for display.
@@ -75,7 +73,7 @@ void get_economy_report_data(struct improvement_entry *entries,
 
       entries[*num_entries_used].type = pimprove;
       entries[*num_entries_used].count = count;
-      entries[*num_entries_used].redundant = redundant;
+      entries[*num_entries_used].redundant = redundant_cities.size();
       entries[*num_entries_used].total_cost = cost;
       entries[*num_entries_used].cost = cost / count;
       entries[*num_entries_used].city_names = str;

--- a/client/views/view_economics.cpp
+++ b/client/views/view_economics.cpp
@@ -185,8 +185,13 @@ void eco_report::update_report()
             .arg(QString::number(tax),
                  QString::number(building_total + unit_total));
   ui.eco_label->setText(buf);
+
+  // Resize all columns except the last (which we want to wrap).
+  for (int i = 0; i < ui.eco_widget->columnCount() - 1; ++i) {
+    ui.eco_widget->resizeColumnToContents(i);
+  }
+  // Resize rows to let text wrap around.
   ui.eco_widget->resizeRowsToContents();
-  ui.eco_widget->resizeColumnsToContents();
 }
 
 /**

--- a/client/views/view_economics.ui
+++ b/client/views/view_economics.ui
@@ -73,6 +73,12 @@
       <property name="selectionBehavior">
        <enum>QAbstractItemView::SelectRows</enum>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
+      <property name="horizontalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
       <property name="showGrid">
        <bool>false</bool>
       </property>
@@ -83,7 +89,7 @@
        <bool>false</bool>
       </attribute>
       <attribute name="horizontalHeaderStretchLastSection">
-       <bool>false</bool>
+       <bool>true</bool>
       </attribute>
       <attribute name="verticalHeaderVisible">
        <bool>false</bool>


### PR DESCRIPTION
Fix wrapping redundant cities in the economics view
    
We were resizing columns to avoid wrapping with resizeColumnsToContents,
then resizing rows. This produced horizontal scrolling and strange
behaviour when the redundant list got long.
    
Fix this by:
1) Setting the last column (redundant cities) to use all remaining
   space, and
2) Adjusting the width of all columns except the last.
    
Closes #2289.

Tested locally by inverting the logic of `get_economy_report_data` to show all non-redundant cities (which is usually many).