### PR TITLE
Only send bombardment combat when targets are visible

### DIFF
--- a/client/views/view_map_common.h
+++ b/client/views/view_map_common.h
@@ -105,6 +105,7 @@ void draw_segment(const tile *ptile, enum direction8 dir, bool safe);
 
 void decrease_unit_hp_smooth(struct unit *punit0, int hp0,
                              struct unit *punit1, int hp1);
+void animate_unit_explosion(const tile *location);
 void move_unit_map_canvas(struct unit *punit, struct tile *ptile, int dx,
                           int dy);
 

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -615,7 +615,7 @@ class Variant:
             def f(cap):
                 return f'has_capability("{cap}", capability)'
 
-            t = list(map(lambda x: f(x), self.poscaps)) + list(
+            t = list(map(f, self.poscaps)) + list(
                 map(lambda x: "!" + f(x), self.negcaps)
             )
             self.condition = " && ".join(t)

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -1088,6 +1088,11 @@ PACKET_UNIT_COMBAT_INFO = 65; sc, lsend
   BOOL make_def_veteran;
 end
 
+PACKET_UNIT_BOMBARD_INFO = 66; sc, lsend, cap(bombard-info)
+  UNIT attacker_unit_id;
+  TILE target_tile;
+end
+
 PACKET_UNIT_SSCS_SET = 71; cs, dsend
   UNIT unit_id;
   UNIT_DATA_TYPE type;

--- a/common/networking/packets.def
+++ b/common/networking/packets.def
@@ -132,6 +132,9 @@ Syntax:
      function sends to list of connections instead of just one
      connection, which is the case for the other send functions.
 
+     add-cap(capability): only transmit this packet if the given capability is
+     available at runtime.
+
      cs: a packet which is sent from the client to the server
 
      sc: a packet which is sent from the server to the client

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2787,7 +2787,7 @@ void package_short_unit(struct unit *punit,
 /**
    Handle situation where unit goes out of player sight.
  */
-void unit_goes_out_of_sight(struct player *pplayer, struct unit *punit)
+void unit_goes_out_of_sight(struct player *pplayer, const unit *punit)
 {
   dlsend_packet_unit_remove(pplayer->connections, punit->id);
   if (punit->server.moving != nullptr) {

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -149,7 +149,7 @@ void package_short_unit(struct unit *punit,
                         enum unit_info_use packet_use, int info_city_id);
 void send_unit_info(struct conn_list *dest, struct unit *punit);
 void send_all_known_units(struct conn_list *dest);
-void unit_goes_out_of_sight(struct player *pplayer, struct unit *punit);
+void unit_goes_out_of_sight(struct player *pplayer, const unit *punit);
 
 // doing a unit activity
 void do_nuclear_explosion(struct player *pplayer, struct tile *ptile);

--- a/utility/fc_version.h.in
+++ b/utility/fc_version.h.in
@@ -14,7 +14,7 @@
 
 #define NETWORK_CAPSTRING                                                   \
   "+Freeciv21.21April13 killunhomed-is-game-info player-intel-visibility " \
-  "bought-shields"
+  "bought-shields bombard-info"
 
 #ifndef FOLLOWTAG
 #define FOLLOWTAG "S_HAXXOR"


### PR DESCRIPTION
Bombarding cities was very powerful because it was showing every unit inside the city, something only diplomats and spies can normally do. Stop sending this around.