### PR TITLE
Keep scroll position when reinstantiating science_report

### DIFF
--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -38,9 +38,7 @@
 #include "ratesdlg_g.h"
 #include "tileset/sprite.h"
 #include "top_bar.h"
-#include "views/view_economics.h"
 #include "views/view_map.h"
-#include "views/view_nations.h"
 #include "views/view_research.h"
 #include "views/view_units.h"
 
@@ -449,11 +447,7 @@ void top_bar::addWidget(QWidget *fsw)
  */
 void top_bar_show_map()
 {
-  popdown_units_view();
   popdown_city_dialog();
-  popdown_players_report();
-  popdown_economy_report();
-  popdown_science_report();
   queen()->game_tab_widget->setCurrentIndex(0);
 }
 


### PR DESCRIPTION
The `science_report` loses the scroll position when the view is closed. This is because the object is destroyed and therefore loses its state.

This commit adds code to track the scroll position in static fields and restore the state when the `science_report` is reinstantiated.

Closes #2329.

An alternative solution would be to prevent the destruction of `science_report` when the view is closed; this is the behavior in stable.