### PR TITLE
Allow setting landmass to 100

### DIFF
--- a/common/map.h
+++ b/common/map.h
@@ -545,7 +545,7 @@ moves. Includes MAP_MAX_LINEAR_SIZE because a map can be non wrapping. */
 
 #define MAP_DEFAULT_LANDMASS 30
 #define MAP_MIN_LANDMASS 15
-#define MAP_MAX_LANDMASS 85
+#define MAP_MAX_LANDMASS 100
 
 #define MAP_DEFAULT_RICHES 250
 #define MAP_MIN_RICHES 0

--- a/docs/Manuals/Server/options.rst
+++ b/docs/Manuals/Server/options.rst
@@ -495,7 +495,7 @@ To place a setting value on any of these settings use the ``/set <option-name> <
   the unit.
 
 ``landmass``
-  :strong:`Default Value (Min, Max)`: 30 (15, 85)
+  :strong:`Default Value (Min, Max)`: 30 (15, 100)
 
   :strong:`Description`: Percentage of the map that is land. This setting gives the approximate percentage of
   the map that will be made into land.


### PR DESCRIPTION
Some generators can generate maps without water. Allow game admins to request this.

Closes #2444.