### PR TITLE
Toggle report notifications

### DIFF
--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -981,6 +981,7 @@ void popup_notify_dialog(const char *caption, const char *headline,
   for (auto report : list) {
     if (report->caption() == caption && report->headline() == headline) {
       report->close();
+      return;
     }
   }
 

--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -40,7 +40,6 @@
 #include "client_main.h"
 #include "control.h"
 #include "fc_client.h"
-#include "fonts.h"
 #include "helpdlg.h"
 #include "hudwidget.h"
 #include "icons.h"


### PR DESCRIPTION
This addresses the missing parts from issue #1612. While I already made F6 (research view) and F12 (spaceship view) work as a toggle, making F7 (wonders of the world), F8 (top 5 cities) and F11 (demographics) work like that is a bit special.

These reports are generic notification popups, which the server triggers to be displayed. The flow is

1. the user presses F7
2. the client asks the server for the research report
3. the server sends the research report
4. the client displays the report in a notification popup by calling `popup_notify_dialog`

This PR changes the behavior of subsequent calls to `popup_notify_dialog`. The former behavior was to refresh an existing notification, the new behavior is to close the existing notification. The notification to be manipulated is, in both cases, identified by caption and headline.

A drawback of this implementation is, that toggling a report still needs a round-trip to the server:

1. the user presses F7, while the wonder of the worlds report is open
2. the client asks the server for the research report
3. the server sends the research report
4. the client registers that there is already an open report, identified by the caption and headline provided from the server, and closes it
5. the just received report is discarded.

Keeping state in the client and closing the notifications without involving the server would require the usage of magic strings to identify relevant notification (this implementation does use string comparisons too, but these strings are provided by the server and, at least from the clients perspective, less magic).

Giving the notifications an "identity" would require either changes in the server and the protocol, or the client would need to deduce it by using magic strings.