### PR TITLE
Always require QtGui

### DIFF
--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -21,7 +21,7 @@ check_function_exists(at_quick_exit HAVE_AT_QUICK_EXIT)
 find_package(Python3 REQUIRED)
 
 # Required as the main networking and utility library
-find_package(Qt5 5.15 COMPONENTS Core Network REQUIRED)
+find_package(Qt5 5.15 COMPONENTS Core Gui Network REQUIRED)
 
 # Required for utility
 if(FREECIV_ENABLE_SERVER)


### PR DESCRIPTION
The server now depends on Gui for map image support. Gui was already required in complete builds because all other components use it through Widgets. Make sure it is also required in server-only builds.

Found while building the server for Sim06