### PR TITLE
Save less state in minimap_view

### DIFF
--- a/client/minimap.h
+++ b/client/minimap.h
@@ -38,7 +38,7 @@ class minimap_view : public fcwidget {
 
 public:
   minimap_view(QWidget *parent);
-  ~minimap_view() override;
+
   void paint(QPainter *painter, QPaintEvent *event);
   void update_menu() override;
   void update_image();
@@ -51,14 +51,7 @@ protected:
   void paintEvent(QPaintEvent *event) override;
   void resizeEvent(QResizeEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
-  void moveEvent(QMoveEvent *event) override;
-  void showEvent(QShowEvent *event) override;
 
 private:
   void draw_viewport(QPainter *painter);
-  float w_ratio, h_ratio;
-  QBrush background;
-  QPixmap *pix;
-  QPoint cursor;
-  QPoint position;
 };


### PR DESCRIPTION
The widget needs to compute horizontal and vertical scaling factors to map between the displayed minimap (in pixel units) and the computed one (essentially in tile units). It was computing them on resize events and storing them, which was causing issues when switching maps. Compute them when they are needed instead, it's just two float divisions.

Also remove a bunch of unused variables from the class.

Closes #1657.