### PR TITLE
Send updated research after it is fully updated

### DIFF
--- a/client/views/view_research.cpp
+++ b/client/views/view_research.cpp
@@ -670,7 +670,7 @@ void real_science_report_dialog_update(void *unused)
     struct research *research = research_get(client_player());
     if (research->researching == A_UNSET) {
       str = QString(_("none"));
-    } else if (research->client.researching_cost != 0) {
+    } else {
       str =
           research_advance_name_translation(research, research->researching);
       str += QStringLiteral("\n");
@@ -697,8 +697,6 @@ void real_science_report_dialog_update(void *unused)
         && research->techs_researched < game.control.num_tech_types) {
       blk = true;
     }
-  } else {
-    str = QStringLiteral(" ");
   }
 
   if (blk) {

--- a/server/techtools.cpp
+++ b/server/techtools.cpp
@@ -433,9 +433,6 @@ void found_new_tech(struct research *presearch, Tech_type_id tech_found,
     research_update(presearch);
   }
 
-  // Inform players about their new tech.
-  send_research_info(presearch, nullptr);
-
   if (was_first) {
     /* Inform all players about new global advances to give them a
      * chance for obsolete buildings. */
@@ -576,6 +573,9 @@ void found_new_tech(struct research *presearch, Tech_type_id tech_found,
   if (!saving_bulbs && presearch->bulbs_researched > 0) {
     presearch->bulbs_researched = 0;
   }
+
+  // Inform players about their new tech.
+  send_research_info(presearch, nullptr);
 
   if (bonus_tech_hack) {
     Tech_type_id additional_tech;


### PR DESCRIPTION
Upon getting a free tech, the server was sending the updated research before it was done updating the struct. The client received contradicting information (in #2405, that the tech was both fully researched and still the current tech goal).

Closes #2405.

## Testing

I tested the following cases:
* Tech from hut with no target set
* Tech from hut with a goal set (the next tech towards the target gets selected and researched immediately if there are enough bulbs)
* Researching techs with and without a target
* Getting a tech from allies