### PR TITLE
Improve the documentation of Enable_Nuke

### DIFF
--- a/docs/Modding/Rulesets/actions.rst
+++ b/docs/Modding/Rulesets/actions.rst
@@ -664,6 +664,10 @@ Nuke City
   * the actor unit must be on a tile next to the target unless :code:`nuke_city_max_range` allows it to be
     further away.
 
+  .. note::
+    Units that can perform this action can only be built when the
+    :ref:`Enable_Nuke <effect-enable-nuke>` effect is active.
+
 .. _action-conquer-city:
 
 Conquer City
@@ -1006,6 +1010,10 @@ Nuke Units
     * it is in a city.
     * it is on a tile with a native Extra.
 
+  .. note::
+    Units that can perform this action can only be built when the
+    :ref:`Enable_Nuke <effect-enable-nuke>` effect is active.
+
 .. _action-spy-attack:
 
 Spy Attack
@@ -1046,6 +1054,10 @@ Explode Nuclear
   * if :code:`force_bombard` is TRUE, "Bombard", "Bombard 2", and "Bombard 3" must be impossible.
   * actor must be on the same tile as the target unless :code:`explode_nuclear_max_range` allows it to be
     further away.
+
+  .. note::
+    Units that can perform this action can only be built when the
+    :ref:`Enable_Nuke <effect-enable-nuke>` effect is active.
 
 .. _action-paradrop-unit:
 

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -269,7 +269,10 @@ Gov_Center
 .. _effect-enable-nuke:
 
 Enable_Nuke
-    Allows the production of nuclear weapons.
+    Allows the production of nuclear weapons (units that can do the
+    :ref:`Explode Nuclear <action-explode-nuclear>`,
+    :ref:`Nuke City <action-nuke-city>`, or
+    :ref:`Nuke Units <action-nuke-units>` actions).
 
 .. _effect-enable-space:
 


### PR DESCRIPTION
Document what is considered a nuclear weapon. Add links in both directions between the effect controlling their availability and nuclear actions.

Requested by Hawk on Discord.