### PR TITLE
Sort players alphabetically in the nations view

### DIFF
--- a/client/views/view_nations.cpp
+++ b/client/views/view_nations.cpp
@@ -327,6 +327,7 @@ plr_widget::plr_widget(QWidget *widget) : QTableView(widget)
   coll.setNumericMode(true);
   filter_model->set_collator(coll);
   setModel(filter_model);
+  sortByColumn(0, Qt::AscendingOrder); // Sort players alphabetically
 
   setSortingEnabled(true);
   setSelectionMode(QAbstractItemView::SingleSelection);


### PR DESCRIPTION
They were always sorted from Z to A, which felt wrong.

Test plan:
* Load a game with many players
* Open the nations dialog
* Check that it's sorted A-Z and not Z-A