### PR TITLE
Don't access items in empty cache

### DIFF
--- a/common/city.cpp
+++ b/common/city.cpp
@@ -2247,9 +2247,12 @@ void add_specialist_output(
     // This is more than just an optimization. For governors that forbid
     // specialists, the cache may not be filled.
     if (count > 0) {
+      // If there is a cache it must not be empty.
+      fc_assert(!pcsoutputs || !pcsoutputs->empty());
+
       output_type_iterate(stat_index)
       {
-        int amount = pcsoutputs && !pcsoutputs->empty()
+        int amount = pcsoutputs
                          ? pcsoutputs->at(sp)[stat_index]
                          : get_specialist_output(pcity, sp, stat_index);
 
@@ -2876,10 +2879,12 @@ void set_city_production(struct city *pcity,
    * on, so shield waste will include shield bonuses. */
   output_type_iterate(o)
   {
+    // If there is a cache it must not be empty.
+    fc_assert(!pcwaste || !pcwaste->empty());
+
     pcity->waste[o] =
         city_waste(pcity, o, pcity->prod[o] * pcity->bonus[o] / 100, nullptr,
-                   gov_centers,
-                   pcwaste && !pcwaste->empty() ? &pcwaste->at(o) : nullptr);
+                   gov_centers, pcwaste ? &pcwaste->at(o) : nullptr);
   }
   output_type_iterate_end;
 

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -2249,7 +2249,7 @@ void add_specialist_output(
     if (count > 0) {
       output_type_iterate(stat_index)
       {
-        int amount = pcsoutputs
+        int amount = pcsoutputs && !pcsoutputs->empty()
                          ? pcsoutputs->at(sp)[stat_index]
                          : get_specialist_output(pcity, sp, stat_index);
 

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -2248,7 +2248,8 @@ void add_specialist_output(
     // specialists, the cache may not be filled.
     if (count > 0) {
       // If there is a cache it must not be empty.
-      fc_assert(!pcsoutputs || !pcsoutputs->empty());
+      fc_assert_action(!pcsoutputs || !pcsoutputs->empty(),
+                       pcsoutputs = nullptr);
 
       output_type_iterate(stat_index)
       {
@@ -2873,15 +2874,15 @@ void set_city_production(struct city *pcity,
   trade_routes_iterate_end;
   pcity->prod[O_GOLD] += get_city_tithes_bonus(pcity);
 
+  // If there is a cache it must not be empty.
+  fc_assert_action(!pcwaste || !pcwaste->empty(), pcwaste = nullptr);
+
   /* Account for waste.  Note that waste is calculated before tax income is
    * calculated, so if you had "science waste" it would not include taxed
    * science.  However waste is calculated after the bonuses are multiplied
    * on, so shield waste will include shield bonuses. */
   output_type_iterate(o)
   {
-    // If there is a cache it must not be empty.
-    fc_assert(!pcwaste || !pcwaste->empty());
-
     pcity->waste[o] =
         city_waste(pcity, o, pcity->prod[o] * pcity->bonus[o] / 100, nullptr,
                    gov_centers, pcwaste ? &pcwaste->at(o) : nullptr);

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -2878,7 +2878,8 @@ void set_city_production(struct city *pcity,
   {
     pcity->waste[o] =
         city_waste(pcity, o, pcity->prod[o] * pcity->bonus[o] / 100, nullptr,
-                   gov_centers, pcwaste ? &pcwaste->at(o) : nullptr);
+                   gov_centers,
+                   pcwaste && !pcwaste->empty() ? &pcwaste->at(o) : nullptr);
   }
   output_type_iterate_end;
 


### PR DESCRIPTION
While debugging an issue reported in LT85, I found that in certain circumstances an empty specialist output cache (introduced in 5c44029) is accessed, what crashed the client.

An obvious fix, contained in this PR, is limiting access to non-empty caches. There may be better ways to handle this though.

While here, I applied the same safety measure to the waste level cache, introduced in ecabf5d.