### PR TITLE
Reduce mentions of MP2

### DIFF
--- a/docs/Manuals/Game/menu.rst
+++ b/docs/Manuals/Game/menu.rst
@@ -535,7 +535,7 @@ Multiplayer Menu
 ================
 
 The :guilabel:`Multiplayer` menu has a collection of functions to aid certain multiplayer games. Many of
-the options are specifically tailored to the MP2c and WarCiv rulesets. It has the following options:
+the options are specifically tailored to fast multiplayer games. It has the following options:
 
 Delayed Go To
     Give a unit orders to move at a specific time in the turn. This assumes that the turn is time based.

--- a/docs/Playing/faq.rst
+++ b/docs/Playing/faq.rst
@@ -893,17 +893,17 @@ How do I take over an idle player that was assigned to me?
 
 Same procedure as `How do I take over an AI player?`_ above.
 
-Does capturing work like MP2?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Does capturing work like Freeciv-Web?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Unit capturing is ruleset defined. Capturing in :term:`LTT` works slightly differently than in the :term:`MP2`
-ruleset. You can capture any “capturable” unit with a “capturer” unit, if the target is alone on a tile. Units
+ruleset used at Freeciv-Web.
+You can capture any “capturable” unit with a “capturer” unit, if the target is alone on a tile. Units
 that are “capturable” have a mention of this in their help text. Units that are “capturers” also have a
 mention of this in their help text.
 
 .. Tip::
-  Due to the game interface mechanics, you can capture units from boats. This cannot be done using the regular
-  :term:`Goto` command, but has to be done using the number pad on your keyboard.
+  You can also capture units from boats. Guard your coastal workers.
 
 
 Where do I go to see the rules for a game? Like how big a victory alliance can be?

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -88,6 +88,7 @@ community discussions.
     Multiplayer 2 Ruleset
 
     There are many MP2 :ref:`rulesets <modding-rulesets>` and they are numbered: MP2a, MP2b, MP2c, etc.
+    They are not compatible with Freeciv21.
 
   MP
     Move Point(s)


### PR DESCRIPTION
We have multiple mentions of MP2 in the docs, including one in the manual suggesting that we support the ruleset (how did this come to be?). Adjust the wording slightly.