### PR TITLE
Units view: Show map after clicking "find nearest unit"

### DIFF
--- a/client/views/view_units.cpp
+++ b/client/views/view_units.cpp
@@ -557,7 +557,9 @@ void units_view::find_nearest()
       }
     }
   }
-  popdown_units_view();
+
+  // Show map
+  queen()->game_tab_widget->setCurrentIndex(0);
 }
 
 /**


### PR DESCRIPTION
Views are no longer destroyed, if the view is switched. That's the reason why the `popdown_units_view`, that is called after clicking "find nearest unit", is no longer guaranteed to show the map.

Closes #2451