### PR TITLE
Initialize order.sub_target in path_finder

### DIFF
--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -48,6 +48,7 @@ vertex vertex::child_for_action(action_id action, const unit &probe,
   ret.order.order = ORDER_PERFORM_ACTION;
   ret.order.action = action;
   ret.order.target = target->index;
+  ret.order.sub_target = NO_TARGET;
   ret.order.dir = DIR8_ORIGIN;
   ret.moves_left = probe.moves_left;
   ret.location = target;

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -6035,14 +6035,14 @@ static bool sg_load_player_unit(struct loaddata *loading, struct player *plr,
             break;
           case ASTK_NONE:
             // None of these can take a sub target.
-            fc_assert_msg(order_sub_tgt == -1,
+            fc_assert_msg(order_sub_tgt == NO_TARGET,
                           "Specified sub target for action %d unsupported.",
                           order->action);
             order->sub_target = NO_TARGET;
             break;
           case ASTK_COUNT:
-            fc_assert_msg(order_sub_tgt == -1, "Bad action action %d.",
-                          order->action);
+            fc_assert_msg(order_sub_tgt == NO_TARGET,
+                          "Bad action action %d.", order->action);
             order->sub_target = NO_TARGET;
             break;
           }


### PR DESCRIPTION
The sub_target should be set to NO_ORDER by default, otherwise we get a warning when reading back from saves.

Closes #2394.

.I tested using the save from #2394:
* Set long goto for a few paratroopers
* Save
* Load again
* Warnings are gone