### PR TITLE
Add the ability to turn trade into pollution

### DIFF
--- a/ai/default/daicity.cpp
+++ b/ai/default/daicity.cpp
@@ -1479,7 +1479,8 @@ adv_want dai_city_want(struct player *pplayer, struct city *acity,
   want += prod[O_FOOD] * adv->food_priority;
   if (prod[O_SHIELD] != 0) {
     want += prod[O_SHIELD] * adv->shield_priority;
-    want -= city_pollution(acity, prod[O_SHIELD]) * adv->pollution_priority;
+    want -= city_pollution(acity, prod[O_SHIELD], prod[O_TRADE])
+            * adv->pollution_priority;
   }
   want += prod[O_LUXURY] * adv->luxury_priority;
   want += prod[O_SCIENCE] * adv->science_priority;

--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -170,6 +170,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_POLLU_POP_PCT:
   case EFT_POLLU_POP_PCT_2:
   case EFT_POLLU_PROD_PCT:
+  case EFT_POLLU_TRADE_PCT:
   case EFT_OUTPUT_BONUS:
   case EFT_OUTPUT_BONUS_2:
   case EFT_OUTPUT_ADD_TILE:

--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -666,16 +666,18 @@ QString get_city_dialog_illness_text(const struct city *pcity)
  */
 QString get_city_dialog_pollution_text(const struct city *pcity)
 {
-  int pollu, prod, pop, mod;
+  int pollu, prod, trade, pop, mod;
   struct city_sum *sum = city_sum_new(Q_("?city_pollution:%+4.0f : %s"));
 
   /* On the server, pollution is calculated before production is deducted
    * for disorder; we need to compensate for that */
   pollu = city_pollution_types(
-      pcity, pcity->prod[O_SHIELD] + pcity->unhappy_penalty[O_SHIELD], &prod,
+      pcity, pcity->prod[O_SHIELD] + pcity->unhappy_penalty[O_SHIELD],
+      pcity->prod[O_TRADE] + pcity->unhappy_penalty[O_TRADE], &prod, &trade,
       &pop, &mod);
 
   city_sum_add(sum, prod, Q_("?city_pollution:Pollution from shields"));
+  city_sum_add(sum, trade, Q_("?city_pollution:Pollution from trade"));
   city_sum_add(sum, pop, Q_("?city_pollution:Pollution from citizens"));
   city_sum_add(sum, mod, Q_("?city_pollution:Pollution modifier"));
   return city_sum_print(sum, false,

--- a/common/city.h
+++ b/common/city.h
@@ -733,8 +733,10 @@ void city_styles_free();
 void add_tax_income(const struct player *pplayer, int trade, int *output);
 int get_city_tithes_bonus(const struct city *pcity);
 int city_pollution_types(const struct city *pcity, int shield_total,
-                         int *pollu_prod, int *pollu_pop, int *pollu_mod);
-int city_pollution(const struct city *pcity, int shield_total);
+                         int trade_total, int *pollu_prod, int *pollu_trade,
+                         int *pollu_pop, int *pollu_mod);
+int city_pollution(const struct city *pcity, int shield_total,
+                   int trade_total);
 int city_illness_calc(const struct city *pcity, int *ill_base, int *ill_size,
                       int *ill_trade, int *ill_pollution);
 bool city_had_recent_plague(const struct city *pcity);

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1074,6 +1074,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_POLLU_POP_PCT:
   case EFT_POLLU_POP_PCT_2:
   case EFT_POLLU_PROD_PCT:
+  case EFT_POLLU_TRADE_PCT:
   case EFT_INCITE_COST_PCT:
   case EFT_SPY_RESISTANT:
   case EFT_VETERAN_COMBAT:

--- a/common/effects.h
+++ b/common/effects.h
@@ -315,6 +315,8 @@
 #define SPECENUM_VALUE134NAME "Nuke_Infrastructure_Pct"
 #define SPECENUM_VALUE135 EFT_GROWTH_SURPLUS_PCT
 #define SPECENUM_VALUE135NAME "Growth_Surplus_Pct"
+#define SPECENUM_VALUE136 EFT_POLLU_TRADE_PCT
+#define SPECENUM_VALUE136NAME "Pollu_Trade_Pct"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -434,6 +434,11 @@ Pollu_Pop_Pct_2
     i.e. 1 pollution per citizen). This factor is applied after :ref:`Pollu_Pop_Pct <effect-pollu-pop-pct>`,
     so is multiplicative with it.
 
+.. _effect-pollu-trade-pct:
+
+Pollu_Trade_Pct
+    Each trade generates AMOUNT percent of pollution.
+
 .. _effect-pollu-prod-pct:
 
 Pollu_Prod_Pct


### PR DESCRIPTION
This adds a Pollu_Trade_Pct effect that can be used to generate pollution from trade. This may be more realistic for trade-based governments like Democracy.

Requested by Hawk.
Closes #2446.

## Testing

Add the following effect to your favorite ruleset:
```ini
[effect_pollution]
type = "Pollu_Trade_Pct"
value = 100
```
Now try to tame down GW...