### PR TITLE
Implement units cycling

### DIFF
--- a/client/control.cpp
+++ b/client/control.cpp
@@ -357,12 +357,32 @@ static void ask_server_for_actions(struct unit *punit)
 }
 
 /**
-   Return TRUE iff this unit is in focus.
+   Return TRUE if this unit is in focus.
  */
 bool unit_is_in_focus(const struct unit *punit)
 {
   const auto &focus = get_units_in_focus();
   return std::find(focus.begin(), focus.end(), punit) != focus.end();
+}
+
+/**
+   Returns TRUE if this unit is on stand by.
+
+   A unit is on stand by, if it is idle or sentried and not busy
+   building anything.
+*/
+bool unit_is_on_stand_by(const struct unit *punit)
+{
+  if (ACTIVITY_IDLE != punit->activity
+      && ACTIVITY_SENTRY != punit->activity) {
+    return false;
+  }
+
+  if (!can_unit_do_activity(punit, ACTIVITY_IDLE)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/client/control.cpp
+++ b/client/control.cpp
@@ -37,12 +37,10 @@
 
 // client
 #include "audio/audio.h"
-#include "chatline.h"
 #include "client_main.h"
 #include "climap.h"
 #include "climisc.h"
 #include "control.h"
-#include "editor.h"
 #include "goto.h"
 #include "governor.h"
 #include "options.h"

--- a/client/control.h
+++ b/client/control.h
@@ -141,6 +141,7 @@ void wakeup_sentried_units(struct tile *ptile);
 void clear_unit_orders(struct unit *punit);
 
 bool unit_is_in_focus(const struct unit *punit);
+bool unit_is_on_stand_by(const struct unit *punit);
 struct unit *get_focus_unit_on_tile(const struct tile *ptile);
 struct unit *head_of_units_in_focus();
 std::vector<unit *> &get_units_in_focus();

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -1877,9 +1877,7 @@ void cycle_units(const int direction)
 
   struct unit *current_unit = head_of_units_in_focus();
 
-  int unit_count = 0;
-  int current_unit_index = 0;
-  std::tie(unit_count, current_unit_index) =
+  auto [unit_count, current_unit_index] =
       cycle_units_get_count_and_index(current_unit);
 
   if (unit_count == 0) {

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -1787,16 +1787,7 @@ static bool cycle_units_predicate(const struct unit *current_unit,
     return false;
   }
 
-  if (ACTIVITY_IDLE != candidate->activity
-      && ACTIVITY_SENTRY != candidate->activity) {
-    return false;
-  }
-
-  if (!can_unit_do_activity(candidate, ACTIVITY_IDLE)) {
-    return false;
-  }
-
-  return true;
+  return unit_is_on_stand_by(candidate);
 }
 
 /**

--- a/client/hudwidget.h
+++ b/client/hudwidget.h
@@ -43,6 +43,7 @@ struct tile;
 struct unit;
 struct unit_list;
 
+void cycle_units(const int direction);
 void show_new_turn_info();
 bool has_player_unit_type(Unit_type_id utype);
 

--- a/client/hudwidget.h
+++ b/client/hudwidget.h
@@ -1,5 +1,5 @@
 /**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
+ Copyright (c) 1996-2024 Freeciv21 and Freeciv contributors. This file is
  part of Freeciv21. Freeciv21 is free software: you can redistribute it
  and/or modify it under the terms of the GNU  General Public License  as
  published by the Free Software Foundation, either version 3 of the
@@ -144,11 +144,13 @@ public:
   click_label();
 signals:
   void left_clicked();
+  void wheel_scrolled(const int delta);
 private slots:
   void mouse_clicked();
 
 protected:
   void mousePressEvent(QMouseEvent *e) override;
+  void wheelEvent(QWheelEvent *e) override;
 };
 
 /****************************************************************************
@@ -221,6 +223,9 @@ private:
   move_widget *mw;
   unit_list *ul_units;
   tile *current_tile;
+
+private slots:
+  void cycle_units(const int delta);
 };
 
 /****************************************************************************

--- a/client/views/view_units.cpp
+++ b/client/views/view_units.cpp
@@ -550,11 +550,8 @@ void units_view::find_nearest()
   if ((punit = find_nearest_unit(utype, ptile))) {
     queen()->mapview_wdg->center_on_tile(punit->tile);
 
-    if (ACTIVITY_IDLE == punit->activity
-        || ACTIVITY_SENTRY == punit->activity) {
-      if (can_unit_do_activity(punit, ACTIVITY_IDLE)) {
-        unit_focus_set_and_select(punit);
-      }
+    if (unit_is_on_stand_by(punit)) {
+      unit_focus_set_and_select(punit);
     }
   }
 

--- a/docs/Manuals/Game/unit-controls.rst
+++ b/docs/Manuals/Game/unit-controls.rst
@@ -44,4 +44,4 @@ the left side and the game map will center on the unit for you. As with other wi
 click+drag the widget to move it by using the plus symbol in the upper left corner.
 
 If you scroll your mouse wheel over the unit icon on the left side of the widget, the game will cycle through
-idle or units of the same unit type.
+idle or sentried units of the same unit type.

--- a/docs/Manuals/Game/unit-controls.rst
+++ b/docs/Manuals/Game/unit-controls.rst
@@ -43,5 +43,5 @@ If the unit selected is not in your field of vision on the map, then you can cli
 the left side and the game map will center on the unit for you. As with other widgets in Freeciv21, you can
 click+drag the widget to move it by using the plus symbol in the upper left corner.
 
-If you scroll your mouse wheel on icon for the unit on the left side, than the game will cycle through idle or
-sentried units of the same unit type.
+If you scroll your mouse wheel over the unit icon on the left side of the widget, the game will cycle through
+idle or units of the same unit type.

--- a/docs/Manuals/Game/unit-controls.rst
+++ b/docs/Manuals/Game/unit-controls.rst
@@ -42,3 +42,6 @@ appear in quotes after the Unit ID value.
 If the unit selected is not in your field of vision on the map, then you can click on the icon for the unit on
 the left side and the game map will center on the unit for you. As with other widgets in Freeciv21, you can
 click+drag the widget to move it by using the plus symbol in the upper left corner.
+
+If you scroll your mouse wheel on icon for the unit on the left side, than the game will cycle through idle or
+sentried units of the same unit type.


### PR DESCRIPTION
Since the new Units Report was introduced in 3.1, there was no longer a way to cycle all units of a given unit type on the map.

With this commit scrolling the mouse wheel on the selected unit icon in the "Unit Controls" widget, cycles through idle or sentried units of the same unit type.