### PR TITLE
Bump actions/upload-artifact to 4.1.7

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -63,7 +63,7 @@ jobs:
             | ansifilter \
             | ./codacy-clang-tidy >report.json
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.1.7
         with:
           name: clang-tidy-report
           path: report.json


### PR DESCRIPTION
This is needed for compatibility with the latest download-artifact.