### PR TITLE
Remove dangling city pointers from the governor code

### DIFF
--- a/client/governor.h
+++ b/client/governor.h
@@ -11,7 +11,8 @@
 #pragma once
 
 #include "attribute.h"
-#include <QSet>
+
+#include <set>
 
 class governor {
 public:
@@ -33,8 +34,8 @@ private:
   governor() { superhot = 1; };
   void run();
   static governor *m_instance;
-  QSet<struct city *> scity_changed;
-  QSet<struct city *> scity_remove;
+  std::set<int> scity_changed;
+  std::set<int> scity_remove;
   int superhot;
 };
 


### PR DESCRIPTION
The governor code was using pointers to keep track of cities to be removed or updated. These pointers would sometimes become invalid when the city was lost or otherwise conquered, causing use-after-free errors.

This fixes the first version of #2351.