### PR TITLE
Rework the how the units view is updated

### DIFF
--- a/client/top_bar.cpp
+++ b/client/top_bar.cpp
@@ -617,6 +617,7 @@ void top_bar_units_view()
       return;
     }
     uv = reinterpret_cast<units_view *>(w);
+    uv->update_units();
     queen()->game_tab_widget->setCurrentWidget(uv);
   }
 }

--- a/client/views/view_units.h
+++ b/client/views/view_units.h
@@ -62,6 +62,7 @@ public:
   units_view();
   ~units_view();
   void update_view();
+  void update_units();
   void update_waiting();
   void init();
 


### PR DESCRIPTION
The logic to update the units table has been moved into a dedicated method and has been adapted in a way, that the content of the units table is not regenerated on update. Instead the already existing table contents are updated as needed. This allows the table to keep its selection on update.

If the units view is reopened after it has already been opened once, this newly created method is called to update the units table.

Fixes #2399.