### PR TITLE
Use @v4 for actions/{upload,download}-artifact

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -63,7 +63,7 @@ jobs:
             | ansifilter \
             | ./codacy-clang-tidy >report.json
 
-      - uses: actions/upload-artifact@v4.1.7
+      - uses: actions/upload-artifact@v4
         with:
           name: clang-tidy-report
           path: report.json
@@ -75,7 +75,7 @@ jobs:
     needs: run
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           name: clang-tidy-report
 


### PR DESCRIPTION
This will pick the latest available v4 for both actions without us needing to care about exact version numbers. Should fix the clang-tidy action.

The changes will only take effect once merged in `master`.