### PR TITLE
Fix reports being shown out of screen

### DIFF
--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -987,6 +987,7 @@ void popup_notify_dialog(const char *caption, const char *headline,
 
   freeciv::report_widget *nd = new freeciv::report_widget(
       caption, headline, lines, queen()->mapview_wdg);
+  nd->move(queen()->mapview_wdg->find_place(nd->size()));
   nd->show();
 }
 

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -54,10 +54,9 @@ class map_view : public QWidget {
 
 public:
   map_view();
-  void find_place(int pos_x, int pos_y, int &w, int &h, int wdth, int hght,
-                  int recursive_nr, bool direction = false);
-  void resume_searching(int pos_x, int pos_y, int &w, int &h, int wdtht,
-                        int hght, int recursive_nr, bool direction);
+
+  QPoint find_place(const QSize &size) const;
+
   void update_cursor(enum cursor_type);
 
   void hide_all_fcwidgets();
@@ -105,6 +104,7 @@ private:
   double m_scale = 1;
   std::unique_ptr<QPropertyAnimation> m_origin_animation;
   std::unique_ptr<QPropertyAnimation> m_scale_animation;
+
   QPointer<freeciv::tileset_debugger> m_debugger = nullptr;
   std::vector<QPointer<fcwidget>> m_hidden_fcwidgets;
 };

--- a/client/widgets/report_widget.cpp
+++ b/client/widgets/report_widget.cpp
@@ -8,10 +8,8 @@
 #include "widgets/report_widget.h"
 
 // client
-#include "dialogs_g.h"
 #include "fc_client.h"
 #include "fonts.h"
-#include "page_game.h"
 #include "views/view_map.h"
 
 // Qt
@@ -55,12 +53,6 @@ report_widget::report_widget(const QString &caption, const QString &headline,
   auto cw = new close_widget(this);
   cw->setFixedSize(12, 12);
   cw->put_to_corner();
-
-  auto x = width();
-  auto y = height();
-  queen()->mapview_wdg->find_place(queen()->mapview_wdg->width() - x - 4, 4,
-                                   x, y, x, y, 0);
-  move(x, y);
 }
 
 /**


### PR DESCRIPTION
When connecting to a game and receiving an historian report, they would often be shown out-of-screen. This is ultimately caused by the resizing of the client window happening only after the game state is fully loaded. The placement algorithm has to provide sensible results when the widget doesn't fit inside the (small) base window size.

The complicated placement algorithm relied on an initial guess for the position and could result in the widget being shown off-screen when the window was too small. Replace it with a linear scan going left-to-right and top-to-bottom across the entire screen. Also avoid recursion, permitting more attempts by lifting the limitation due to the stack size.

This doesn't entirely solve the issue of widgets being shown in an unexpected location when connecting to a game: when the algorithm finds no solution, it now defaults to 0,0 to maximize visible content. This can in particular be the case for the small window size used right before connecting. I think a full revision of the pregame screens is needed, but this is way beyond the scope of this PR and won't make it to 3.1.

Closes #1989.

## Before Patch

![image](https://github.com/user-attachments/assets/63cfe48e-188b-4455-96c6-e08ab5c78f49)

## After Patch

![image](https://github.com/user-attachments/assets/08de7f6b-d743-4fe7-ab68-6d551fe1b7eb)

The Demographics report gets placed correctly when invoked:

![image](https://github.com/user-attachments/assets/7124dd60-8d96-4e06-88f6-0d7d7f023355)
