### PR TITLE
Action names: You're Fired -> Disband Unit

### DIFF
--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -6219,8 +6219,8 @@ const char *action_ui_name_default(int act)
     // TRANS: Rec_ycle Unit (100% chance of success).
     return N_("Rec%sycle Unit%s");
   case ACTION_DISBAND_UNIT:
-    // TRANS: _You're Fired (100% chance of success).
-    return N_("%sYou're Fired%s");
+    // TRANS: _Disband Unit (100% chance of success).
+    return N_("%sDisband Unit%s");
   case ACTION_HOME_CITY:
     // TRANS: Set _Home City (100% chance of success).
     return N_("Set %sHome City%s");

--- a/data/civ1/game.ruleset
+++ b/data/civ1/game.ruleset
@@ -363,8 +363,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Build City (100% chance of success). */
 ui_name_found_city = _("%sBuild City%s")

--- a/data/civ2/game.ruleset
+++ b/data/civ2/game.ruleset
@@ -399,8 +399,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Build City (100% chance of success). */
 ui_name_found_city = _("%sBuild City%s")

--- a/data/civ2civ3/game.ruleset
+++ b/data/civ2civ3/game.ruleset
@@ -421,8 +421,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/data/classic/game.ruleset
+++ b/data/classic/game.ruleset
@@ -416,8 +416,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Build City (100% chance of success). */
 ui_name_found_city = _("%sBuild City%s")

--- a/data/experimental/game.ruleset
+++ b/data/experimental/game.ruleset
@@ -424,8 +424,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Build City (100% chance of success). */
 ui_name_found_city = _("%sBuild City%s")

--- a/data/multiplayer/game.ruleset
+++ b/data/multiplayer/game.ruleset
@@ -413,8 +413,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Build City (100% chance of success). */
 ui_name_found_city = _("%sBuild City%s")

--- a/data/royale/game.ruleset
+++ b/data/royale/game.ruleset
@@ -432,8 +432,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/data/sandbox/game.ruleset
+++ b/data/sandbox/game.ruleset
@@ -417,8 +417,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")


### PR DESCRIPTION
"You're Fired" was difficult to understand and was on a totally different tone than other action names.

Closes #2392.