### PR TITLE
RTD 2025-01 Updates

### DIFF
--- a/docs/Coding/ai.rst
+++ b/docs/Coding/ai.rst
@@ -3,11 +3,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Artificial Intelligence (AI)
 ****************************

--- a/docs/Coding/architecture.rst
+++ b/docs/Coding/architecture.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Architecture
 ************
 
@@ -61,6 +63,7 @@ structure of the repository:
   :file:`translations` Localization.
   :file:`utility`      Utility classes and functions not found in Qt or other dependencies.
   ==================== ==========
+
 
 .. note::
     Some folders do not follow this structure. Their contents should eventually be moved.

--- a/docs/Coding/attributes.rst
+++ b/docs/Coding/attributes.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Attribute Blocks
 ****************
 

--- a/docs/Coding/guidelines.rst
+++ b/docs/Coding/guidelines.rst
@@ -1,7 +1,8 @@
-..
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
+
+.. include:: /global-include.rst
 
 Coding Guidelines
 *****************

--- a/docs/Coding/hacking.rst
+++ b/docs/Coding/hacking.rst
@@ -5,11 +5,7 @@
 .. SPDX-FileCopyrightText: NIKEA-SOFT
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Freeciv21 Hacker's Guide
 ************************

--- a/docs/Coding/internationalization.rst
+++ b/docs/Coding/internationalization.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Internationalization
 ********************
 
@@ -23,7 +25,7 @@ Paying attention to these three points is sufficient to get internationalization
 of the cases.
 
 Translating Text
-----------------
+================
 
 Translating user-facing text is the most work-intensive part of internationalization. As a developer, you
 only need to make sure that strings are marked for translation when appropriate. In Freeciv21, this is done
@@ -67,7 +69,7 @@ returns the original). This is useful in static contexts.
 
 
 Not Translated
---------------
+==============
 
 While most text should be translated, there are a few cases where this is not wanted:
 
@@ -78,7 +80,7 @@ While most text should be translated, there are a few cases where this is not wa
 
 
 Helper Comments
----------------
+===============
 
 When translators work on strings, they are provided with a list taken out of context. They can see the
 original text in English and sometimes the source code, but most translators cannot read code. In some
@@ -112,7 +114,7 @@ In complex cases, adding an example or a short explanation also makes the code e
 
 
 Character Encodings
--------------------
+===================
 
 The way characters are encoded into strings has long been a hot topic of internationalization, and
 language-specific character encodings are still around on some systems. Freeciv21 always uses UTF-8 for data
@@ -128,7 +130,7 @@ be rarely, if ever, needed.
 
 
 Common Difficulties
--------------------
+===================
 
 Every language is different, and there is no reason for the order of words or even sentences to be the same
 as in English. When possible, it is thus preferable to provide the translators with full sentences or

--- a/docs/Coding/logging.rst
+++ b/docs/Coding/logging.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Logging
 *******
 

--- a/docs/Coding/mapgen.rst
+++ b/docs/Coding/mapgen.rst
@@ -2,11 +2,7 @@
 .. SPDX-FileCopyrightText: Erik Sigra <sigra@home.se>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Map Generator
 *************
@@ -509,7 +505,7 @@ Player Placement
 
 .. table:: Mode chosen by the generator to generate start positions
   :widths: auto
-  :align: right
+  :align: center
 
   ============ =======
   Generator    Default

--- a/docs/Coding/network-protocol.rst
+++ b/docs/Coding/network-protocol.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Network Protocol
 ****************
 
@@ -150,14 +152,13 @@ reply its connection is closed.
 Delta
 =====
 
-If delta is enabled for this packet, the packet-payload (after the bytes used by the packet-header) is followed
-by the ``delta-header``. The ``delta-header`` is a bitvector which represents all non-key fields of the
-packet. If
-the field has changed the corresponding bit is set and the field value is also included in ``delta-body``. The
-values of the unchanged fields will be filled in from an old version at the receiving side. The old version
-filled in from is the previous packet of the same kind that has the same value in each key field. If the
-packet's kind do not have any key fields the previous packet of the same kind is used. If no old version
-exists the unchanged fields will be assumed to be zero.
+If delta is enabled for this packet, the packet-payload (after the bytes used by the packet-header) is
+followed by the ``delta-header``. The ``delta-header`` is a bitvector which represents all non-key fields of
+the packet. If the field has changed the corresponding bit is set and the field value is also included in
+``delta-body``. The values of the unchanged fields will be filled in from an old version at the receiving
+side. The old version filled in from is the previous packet of the same kind that has the same value in each
+key field. If the packet's kind do not have any key fields the previous packet of the same kind is used. If
+no old version exists the unchanged fields will be assumed to be zero.
 
 For a ``bool`` field, another optimization called ``bool-header-folding`` is applied. Instead of sending an
 indicator in the bitvector if the given ``bool`` value has changed, and so using 1 byte for the real value,

--- a/docs/Coding/scorelog.rst
+++ b/docs/Coding/scorelog.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Format Description of the Scorelog
 **********************************
 
@@ -11,20 +13,20 @@ are always the last parameter and so extend until the end of line.
 
 The following commands exists:
 
-* :code:`id <game-id>` : :code:`<game-id>` is a string without whitespaces which is used to match a scorelog
+* :code:`id <game-id>` --- :code:`<game-id>` is a string without whitespaces which is used to match a scorelog
   against a savegame.
 
-* :code:`tag <tag-id> <descr>` : Add a data-type (tag) the :code:`<tag-id>` is used in the 'data' commands
+* :code:`tag <tag-id> <descr>` --- Add a data-type (tag) the :code:`<tag-id>` is used in the 'data' commands
   :code:`<descr>` is a string without whitespaces which identified this tag.
 
-* :code:`turn <turn> <number> <descr>` : Adds information about the :code:`<turn>` turn :code:`<number>` can
+* :code:`turn <turn> <number> <descr>` --- Adds information about the :code:`<turn>` turn :code:`<number>` can
   be for example year :code:`<descr>` may contain whitespaces.
 
-* :code:`addplayer <turn> <player-id> <name>` : Adds a player starting at the given turn (inclusive).
+* :code:`addplayer <turn> <player-id> <name>` --- Adds a player starting at the given turn (inclusive).
   :code:`<player-id>`  is a number which can be reused :code:`<name>` may contain whitespaces.
 
-* :code:`delplayer <turn> <player-id>` : Removes a player from the game. The player was active till the given
+* :code:`delplayer <turn> <player-id>` --- Removes a player from the game. The player was active till the given
   turn (inclusive) :code:`<player-id>` used by the creation.
 
-* :code:`data <turn> <tag-id> <player-id> <value>` : Gives the value of the given tag for the given player for
+* :code:`data <turn> <tag-id> <player-id> <value>` --- Gives the value of the given tag for the given player for
   the given turn.

--- a/docs/Contributing/bugs.rst
+++ b/docs/Contributing/bugs.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Filing Bugs and Enhancement Requests
 ************************************
 

--- a/docs/Contributing/capitalized-terms.rst
+++ b/docs/Contributing/capitalized-terms.rst
@@ -2,11 +2,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 List of Capitalized Terms
 *************************

--- a/docs/Contributing/dev-env.rst
+++ b/docs/Contributing/dev-env.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Set up a Development Environment
 ********************************
 
@@ -116,8 +118,9 @@ Once installed, you can then import the Freeciv21 project into it. Follow these 
 #. Find :file:`freeciv21/CMakeLists.txt`
 #. :menuselection:`Session --> Rename Current Session` to Freeciv21
 #. :menuselection:`Project --> Open Configuration --> Language Support`. Click on the
-   :guilabel:`Language Support` tab and ensure that the C++ Profile is `c++17`, the C Profile is `c99`, the
-   OpenCL C Profile is `CL1.1`, the CUDA C Profile is `c++11`, and finall the Compiler for Path is `GCC`.
+   :guilabel:`Language Support` tab and ensure that the C++ Profile is :guilabel:`c++17`, the C Profile is
+   :guilabel:`c99`, the OpenCL C Profile is :guilabel:`CL1.1`, the CUDA C Profile is :guilabel:`c++11`, and
+   finally the Compiler for Path is :guilabel:`GCC`.
 #. Allow kdevelop to parse all of the code. This can take a while. Eventually you will see a full tree of
    the code in the Projects tab on the left.
 

--- a/docs/Contributing/eval-pull-request.rst
+++ b/docs/Contributing/eval-pull-request.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
 
+.. include:: /global-include.rst
+
 Evaluating a Pull Request
 *************************
 

--- a/docs/Contributing/game-admin.rst
+++ b/docs/Contributing/game-admin.rst
@@ -1,22 +1,19 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Longturn Game Admin Guide
 *************************
 
-Any competent player can act as a Game Admin. There are a few tools and some knowledge you will need to be successful.
+Any competent player can act as a Game Admin. There are a few tools and some knowledge you will need to be
+successful.
 
 Tools
 =====
 
-Games are established by an admin by editing ruleset, server settings, and player settings files. All of these files
-are in plain text. You will need at least two tools:
+Games are established by an admin by editing ruleset, server settings, and player settings files. All of these
+files are in plain text. You will need at least two tools:
 
 #. ``git``
 #. Plain Text Editor: Kate/Gedit/Nano/Vi on Linux. Notepad++ on Windows are quick suggestions.
@@ -24,9 +21,9 @@ are in plain text. You will need at least two tools:
 GitHub
 ======
 
-All of the games are on the `Longturn Games Repository <https://github.com/longturn/games>`_. Follow the instructions
-in the GitHub section of the :ref:`Dev Environment page <dev-env-github>` to setup a GitHub account and establish a
-local working area. Skip the ``clone`` steps for Freeciv21.
+All of the games are on the `Longturn Games Repository <https://github.com/longturn/games>`_. Follow the
+instructions in the GitHub section of the :ref:`Dev Environment page <dev-env-github>` to setup a GitHub
+account and establish a local working area. Skip the ``clone`` steps for Freeciv21.
 
 Now clone the games repository:
 
@@ -36,8 +33,8 @@ Now clone the games repository:
   ~/GitHub$ git clone git@github.com:longturn/games.git
 
 
-You will be prompted for your SSH key to complete the ``clone``. You should have a local :file:`games` directory when
-complete.
+You will be prompted for your SSH key to complete the ``clone``. You should have a local :file:`games`
+directory when complete.
 
 Games Repo Structure
 ====================
@@ -68,67 +65,70 @@ The Games repository has a logical structure::
 
 Here are some notes/edits needed for each file.
 
-#. ``[Game Number].serv`` -- This is the primary server configuration file. You can edit any and all parameters to setup
-   the game the way you want. Refer to the :doc:`/Manuals/Server/index`, and for help with the map generator, refer to
-   :doc:`/Manuals/Advanced/map-generator`.
-#. ``[Game Number].sh`` -- Edit the top three values for the ``Game Number`` and set the TCP Port for the game.
-#. ``db.conf`` -- Edit for the ``Game Number``
-#. ``env.sh`` -- Edit the ``FREECIV_DATA_PATH`` value for the ``Game Number``
-#. ``players.serv`` -- This is the list of players for the game. You can get the list from the game page on the main
-   longturn.net website. Refer to :doc:`/Manuals/Advanced/players` for more information. You can also refer to other
-   recent games for help with the format.
-#. The files in ``data/[Game Number]`` are standard ruleset files. You can copy the ruleset files from our common
-   `ruleset repository <https://github.com/longturn/LTT-LTX>`_, or create your own custom ruleset. We have Sim and
-   Aviation as current third-part rulesets we play games with. For more information on ruleset files, refer to
-   :doc:`/Modding/index`.
+#. ``[Game Number].serv`` --- This is the primary server configuration file. You can edit any and all
+   parameters to setup the game the way you want. Refer to the :doc:`/Manuals/Server/index`, and for help with
+   the map generator, refer to :doc:`/Manuals/Advanced/map-generator`.
+#. ``[Game Number].sh`` --- Edit the top three values for the ``Game Number`` and set the TCP Port for the game.
+#. ``db.conf`` --- Edit for the ``Game Number``
+#. ``env.sh`` --- Edit the ``FREECIV_DATA_PATH`` value for the ``Game Number``
+#. ``players.serv`` --- This is the list of players for the game. You can get the list from the game page on
+   the main longturn.net website. Refer to :doc:`/Manuals/Advanced/players` for more information. You can also
+   refer to other recent games for help with the format.
+#. The files in ``data/[Game Number]`` are standard ruleset files. You can copy the ruleset files from our
+   common `ruleset repository <https://github.com/longturn/LTT-LTX>`_, or create your own custom ruleset. We
+   have Sim and Aviation as current third-part rulesets we play games with. For more information on ruleset
+   files, refer to :doc:`/Modding/index`.
 
 
 Setup a New Game
 ================
 
-Now that you know the basics of how the game files on the repository work, let us move to the steps to admin a new game.
+Now that you know the basics of how the game files on the repository work, let us move to the steps to admin a
+new game.
 
-You must first have been granted Game Admin rights on the main longturn website. The website uses Django as the
-back-end, so managing game pages on the site is very simple. If you do not have access, please ask on the main Longturn
-Discord server.
+You must first have been granted Game Admin rights on the main longturn website. The website uses Django as
+the back-end, so managing game pages on the site is very simple. If you do not have access, please ask on the
+main Longturn Discord server.
 
 #. Login at https://longturn.net
 #. On the lower left, click "Admin Site".
-#. On the site administration panel on the left, click ``+ Add`` on the row for *Games*.
+#. On the site administration panel on the left, click :guilabel:`+ Add` on the row for :guilabel:`Games`.
 #. Give it a name, such as LT86. The name must be unique and can not have been used before.
 #. Fill in the game description field. See below on some more notes related to the game description.
 #. Select the game mode: Team Game, Teamless, Experimental.
 #. Select the version of Freeciv21 the game will run on.
 #. Select your handle from the Admin drop down box to set yourself as game admin.
 #. Leave all the rest of the fields as is. Do not set the port or a start date at this time. Those will get set later.
-#. Click ``Save`` in the lower right.
+#. Click :guilabel:`Save` in the lower right.
 
 
-.. note:: The Longturn server is configured to accept incoming connections on ports ``5050`` to ``5099``. Note
-  that port ``5060`` can be problematic for some corporate and educational facilites and should be avoided.
+.. note::
+  The Longturn server is configured to accept incoming connections on ports ``5050`` to ``5099``. Note that
+  port ``5060`` can be problematic for some corporate and educational facilites and should be avoided.
 
 
 Notes on the :strong:`game description`:
 
-* Give details as to the type of game you want to play. This is especially important for Team and Experimental games.
-  This is also important if the game is going to be special, such as a Scenario or use a third-party ruleset. Recall
-  that Experimental games often have rules change mid game to fix bugs or make changes. They are Experimental by nature,
-  so its good to add these kinds of notes to the description.
+* Give details as to the type of game you want to play. This is especially important for Team and Experimental
+  games. This is also important if the game is going to be special, such as a Scenario or use a third-party
+  ruleset. Recall that Experimental games often have rules change mid game to fix bugs or make changes. They
+  are Experimental by nature, so its good to add these kinds of notes to the description.
 * Mention what ruleset will be used or any other special rules for the game.
 * Mention winning alliance size and any game ending / announcement rules.
-* For team games, explain how the teams will be selected / defined up front. For teamless games, potentially mention how
-  many players are needed for the game to start.
-* Players are very interested in what kind of map topology will be used. Some only play squares, some only hexes. Define
-  the map topology in the description.
-* Establish the length of turns. We have often run turns at 23 hours. However, lately we have been going with 25 hours.
-  Either way, make sure to mention it in the game description. If you intend to change the length of the turn at a
-  certain point in the game (e.g. for late game make the turns two days -- ``2*23`` or ``2*25``) you will definitely
-  want to state this up front.
-* Define up front how you want to handle RTS. RTS (Real Time Strategy) is a term we use to define how actions between
-  players can occur when both are playing at the same time. When a player RTS's, they will be acting against you at the
-  same time you are trying to do some moves, such as establishing a new city or attacking. A non-RTS game would not
-  allow this synchronous action. A RTS game would allow it. Teamless games are often non-RTS, same with Team games.
-  However, Experimental or other types are games could allow it.
+* For team games, explain how the teams will be selected / defined up front. For teamless games, potentially
+  mention how many players are needed for the game to start.
+* Players are very interested in what kind of map topology will be used. Some only play squares, some only
+  hexes. Define the map topology in the description.
+* Establish the length of turns. We have often run turns at 23 hours. However, lately we have been going with
+  25 hours. Either way, make sure to mention it in the game description. If you intend to change the length of
+  the turn at a certain point in the game (e.g. for late game make the turns two days --- :math:`2\times23` or
+  :math:`2\times25`) you will definitely want to state this up front.
+* Define up front how you want to handle :term:`RTS`. RTS (Real Time Strategy) is a term we use to define how
+  actions between players can occur when both are playing at the same time. When a player RTS's, they will be
+  acting against you at the same time you are trying to do some moves, such as establishing a new city or
+  attacking. A non-RTS game would not allow this synchronous action. A :term:`RTS` game would allow it.
+  Teamless games are often non-RTS, same with Team games. However, Experimental or other types are games could
+  allow it.
 
 
 The following code-block can be used to copy and paste into the Django admin site for new games.
@@ -145,12 +145,12 @@ The following code-block can be used to copy and paste into the Django admin sit
   <b>RTS: </b>This game [will | will not] allow Real Time Strategy (RTS) player engagement.
 
 
-At this point you can announce the game on the ``#new-games`` channel on the Longturn Discord server to let people know
-about it. Ask a Discord Admin to create a channel for the game as well.
+At this point you can announce the game on the ``#new-games`` channel on the Longturn Discord server to let
+people know about it. Ask a Discord Admin to create a channel for the game as well.
 
-While players are talking about the game on Discord and signing up on the website, you can get the game files ready. The
-easiest way to start is by copying a previous game and then editing the files. When finished you will combine the
-changes into a ``git commit`` and push them up to the games repository.
+While players are talking about the game on Discord and signing up on the website, you can get the game files
+ready. The easiest way to start is by copying a previous game and then editing the files. When finished you
+will combine the changes into a ``git commit`` and push them up to the games repository.
 
 .. code-block:: sh
 
@@ -160,52 +160,55 @@ changes into a ``git commit`` and push them up to the games repository.
   ~/GitHub/games$ git push origin
 
 
-The ``git status`` command gives you information on what changed on your local workspace. It gives you a chance to fix
-any files that may have changed that you did not intend to.  The ``git add`` command will add all changed files to the
-commit package.  The ``git commit`` command will bring up a text editor (often Nano) allowing you to enter in a commit
-message. Preface commit messages with the ``[Game Number]:``. Finally you push the changes up to the repo with the
-``git push`` command. You will be prompted for your SSH passkey to complete the step.
+The ``git status`` command gives you information on what changed on your local workspace. It gives you a
+chance to fix any files that may have changed that you did not intend to.  The ``git add`` command will add
+all changed files to the commit package.  The ``git commit`` command will bring up a text editor (often Nano)
+allowing you to enter in a commit message. Preface commit messages with the ``[Game Number]:``. Finally you
+push the changes up to the repo with the ``git push`` command. You will be prompted for your SSH passkey to
+complete the step.
 
 
 Start the New Game
 ==================
 
-When enough players have signed up, you will want to announce it on the game channel and set a potential start date.
+When enough players have signed up, you will want to announce it on the game channel and set a potential start
+date.
 
 These are the steps to finalize a game:
 
 #. Go into the admin site on the Longturn server and set a start date at least 7 days into the future and save.
 #. Ask players to confirm participation on the website. The typical confirmation period is 7 days.
 #. Start editing the ``players.serv`` file and push changes up to the repo.
-#. Ask a Server Admin to setup a test game with the game server and map generator settings to see how things look.
-   :strong:`Note`: Game Admins should test locally to check things out before asking a server admin to do it on the main
-   game server.
-#. Based on confirmations, you will finalize the ``players.serv`` file and push any other last minute changes to the
-   game server settings based on test results. The server can not handle a nation name of "random", you will need to be
-   the random nation namer for those players that ask for a random nation.
+#. Ask a Server Admin to setup a test game with the game server and map generator settings to see how things
+   look. :strong:`Note`: Game Admins should test locally to check things out before asking a server admin to
+   do it on the main game server.
+#. Based on confirmations, you will finalize the ``players.serv`` file and push any other last minute changes
+   to the game server settings based on test results. The server can not handle a nation name of "random", you
+   will need to be the random nation namer for those players that ask for a random nation.
 #. Go to the admin site and set the port for the game.
 #. Ask a Server Admin to start the game for you.
 #. Announce game start. Ensure first turn is extended.
 
-..note:: Server admins can perform additional actions when starting the game, such as looking at the map or performing
-  edits. For example, it is common to post the size of the largest islands. Since this requires extra work, make sure
-  you talk to the Server Admin beforehand.
+.. note::
+  Server admins can perform additional actions when starting the game, such as looking at the map or
+  performing edits. For example, it is common to post the size of the largest islands. Since this requires
+  extra work, make sure you talk to the Server Admin beforehand.
 
 
 During the Game
 ===============
 
-Once the game has started, the Game Admin is expected to keep an eye on the game channel on the Discord server. It is
-the Game Admin's responsibility to arbitrate complaints or issues between players. Timely response is important as you
-are able given the time zone you live in. Other Game and Server Admins often watch the active game channels to provide
-guidance and assistance as well.
+Once the game has started, the Game Admin is expected to keep an eye on the game channel on the Discord
+server. It is the Game Admin's responsibility to arbitrate complaints or issues between players. Timely
+response is important as you are able given the time zone you live in. Other Game and Server Admins often
+watch the active game channels to provide guidance and assistance as well.
 
 Ending the Game
 ===============
 
-Depending on how you setup the game, players can form alliances or other winning conditions will come true. Players
-typically announce the win on the game channel on Discord. Admins typically offer a 5 day (``5*24``) cooling period to
-allow other players to either reject the win -- keep playing -- or accepting the win -- stop playing. The Server Admin
-can end the game when asked. A player from the winning alliance can grab a screenshot of the final game report and post.
-Server Admins can also generate an animated ``gif`` file of the map to show the rise and fall of nations as the game
-progressed.
+Depending on how you setup the game, players can form alliances or other winning conditions will come true.
+Players typically announce the win on the game channel on Discord. Admins typically offer a 5 day
+(:math:`5\times24`) cooling period to allow other players to either reject the win --- keep playing, or
+accepting the win --- stop playing. The Server Admin can end the game when asked. A player from the winning
+alliance can grab a screenshot of the final game report and post. Server Admins can also generate an animated
+:file:`gif` file of the map to show the rise and fall of nations as the game progressed.

--- a/docs/Contributing/msys2.rst
+++ b/docs/Contributing/msys2.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: zekoz
 
+.. include:: /global-include.rst
+
 Setting up MSYS2 for Windows
 ****************************
 

--- a/docs/Contributing/pull-request.rst
+++ b/docs/Contributing/pull-request.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Pranav Sampathkumar <pranav.sampathkumar@gmail.com>
 
+.. include:: /global-include.rst
+
 How to Submit a Pull Request
 ****************************
 

--- a/docs/Contributing/release.rst
+++ b/docs/Contributing/release.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
-.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>s
+.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+.. include:: /global-include.rst
 
 The Release Process
 *******************

--- a/docs/Contributing/stable-branch.rst
+++ b/docs/Contributing/stable-branch.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Maintaining the Stable Branch
 *****************************
 

--- a/docs/Contributing/style-guide.rst
+++ b/docs/Contributing/style-guide.rst
@@ -2,12 +2,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Documentation Style Guide
 *************************
@@ -31,8 +26,8 @@ Heading 1
 
 .. code-block:: rst
 
-    This is an awesome page title
-    *****************************
+    This is an awesome page title (h1)
+    **********************************
 
 
 Heading 2
@@ -41,8 +36,8 @@ Heading 2
 
 .. code-block:: rst
 
-    This is a chapter marker
-    ========================
+    This is a chapter marker (h2)
+    =============================
 
 
 Heading 3
@@ -52,8 +47,8 @@ Heading 3
 
 .. code-block:: rst
 
-    This is a sub-chapter marker
-    ----------------------------
+    This is a sub-chapter marker (h3)
+    ---------------------------------
 
 
 Heading 4
@@ -62,8 +57,8 @@ Heading 4
 
 .. code-block:: rst
 
-    This is a sub-chapter break
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    This is a sub-chapter break (h4)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 .. _style-attribution:
@@ -85,8 +80,8 @@ or later license. Here is what the SPDX header should look like in all scenarios
 
 
 .. note::
-    We do not add a date (e.g. year) to our attribution blocks. There is recent commentary that this is not
-    needed and leaving the date off makes keeping header blocks up to date easier.
+  We do not add a date (e.g. year) to our attribution blocks. There is recent commentary that this is not
+  needed and leaving the date off makes keeping header blocks up to date easier.
 
 If the file you are working with came from legacy Freeciv, please add this line to the SPDX header for proper
 attribution:
@@ -107,22 +102,10 @@ to alter is placed inside back-ticks.
 * :literal:`:doc:` --- Doc is used to create a hyperlink reference between documents in the documentation
   system.
 
-* :literal:`:ref:` --- Create a cross-reference link to an anchor in another document. This is similar to
-  :literal:`:doc:`, except it allows you to go to a specific location within a page, instead of the top of the
-  page. To use :literal:`:ref:`, you add an anchor in a page such as :literal:`.. _My-Anchor:` and then refer
-  to it like this: :literal:`:ref:`My Anchor``. Notice that the anchor has an underscore at the beginning.
-  This is required for sphinx to recognize it. Also notice the use of the anchor in :literal:`:ref:` leaves
-  the underscore off.
-
-* :literal:`:numref:` --- Create a cross-reference to a named figure.
-
-* :literal:`:table:` --- Create a named table reference. Place an anchor (e.g. :literal:`.. _My-Anchor:`)
-  above to enable :literal:`:numref:`.
-
-* :literal:`:figure:` --- Create a named figure reference. Place an anchor (e.g. :literal:`.. _My Anchor:`)
-  above to enable :literal:`:numref:`.
-
 * :literal:`:emphasis:` --- Emphasis is used to :emphasis:`bring attention to something`.
+
+* :literal:`:figure:` --- Create a named figure reference. Place an anchor (e.g. :literal:`.. _My-Anchor:`)
+  above to enable :literal:`:numref:`.
 
 * :literal:`:file:` --- File is used for file names and paths such as :file:`~/.local/share/freeciv21/saves`.
 
@@ -132,14 +115,26 @@ to alter is placed inside back-ticks.
 * :literal:`:literal:` --- Literal is used when you want to note a text element in its raw form. This is
   equivalent to using two back-ticks: ````text````.
 
-* :literal:`math` and :literal:`.. math::` --- Used to insert mathematics, see `Formulas`_.
+* :literal:`:math:` and :literal:`.. math::` --- Used to insert mathematics, see `Formulas`_.
 
 * :literal:`:menuselection:` --- Menu Selection is used to give the path of menu clicks such as
   :menuselection:`Game --> Local Options`. To denote submenus, use a test arrow like this: :literal:`-->`
   between the selection items.
 
+* :literal:`:numref:` --- Create a cross-reference to a named figure.
+
+* :literal:`:ref:` --- Create a cross-reference link to an anchor in another document. This is similar to
+  :literal:`:doc:`, except it allows you to go to a specific location within a page, instead of the top of the
+  page. To use :literal:`:ref:`, you add an anchor in a page such as :literal:`.. _My-Anchor:` and then refer
+  to it like this: :literal:`:ref:`My-Anchor``. Notice that the anchor has an underscore at the beginning.
+  This is required for sphinx to recognize it. Also notice the use of the anchor in :literal:`:ref:` leaves
+  the underscore off.
+
 * :literal:`:strong:` --- Strong is used to :strong:`bold some text`. A good use of :literal:`:strong:` is to
   highlight game elements.
+
+* :literal:`:table:` --- Create a named table reference. Place an anchor (e.g. :literal:`.. _My-Anchor:`)
+  above to enable :literal:`:numref:`.
 
 * :literal:`:term:` --- Term is used to cross-reference to an entry in the :doc:`/glossary`.
 
@@ -154,17 +149,17 @@ The docutils specification allows for custom Interpreted Text Roles and we use t
 documentation on this feature is available here:
 https://docutils.sourceforge.io/docs/ref/rst/directives.html#custom-interpreted-text-roles
 
-* :literal:`:unit:` --- This provides an opportunity to highlight a Freeciv21 unit, such as the
-  :unit:`Musketeer`.
+* :literal:`:advance:` --- This provides an opportunity to highlight a Freeciv21 technology advance, such as
+  :advance:`Ceremonial Burial`.
 
 * :literal:`:improvement:` --- This provides an opportunity to highlight a Freeciv21 building or city
   improvement, such as the :improvement:`Granary`.
 
+* :literal:`:unit:` --- This provides an opportunity to highlight a Freeciv21 unit, such as the
+  :unit:`Musketeer`.
+
 * :literal:`:wonder:` --- This provides an opportunity to highlight a Freeciv21 small or great wonder, such as
   the :wonder:`Pyramids`.
-
-* :literal:`:advance:` --- This provides an opportunity to highlight a Freeciv21 technology advance, such as
-  :advance:`Ceremonial Burial`.
 
 Admonition Directives
 =====================
@@ -173,24 +168,29 @@ Admonitions are specially marked "topics" that can appear anywhere an ordinary b
 admonition is rendered as an offset block in a document, sometimes outlined or shaded, with a title matching
 the admonition type. We use some of the standard admonitions in our documentation as well.
 
-* :literal:`.. attention::` -- Use Attention to bring a very important high profile item to the reader's
+* :literal:`.. attention::` --- Use Attention to bring a very important high profile item to the reader's
   attention.
 
 .. attention::
-    This is a really important message! Do not forget to eat breakfast every day.
+  This is a really important message! Do not forget to eat breakfast every day.
 
-* :literal:`.. todo::` -- Use To Do as a reminder for documentation editors to come back and fix things at
+* :literal:`.. note::` ---  Use the Note as the way to give more information to the reader on a topic.
+
+.. note::
+  It is important to note that Freeciv21 is really fun to play with groups of people online.
+
+* :literal:`.. tip::` --- Use Tip to give a trick on how to do something.
+
+.. tip::
+  It is always best to play Freeciv21 with friends.
+
+* :literal:`.. todo::` --- Use To Do as a reminder for documentation editors to come back and fix things at
   a later date.
 
 .. todo::
-    Come back and fix something later.
+  Come back and fix something later.
 
-* :literal:`.. note::` --  Use the Note as the way to give more information to the reader on a topic.
-
-.. note::
-    It is important to note that Freeciv21 is really fun to play with groups of people online.
-
-* :literal:`.. code-block:: rst` -- The code block is an excellent way to display actual code or any
+* :literal:`.. code-block:: rst` --- The code block is an excellent way to display actual code or any
   pre-formatted plain text. The tag ``rst`` can be replaces by ``sh``, ``cpp``, and ``ini`` as well to give
   different types of markup for shell commands, C++ code, and ini file formatting.
 
@@ -248,9 +248,9 @@ Language Contractions
     :strong:`the usage of contractions is not advised` and should be used sparingly.
 
 The Use of Person
-    In English there are three types of person: first, second, and third. First person is possessive -- "I
-    took a walk down the street". Second person is about speaking to someone -- "You took a walk down the
-    street". Third person is non-specific -- "They took a walk down the street". In our documentation we use
+    In English there are three types of person: first, second, and third. First person is possessive --- "I
+    took a walk down the street". Second person is about speaking to someone --- "You took a walk down the
+    street". Third person is non-specific --- "They took a walk down the street". In our documentation we use
     the second person form. We want to be conversational with our readers and speak to them about the game,
     features, actions, etc.
 
@@ -260,7 +260,7 @@ The Use of Person
 Double Negatives / Negations
     To aid the readability of our documentation, we want to stay away from using double negatives. A double
     negative is where two negative words are combined together that end with a positive. For example:
-    "The guidelines are not bad". The last two words are negative -- "not bad". It is better to use positive
+    "The guidelines are not bad". The last two words are negative --- "not bad". It is better to use positive
     language. For example the first sentence is better written as: "The guidelines are good".
 
 Figure Numbers

--- a/docs/Contributing/visual-studio.rst
+++ b/docs/Contributing/visual-studio.rst
@@ -1,14 +1,17 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Visual Studio for Windows
 *************************
 
 Freeciv21 can be compiled using Microsoft Visual Studio\ |reg| and :file:`clang-cl`. This page will help you
 get version 2022 up and running.
 
-.. warning:: Visual Studio and the corresponding dependencies require a great deal of HDD space on your
-   computer. Be sure to have at least 80GB of available space before starting this process.
+.. warning::
+  Visual Studio and the corresponding dependencies require a great deal of HDD space on your computer. Be
+  sure to have at least 80GB of available space before starting this process.
 
 
 Base Installation
@@ -22,8 +25,9 @@ install. Select :guilabel:`Python Development` and :guilabel:`Desktop developmen
 panel, under :guilabel:`Installation Details`, uncheck :guilabel:`vcpkg package manager` and check
 :guilabel:`Windows 10 SDK 10.0.20348.0)`.
 
-.. note:: We remove the ``vcpkg`` package manager inside of Visual Studio in order to install one that is
-   better managed and easily updated later down this page.
+.. note::
+  We remove the ``vcpkg`` package manager inside of Visual Studio in order to install one that is better
+  managed and easily updated later down this page.
 
 Next click on the :guilabel:`Individual Components` tab and select the following options:
 :guilabel:`Git for Windows`, :guilabel:`C++ Clang Compiler for Windows (17.0.3)`, and
@@ -87,9 +91,10 @@ that you installed :file:`vcpkg` into. The forward slashes are correct.
     Tools> exit
 
 
-.. warning:: The :file:`vcpkg` website/readme will ask for you to run a :file:`vcpkg integrate install`
-  command to fully integrate all the packages installed into Visual Studio. :strong:`Do Not` run this command
-  as it actually breaks Visual Studio's ability to find and use the :file:`clang-cl` compiler, which we need.
+.. warning::
+  The :file:`vcpkg` website/readme will ask for you to run a :file:`vcpkg integrate install` command to fully
+  integrate all the packages installed into Visual Studio. :strong:`Do Not` run this command as it actually
+  breaks Visual Studio's ability to find and use the :file:`clang-cl` compiler, which we need.
 
 GitHub
 ======
@@ -185,7 +190,8 @@ Start by `downloading <https://www.qt.io/download-qt-installer-oss>`_ the instal
 #. Click :guilabel:`Next` and note that :strong:`Qt` for the Start Menu is fine.
 #. Click :guilabel:`Next` and :guilabel:`Install` to begin the process.
 
-.. note:: You can reduce the size of the Qt Tools install by expanding the ``5.15.2`` option and unchecking
+.. note::
+  You can reduce the size of the Qt Tools install by expanding the ``5.15.2`` option and unchecking
   ``WebAssembly``, ``MSVC 2015 64-bit``, ``MSVC 2019 32-bit``, ``MinGW 8.1.0 32-bit``, ``MinGW 8.1.0 64-bit``,
   ``UWP*``, and ``Android``. Unless you intend to develop for those platforms, you do not need to download and
   install those components for Freeciv21.
@@ -216,24 +222,27 @@ compile all targets for Freeciv21 and place the output into the :file:`build-vs`
 install Freeciv21 to test any work you are doing, you can go to :menuselection:`Build --> install Freeciv21`.
 When complete, you should find a fully functional install in the :file:`build-vs/install` directory.
 
-.. note:: The preferred :guilabel:`Configuration` is :strong:`debug-windows`, especially if you want to
+.. note::
+  The preferred :guilabel:`Configuration` is :strong:`debug-windows`, especially if you want to
   troubleshoot code with the built-in debugger and also if you plan to use the unit test feature ``CTest``.
 
-.. note:: The first time you run the Configure Cache command (from
-  :menuselection:`Project --> Configure Cache`) or ask Visual Studio to generate the C++ Intellisense data,
-  Visual Studio will invoke the :file:`vcpkg` installation process to download and compile all of the project
-  dependencies listed in the manifest file: :file:`vcpkg.json`. :strong:`This will take a very long time`. On
-  a fast computer with a good Internet connection it will take at least 3 hours to complete. Everything will
-  be downloaded and compiled into the :file:`C:\\Tools\\vcpkg` directory, or wherever you configured
-  :file:`vcpkg` earlier. Binaries for the packages will be copied into the :file:`./build-vs/` directory
-  inside of the main Freeciv21 directory and reused for subsequent builds.
+.. note::
+  The first time you run the Configure Cache command (from :menuselection:`Project --> Configure Cache`) or
+  ask Visual Studio to generate the C++ Intellisense data, Visual Studio will invoke the :file:`vcpkg`
+  installation process to download and compile all of the project dependencies listed in the manifest file:
+  :file:`vcpkg.json`. :strong:`This will take a very long time`. On a fast computer with a good Internet
+  connection it will take at least 3 hours to complete. Everything will be downloaded and compiled into the
+  :file:`C:\\Tools\\vcpkg` directory, or wherever you configured :file:`vcpkg` earlier. Binaries for the
+  packages will be copied into the :file:`./build-vs/` directory inside of the main Freeciv21 directory and
+  reused for subsequent builds.
 
-.. attention:: As documented in :doc:`/Getting/compile`, there is a :file:`--target package` option
-  available to build an installable package for Windows. This is only available to the MSYS2 environment. This
-  does not mean that you can not test an install using Visual Studio. After going to
-  :menuselection:`Build --> install Freeciv21` you can still manually start up the client or a server as
-  needed to debug. To do this you will start up either the client, the server, or both and then in Visual
-  Studio go to :menuselection:`Debug --> Attach to Process`
+.. attention::
+  As documented in :doc:`/Getting/compile`, there is a :file:`--target package` option available to build an
+  installable package for Windows. This is only available to the MSYS2 environment. This does not mean that
+  you can not test an install using Visual Studio. After going to :menuselection:`Build --> install Freeciv21`
+  you can still manually start up the client or a server as needed to debug. To do this you will start up
+  either the client, the server, or both and then in Visual Studio go to
+  :menuselection:`Debug --> Attach to Process`.
 
 :strong:`Notes about Clang-Cl vs MSVC`
 
@@ -259,5 +268,3 @@ location to be a sub-directory of the :file:`build-vs` directory for use during 
 purposes. This is the same as selecting the :file:`windows-debug` preset configuration. The second and third
 command then "builds" and "installs" the configured code solution. You will need to manually start the client
 and/or server to test.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/Contributing/workarounds.rst
+++ b/docs/Contributing/workarounds.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Workarounds
 ***********
 

--- a/docs/Getting/about.rst
+++ b/docs/Getting/about.rst
@@ -3,12 +3,6 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
 About Freeciv21
 ***************
 
@@ -21,8 +15,6 @@ About Freeciv21
 
   Freeciv21 Overview
 
-
-|
 
 .. The top level description is also in README.md, freeciv21-server.rst, the 4 metainfo files, and snapcraft.yaml.
 
@@ -52,4 +44,5 @@ empire, but any of these four items may provide victory over your opponents:
 * If playing a multiplayer game with only humans, victory can be declared based on diplomatic factors and
   other pre-set game rules.
 
-.. note:: Spacerace Victory is set by the ruleset and thereby may not be not enabled for all games.
+.. note::
+  Spacerace Victory is set by the ruleset and thereby may not be not enabled for all games.

--- a/docs/Getting/compile.rst
+++ b/docs/Getting/compile.rst
@@ -4,6 +4,7 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: Tobias Rehbein <tobias.rehbein@web.de>
 
+.. include:: /global-include.rst
 
 Compiling Freeciv21
 *******************
@@ -257,11 +258,12 @@ reading in the `Other CMake Notes`_ section below for more notes about other com
   $ cmake . -B build -G Ninja
 
 
-.. note:: If you are compiling on Windows MSYS2, alter the above command to add
+.. note::
+  If you are compiling on Windows MSYS2, alter the above command to add
 
-   ``-DCMAKE_INSTALL_PREFIX=$PWD/build/install``
+  ``-DCMAKE_INSTALL_PREFIX=$PWD/build/install``
 
-   at the end.
+  at the end.
 
 On macOS, you need to use a preset that is defined in the :file:`CMakePresets.json` file. When complete
 you can go to the `Compiling/Building`_ section below to continue.
@@ -299,16 +301,18 @@ Once the compilation is complete, install the game with this command.
   $ cmake --build build --target install
 
 
-.. note:: If you did not change the default install prefix, you will need to elevate privileges
-    with :file:`sudo`.
+.. note::
+  If you did not change the default install prefix, you will need to elevate privileges with :file:`sudo`.
+
 
 .. tip::
-    If you want to enable menu integration for the installed copy of Freeciv21, you will want to copy the
-    :literal:`.desktop` files in :file:`$CMAKE_INSTALL_PREFIX/share/applications` to
-    :file:`$HOME/.local/share/applications`.
+  If you want to enable menu integration for the installed copy of Freeciv21, you will want to copy the
+  :literal:`.desktop` files in :file:`$CMAKE_INSTALL_PREFIX/share/applications` to
+  :file:`$HOME/.local/share/applications`.
 
-    This is only necessary if you change the installation prefix. If you do not and use elevated privileges,
-    then the files get copied to the system default location.
+  This is only necessary if you change the installation prefix. If you do not and use elevated privileges,
+  then the files get copied to the system default location.
+
 
 At this point, the compilation and installation process is complete. The following sections document other
 aspects of the packaging and documentation generation process.
@@ -430,6 +434,3 @@ A very common Debian Linux configuration command looks like this:
 .. code-block:: sh
 
   $ cmake . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PWD/build/install
-
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/Getting/index.rst
+++ b/docs/Getting/index.rst
@@ -2,7 +2,6 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-
 Getting
 *******
 

--- a/docs/Getting/install.rst
+++ b/docs/Getting/install.rst
@@ -3,6 +3,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
 
 Installing Freeciv21
 ********************
@@ -34,5 +35,3 @@ macOS
 
 To install the macOS ``.dmg`` package, you start by double-clicking the file to mount it in Finder. Drag the
 game to your Applications folder, or a place of your choosing.  When finished, unmount the package.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/Getting/windows-install.rst
+++ b/docs/Getting/windows-install.rst
@@ -1,6 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
 
 Windows Installation
 ********************
@@ -185,5 +186,3 @@ uncheck the box before clicking :guilabel:`Finish` to complete the installation.
 
 You will find an icon for the client on the Desktop or in the Start Menu at
 :menuselection:`Start Menu --> Freeciv21 --> Freeciv21 Client`.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/Manuals/Advanced/fc21-uri.rst
+++ b/docs/Manuals/Advanced/fc21-uri.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Launching the Game with fc21 Links
 **********************************
 

--- a/docs/Manuals/Advanced/index.rst
+++ b/docs/Manuals/Advanced/index.rst
@@ -1,6 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
 
 Advanced Game Topics
 ********************

--- a/docs/Manuals/Advanced/map-generator.rst
+++ b/docs/Manuals/Advanced/map-generator.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Controlling the Map Generator
 *****************************
 
@@ -42,16 +44,16 @@ the options that are least impacting to the overall map.
 
 These options change the makeup of tiles and not the map itself:
 
-* ``alltemperate`` -- When ``enabled``, all tiles have a similar temperature. Players will all have similar
+* ``alltemperate`` --- When ``enabled``, all tiles have a similar temperature. Players will all have similar
   tiles to work. Set to ``disabled`` if you want to control with the ``temperature`` and ``wetness`` options.
-* ``huts`` -- How many huts you want on the map. Longturn games typically have ``0`` huts.
-* ``specials`` -- How many specials (tile resources) you want on the map.
-* ``steepness`` -- Bigger numbers produce hilly and mountainous terrain, lower numbers do not.
-* ``temperature`` -- You can create a hot or cold world with this option.
-* ``tinyisles`` -- Set to ``enabled`` if you want small single-tile (1x1) islands on the map.
-* ``wetness`` -- This option allows you to create a dry or wet map. Lower numbers are dry, higher numbers are
+* ``huts`` --- How many huts you want on the map. Longturn games typically have ``0`` huts.
+* ``specials`` --- How many specials (tile resources) you want on the map.
+* ``steepness`` --- Bigger numbers produce hilly and mountainous terrain, lower numbers do not.
+* ``temperature`` --- You can create a hot or cold world with this option.
+* ``tinyisles`` --- Set to ``enabled`` if you want small single-tile (1x1) islands on the map.
+* ``wetness`` --- This option allows you to create a dry or wet map. Lower numbers are dry, higher numbers are
   wet.
-* ``revealmap`` -- This setting is used to reveal the whole map at game start. Good to use for testing, but
+* ``revealmap`` --- This setting is used to reveal the whole map at game start. Good to use for testing, but
   not for real games.
 
 
@@ -64,11 +66,11 @@ map that you can work and navigate around.
 
 The settings that define the poles and base topology are:
 
-* ``flatpoles`` -- A low setting (``0``) will give poles with water and a high (``100``) will fill in with
+* ``flatpoles`` --- A low setting (``0``) will give poles with water and a high (``100``) will fill in with
   mostly glacier tiles on the poles.
-* ``separatepoles`` -- When ``enabled`` will break poles up and when ``disabled`` will keep them together.
-* ``singlepole`` -- When ``enabled`` will allow for a single pole and when ``disabled`` will give two poles.
-* ``topology`` -- Sets the wrap (``X``, ``Y``), the orientation (isometric or overhead) and the tile type
+* ``separatepoles`` --- When ``enabled`` will break poles up and when ``disabled`` will keep them together.
+* ``singlepole`` --- When ``enabled`` will allow for a single pole and when ``disabled`` will give two poles.
+* ``topology`` --- Sets the wrap (``X``, ``Y``), the orientation (isometric or overhead) and the tile type
   (squares vs hexes).
 
 :strong:`Recipe: Blocking poles on the map`
@@ -123,11 +125,11 @@ The overall size of the map (total number of X and Y tiles) is driven by a colle
 
 The ``mapsize`` option is the driver and has three possible configurations:
 
-#. ``FULLSIZE`` -- When used, you must also have the ``size`` option set. The value is simply a number (in
+#. ``FULLSIZE`` --- When used, you must also have the ``size`` option set. The value is simply a number (in
    thousands) of tiles.
-#. ``PLAYER`` -- When used, you must also have the ``tilesperplayer`` option set. The map generator will take
+#. ``PLAYER`` --- When used, you must also have the ``tilesperplayer`` option set. The map generator will take
    this into account and try its best to give each player a similar number of tiles to settle.
-#. ``XYSIZE`` -- When used, you must also have the ``xsize`` and ``ysize`` options set. These values are
+#. ``XYSIZE`` --- When used, you must also have the ``xsize`` and ``ysize`` options set. These values are
    similar to the ``size`` option. Give the map generator very specific number of tiles on the two axis.
 
 No recipes here. As a game master, you can figure out how big or small you want your map. Longturn games use
@@ -160,27 +162,27 @@ We will get to some recipes in a bit, but before we do that, let us talk about t
 
 First up, ``generator`` has the following configurations:
 
-* ``SCENARIO`` -- This configuration is for Scenario games only. This is a special use case.
-* ``RANDOM`` -- The default. As the name implies, there is a dependency on the built-in Random Number
+* ``SCENARIO`` --- This configuration is for Scenario games only. This is a special use case.
+* ``RANDOM`` --- The default. As the name implies, there is a dependency on the built-in Random Number
   Generator (RNG) in the server. The generator will attempt to create equally spaced, relatively small
   islands. Player placement will be impacted by the ``landmass`` option. The larger the value the bigger the
   continents/islands. This option is also impacted by the ``mapsize`` option. Best to use the ``FULLSIZE`` or
   the ``XYSIZE`` configuration.
-* ``FRACTAL`` -- This is the setting most Longturn games use. This configuration will create earth-like maps.
+* ``FRACTAL`` --- This is the setting most Longturn games use. This configuration will create earth-like maps.
   By default, all players are placed on the same continent. The ``landmass`` option can also impact placement.
-* ``ISLAND`` -- Each player is placed on their own island. Each island is similar in size, but not shape.
-* ``FAIR`` -- Every player gets the exact same island.
-* ``FRACTURE`` -- Similar to ``FRACTAL``, however this configuration often places mountains on the coasts.
+* ``ISLAND`` --- Each player is placed on their own island. Each island is similar in size, but not shape.
+* ``FAIR`` --- Every player gets the exact same island.
+* ``FRACTURE`` --- Similar to ``FRACTAL``, however this configuration often places mountains on the coasts.
 
 Now let us discuss ``startpos``, which has the following configurations:
 
-* ``DEFAULT`` -- The default. This configuration uses the ``generator`` configuration to place players.
-* ``SINGLE`` -- One player per island/continent.
-* ``2or3`` -- As the configuration name implies, the ``startpos`` will place 2 or 3 players together on an
+* ``DEFAULT`` --- The default. This configuration uses the ``generator`` configuration to place players.
+* ``SINGLE`` --- One player per island/continent.
+* ``2or3`` --- As the configuration name implies, the ``startpos`` will place 2 or 3 players together on an
   island/continent.
-* ``ALL`` -- Everyone is placed on the same continent. Make sure you give enough tiles when using this
+* ``ALL`` --- Everyone is placed on the same continent. Make sure you give enough tiles when using this
   configuration. The ``landmass`` and ``tilesperplayer`` will come in handy.
-* ``VARIABLE`` -- The server will use the RNG to give a bit of randomness to player placement. The size of the
+* ``VARIABLE`` --- The server will use the RNG to give a bit of randomness to player placement. The size of the
   continents will be taken into account.
 
 :strong:`Recipe: Large Pangea-like world`
@@ -214,12 +216,12 @@ correct when teams are involved is quite important!
 
 The ``teamplacement`` option has the following configurations:
 
-* ``DISABLED`` -- If set, then the option configuration is ignored.
-* ``CLOSEST`` -- The default. The name implies what happens.
-* ``CONTINENT`` -- Everyone on the same continent. This requires tuning ``landmass``, ``generator``, and
+* ``DISABLED`` --- If set, then the option configuration is ignored.
+* ``CLOSEST`` --- The default. The name implies what happens.
+* ``CONTINENT`` --- Everyone on the same continent. This requires tuning ``landmass``, ``generator``, and
   ``startpos`` to fit how you want the teams to get placed on the same continent.
-* ``HORIZONTAL`` -- Place team players in a East-West alignment.
-* ``VERTICAL`` -- Place team players in a North-South alignment.
+* ``HORIZONTAL`` --- Place team players in a East-West alignment.
+* ``VERTICAL`` --- Place team players in a North-South alignment.
 
 :strong:`Recipe: Two team game with each team on their own continent`
 

--- a/docs/Manuals/Advanced/players.rst
+++ b/docs/Manuals/Advanced/players.rst
@@ -1,6 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
 
 Advanced Player Setup
 *********************

--- a/docs/Manuals/Game/city-dialog.rst
+++ b/docs/Manuals/Game/city-dialog.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 City Dialog
 ***********

--- a/docs/Manuals/Game/intro.rst
+++ b/docs/Manuals/Game/intro.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Main Game Interface
 *******************

--- a/docs/Manuals/Game/menu.rst
+++ b/docs/Manuals/Game/menu.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Menu Bar
 ********
@@ -589,7 +584,7 @@ The :guilabel:`Civilization` menu is used to gain access to many functions of yo
 pages for units, cities, nations, etc; change the form of government and see how you are doing compared to
 your opponents with the demographics report. It has the following options:
 
-National Budget...
+National Budget
     Selecting this menu item will bring up a dialog box allowing you to set the rate in percentage points for
     gold (taxes), science (bulbs), and luxury (goods). This is the same as clicking on the
     :ref:`National Budget View <game-manual-national-budget-view>` button on the :doc:`top-bar`.

--- a/docs/Manuals/Game/message-options.rst
+++ b/docs/Manuals/Game/message-options.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Game Message Options
 ********************

--- a/docs/Manuals/Game/mini-map.rst
+++ b/docs/Manuals/Game/mini-map.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Minimap
 *******

--- a/docs/Manuals/Game/shortcut-options.rst
+++ b/docs/Manuals/Game/shortcut-options.rst
@@ -2,12 +2,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Tobias Rehbein <tobias.rehbein@web.de>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Game Shortcut Options
 *********************

--- a/docs/Manuals/Game/start-screen.rst
+++ b/docs/Manuals/Game/start-screen.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Starting the Game
 *****************

--- a/docs/Manuals/Game/top-bar.rst
+++ b/docs/Manuals/Game/top-bar.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Top Function Bar
 ****************

--- a/docs/Manuals/Game/unit-controls.rst
+++ b/docs/Manuals/Game/unit-controls.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Unit Controls
 *************
@@ -28,8 +23,8 @@ that has been selected.
 
 
 You can see that the :unit:`Workers` is selected because it has a white selection ring around its base.
-Looking at the dialog, in the header, you can see that this unit is ID # 111, has 4 3/9 Move Points (MPs), and
-10 of 10 Hit Points (HPs).
+Looking at the dialog, in the header, you can see that this unit is ID # 111, has :math:`4^3/_9` Move Points
+(:term:`MP`), and 10 of 10 Hit Points (:term:`HP`).
 
 From left to right you can see an image of the unit with MPs overlaid, the terrain it is on with
 infrastructure improvements shown, and then the actions that this unit can take. In this example the actions

--- a/docs/Manuals/Rulesets/Common/building_flags.rst
+++ b/docs/Manuals/Rulesets/Common/building_flags.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Building Flags
 **************

--- a/docs/Manuals/Rulesets/Common/tech_adv_flags.rst
+++ b/docs/Manuals/Rulesets/Common/tech_adv_flags.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Technology Advance Flags
 ************************

--- a/docs/Manuals/Rulesets/Common/unit_class_flags.rst
+++ b/docs/Manuals/Rulesets/Common/unit_class_flags.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Unit Class Flags
 ****************

--- a/docs/Manuals/Rulesets/Common/unit_type_flags.rst
+++ b/docs/Manuals/Rulesets/Common/unit_type_flags.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Unit Type Flags
 ***************

--- a/docs/Manuals/Rulesets/Common/unit_type_roles.rst
+++ b/docs/Manuals/Rulesets/Common/unit_type_roles.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Unit Type Role Flags
 ********************

--- a/docs/Manuals/Server/command-line.rst
+++ b/docs/Manuals/Server/command-line.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Server Command Line Options
 ***************************
 

--- a/docs/Manuals/Server/commands.rst
+++ b/docs/Manuals/Server/commands.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Server Commands
 ***************
 
@@ -500,10 +502,6 @@ server's own command-line. This server command-line is separate from the OS term
     "turns=<turns>", "(1)", "save image each <turns> turns (0=no autosave, save with create)"
     "zoom=<zoom>", "(2)", "magnification factor (1-5)"
     "map=<map>", "(bcku)", "which map layers to draw"
-
-  .. raw:: html
-
-        <p>&nbsp;</p>
 
   ``<format> =`` use image format ``<format>``. The ``png`` format is always supported.
 

--- a/docs/Manuals/Server/fcdb.rst
+++ b/docs/Manuals/Server/fcdb.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Authentication and Database Support (fcdb)
 ******************************************
 

--- a/docs/Manuals/Server/index.rst
+++ b/docs/Manuals/Server/index.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Server Manual
 *************
 

--- a/docs/Manuals/Server/intro.rst
+++ b/docs/Manuals/Server/intro.rst
@@ -2,6 +2,7 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
 
 Server Introduction
 *******************

--- a/docs/Manuals/Server/maths.rst
+++ b/docs/Manuals/Server/maths.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Formulas
 ********
 

--- a/docs/Manuals/Server/options.rst
+++ b/docs/Manuals/Server/options.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Server Options
 **************
@@ -1114,6 +1109,8 @@ To place a setting value on any of these settings use the ``/set <option-name> <
 
   :strong:`Description`: Turn-blocking game play mode. If this is turned on, the game turn is not advanced
   until all players have finished their turn, including disconnected players.
+
+.. _server-option-unitwaittime:
 
 ``unitwaittime``
   :strong:`Default Value (Min, Max)`: 0 (0, 8639999)

--- a/docs/Manuals/Server/settings-file.rst
+++ b/docs/Manuals/Server/settings-file.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Server Settings File
 ********************
 

--- a/docs/Manuals/modpack-installer.rst
+++ b/docs/Manuals/modpack-installer.rst
@@ -3,6 +3,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
 
 Using the Modpack Installer Utility
 ***********************************

--- a/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
+++ b/docs/Modding/Rulesets/Effects/Nation_Intelligence.rst
@@ -2,9 +2,7 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: wonder
-
+.. include:: /global-include.rst
 
 Nation_Intelligence
 *******************

--- a/docs/Modding/Rulesets/achievements.rst
+++ b/docs/Modding/Rulesets/achievements.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Achievements
 ************
 

--- a/docs/Modding/Rulesets/actions.rst
+++ b/docs/Modding/Rulesets/actions.rst
@@ -2,12 +2,7 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Actions
 *******

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -3,8 +3,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: improvement
+.. include:: /global-include.rst
 
 Effects
 *******
@@ -1085,7 +1084,7 @@ Wonder_Visible
 
 Nation_Intelligence
     Controls the information available in the :ref:`Nations View <game-manual-nations-and-diplomacy-view>`.
-    :doc:`See the detailed description. <Effects/Nation_Intelligence>`
+    See the :doc:`detailed description. <Effects/Nation_Intelligence>`
 
     .. toctree::
         :hidden:

--- a/docs/Modding/Rulesets/nations.rst
+++ b/docs/Modding/Rulesets/nations.rst
@@ -3,6 +3,8 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Nation Sets and Flags
 *********************
 

--- a/docs/Modding/Rulesets/overview.rst
+++ b/docs/Modding/Rulesets/overview.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Rulesets Overview
 *****************
 

--- a/docs/Modding/Tilesets/Tutorial/01_intro.rst
+++ b/docs/Modding/Tilesets/Tutorial/01_intro.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier:  GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 First steps
 ***********
 

--- a/docs/Modding/Tilesets/Tutorial/02_units.rst
+++ b/docs/Modding/Tilesets/Tutorial/02_units.rst
@@ -1,12 +1,7 @@
 .. SPDX-License-Identifier:  GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Adding units
 ************

--- a/docs/Modding/Tilesets/compatibility.rst
+++ b/docs/Modding/Tilesets/compatibility.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier:  GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Tileset Compatibility
 *********************
 

--- a/docs/Modding/Tilesets/debugger.rst
+++ b/docs/Modding/Tilesets/debugger.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier:  GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Tileset Debugger
 ================
 

--- a/docs/Modding/Tilesets/graphics.rst
+++ b/docs/Modding/Tilesets/graphics.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Tile Specification Files
 ************************
 

--- a/docs/Modding/Tilesets/options.rst
+++ b/docs/Modding/Tilesets/options.rst
@@ -1,7 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. role:: unit
+.. include:: /global-include.rst
 
 Tileset Options
 ***************

--- a/docs/Modding/Tilesets/terrain.rst
+++ b/docs/Modding/Tilesets/terrain.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv contributors
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Terrain
 *******
 
@@ -35,31 +37,32 @@ in the matching. The table below summarizes the naming scheme; available options
 the corresponding sections.
 
 .. _terrain-matching-groups:
-.. table:: Terrain Matching Groups
+.. list-table:: Terrain Matching Groups
   :widths: auto
   :align: left
+  :header-rows: 1
 
-  +--------------------------------+--------------------------------+--------------------------------+--------------------------------------+
-  | Matched groups                 | ``single``                     | ``corner``                     | ``hex_corner``                       |
-  +================================+================================+================================+======================================+
-  | None                           | ``t.l0.grassland1``            | Avoid                          | Avoid                                |
-  |                                | (:ref:`doc <single-simple>`)   | (:ref:`doc <corner-simple>`)   |                                      |
-  +--------------------------------+--------------------------------+--------------------------------+--------------------------------------+
-  | One, same as ``match_type``    | ``t.l1.hills_n0e1s0w1``        | ``t.l0.floor_cell_u011``       | ``t.l0.floor_hex_cell_right_0_1_0``, |
-  |                                | (:ref:`doc <single-match>`)    | (:ref:`doc <corner-same>`)     | ``t.l0.floor_hex_cell_left_1_0_0``   |
-  |                                |                                |                                | (:ref:`doc <hex_corner-same>`)       |
-  +--------------------------------+--------------------------------+--------------------------------+--------------------------------------+
-  | One, different from            | Not implemented                | ``t.l1.coast_cell_u_g_g_g``    | Not implemented                      |
-  | ``match_type``                 |                                | (:ref:`doc <corner-pair>`)     |                                      |
-  +--------------------------------+                                +--------------------------------+--------------------------------------+
-  | Two or more                    |                                | ``t.l0.cellgroup_g_g_g_g``     | ``t.l0.hex_cell_right_g_g_g``,       |
-  |                                |                                | (:ref:`doc <corner-general>`)  | ``t.l0.hex_cell_left_g_g_g``         |
-  |                                |                                |                                | (:ref:`doc <hex_corner-general>`)    |
-  +--------------------------------+--------------------------------+--------------------------------+--------------------------------------+
+  * - Matched groups
+    - ``single``
+    - ``corner``
+    - ``hex_corner``
+  * - None
+    - ``t.l0.grassland1`` (:ref:`doc <single-simple>`)
+    - Avoid (:ref:`doc <corner-simple>`)
+    - Avoid
+  * - One, same as ``match_type``
+    - ``t.l1.hills_n0e1s0w1`` (:ref:`doc <single-match>`)
+    - ``t.l0.floor_cell_u011`` (:ref:`doc <corner-same>`)
+    - ``t.l0.floor_hex_cell_right_0_1_0``, ``t.l0.floor_hex_cell_left_1_0_0`` (:ref:`doc <hex_corner-same>`)
+  * - One, different from ``match_type``
+    - Not implemented
+    - ``t.l1.coast_cell_u_g_g_g`` (:ref:`doc <corner-pair>`)
+    - Not implemented
+  * - Two or more
+    - Not implemented
+    - ``t.l0.cellgroup_g_g_g_g`` (:ref:`doc <corner-general>`)
+    - ``t.l0.hex_cell_right_g_g_g``, ``t.l0.hex_cell_left_g_g_g`` (:ref:`doc <hex_corner-general>`)
 
-.. raw:: html
-
-    <p>&nbsp;</p>
 
 Sprite type ``single``
 ----------------------

--- a/docs/Modding/Tilesets/ts-breaking-changes.rst
+++ b/docs/Modding/Tilesets/ts-breaking-changes.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Tileset Breaking Changes
 ************************
 

--- a/docs/Modding/Tilesets/tutorial.rst
+++ b/docs/Modding/Tilesets/tutorial.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Tileset tutorial
 ****************
 

--- a/docs/Modding/Tilesets/units.rst
+++ b/docs/Modding/Tilesets/units.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv contributors
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
+
 Units
 *****
 

--- a/docs/Modding/index.rst
+++ b/docs/Modding/index.rst
@@ -2,6 +2,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+.. include:: /global-include.rst
 
 Modding
 *******

--- a/docs/Modding/modpack-installer.rst
+++ b/docs/Modding/modpack-installer.rst
@@ -1,6 +1,8 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: David Koníř <david.konir@gmail.com>
 
+.. include:: /global-include.rst
+
 Serving Modpacks for the Modpack Installer
 ******************************************
 

--- a/docs/Modding/musicsets.rst
+++ b/docs/Modding/musicsets.rst
@@ -2,12 +2,7 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 Musicsets Overview
 ******************

--- a/docs/Modding/scenarios.rst
+++ b/docs/Modding/scenarios.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Scenarios Overview
 ******************
 

--- a/docs/Modding/sound.rst
+++ b/docs/Modding/sound.rst
@@ -2,6 +2,8 @@
 .. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
+.. include:: /global-include.rst
+
 Sound Support
 *************
 

--- a/docs/Playing/LT-Guide/final-notes.rst
+++ b/docs/Playing/LT-Guide/final-notes.rst
@@ -1,11 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Final Notes + Victory Declaration
 *********************************
@@ -24,11 +20,11 @@ turn change cycle of 25h.
 We used to use an old Forum site (https://forum.longturn.net/), but have moved away from it in favor of
 Discord.
 
-As a final conclusion – remember, :strong:`this is a game` and the Longturn Community values good
+As a final conclusion –-- remember, :strong:`this is a game` and the Longturn Community values good
 sportsmanship as much as we do anything else. Have a good time, play to win, lose with grace, and make some
 friends.
 
 See you next game!
 
-Regards
-The Longturn Game Admins - Wieder_Fi, Louis94, Panch93, TriClad, Kryon, Corbeau, and Jwrober
+Regards, The Longturn Game Admins:
+  Wieder_Fi, Louis94, Panch93, TriClad, Kryon, Corbeau, and Jwrober

--- a/docs/Playing/LT-Guide/first-turn.rst
+++ b/docs/Playing/LT-Guide/first-turn.rst
@@ -1,11 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 The First Turn
 **************
@@ -17,8 +13,8 @@ important.
 
 .. note::
   If you have not played a game in some time or if this is a first time to play, be sure to explore the
-  in-game help. There is very important information in there. Refer to it often as you progress through the
-  game. You may also some some additional insight by reading the
+  in-game help from the :menuselection:`help` menu. There is very important information in there. Refer to it
+  often as you progress through the game. You may also some some additional insight by reading the
   :ref:`other tutorials <lt-game-guide-other-tutorials>`.
 
 
@@ -71,18 +67,19 @@ to get you started:
     building the :improvement:`Aqueduct+River` improvement.
 
 * Remember that your first city will be your capital. Do not put it on the coast! To change the capital city
-  from one city to another you have to build the :wonder:`Palace` small wonder in the new city, which is A)
+  from one city to another you have to build the :wonder:`Palace` Small Wonder in the new city, which is A)
   expensive and B) costly in time, so plan accordingly.
 
-* Look for specials like wheat, pheasant, and silk. Wheat helps to grow a city like wildfire (+4 food with
+* Look for specials like Wheat, Pheasant, and Silk. Wheat helps to grow a city like wildfire (+4 food with
   Irrigation and :wonder:`Pyramids` or :advance:`Monarchy`). In not too much time you can have a city getting
-  +20 food per turn, which means your city will grow once per turn after size 4 with a :improvement:`Granary`.
+  :math:`+20` food per turn, which means your city will grow once per turn after size 4 with a
+  :improvement:`Granary`.
 
 * There is an important setting called :ref:`City Minimum Distance <server-option-citymindist>`. This setting
   defines how many tiles must be between city centers. See `City Planning`_ section below.
 
 * Once the first 5 cities are planted, you need to expand as fast as possible with more :unit:`Settlers`!
-  Refer to the **Settler Race** section below.
+  Refer to the :ref:`Settler Race <lt-guide-settler-race>` section below.
 
 .. _lt-guide-city-planning:
 
@@ -97,12 +94,12 @@ Some other thoughts related to initial city planning:
 * Using a tool such as Inkscape really helps you plan your cities. Recall that there are a number of factors
   to consider when it comes to city planning and placement:
 
-  * Distance from the Capital.
+  #. Distance from the Capital.
 
-  * Available specials on tiles around the potential city centers.
+  #. Available specials on tiles around the potential city centers.
 
-  * Locations of freshwater from rivers and lakes.
+  #. Locations of freshwater from rivers and lakes.
 
-  * No wasted tiles. Force overlap of any kind so that every tile is available.
+  #. No wasted tiles. Force overlap of any kind so that every tile is available.
 
 With everything in Longturn games: it is all about balance.

--- a/docs/Playing/LT-Guide/intro.rst
+++ b/docs/Playing/LT-Guide/intro.rst
@@ -1,18 +1,14 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Introduction
 ************
 
-The Longturn community maintains and plays three specialized rulesets: Longturn Traditional (LTT), Longturn
-Experimental (LTX), and Royale. The :term:`LTT` and :term:`LTX` rulesets are loosely based on the Civ2Civ3
-ruleset as it existed "way back" in legacy Freeciv v2.0 days. Royale is new as of 2023.
+The Longturn community maintains and plays three specialized rulesets: Longturn Traditional (:term:`LTT`),
+Longturn Experimental (:term:`LTX`), and Royale. The :term:`LTT` and :term:`LTX` rulesets are loosely based on
+the Civ2Civ3 ruleset as it existed "way back" in legacy Freeciv v2.0 days. Royale is new as of 2023.
 
 Here are some generalized notes related to the three rulesets:
 
@@ -23,18 +19,17 @@ Here are some generalized notes related to the three rulesets:
   evolution of :term:`LTT`.
 
   .. note::
-    LTT2 is considered the default stable ruleset. The League still plays LTT and will change to LTT2 when
-    appropriate.
+    :term:`LTT2` is considered the default stable ruleset. The League still plays :term:`LTT` and will change
+    to :term:`LTT2` when appropriate.
 
-* :strong:`LTX`: This is our experimental ruleset. LTX is based on LTT, so many of the play style elements in
-  LTT are similar in LTX. We use LTX as a test bed for new ideas. Ideas that gain traction and are well
-  received by our player community can be merged into LTT2.
+* :strong:`LTX`: This is our experimental ruleset. :term:`LTX` is based on :term:`LTT`, so many of the play
+  style elements in :term:`LTT` are similar in :term:`LTX`. We use :term:`LTX` as a test bed for new ideas.
+  Ideas that gain traction and are well received by our player community can be merged into :term:`LTT2`.
 
-* :strong:`Royale`: This is a newer ruleset that takes many thoughts from LTT and tries to create a simpler
-  set of rules for brand new Longturn players. The general idea is to create a set of rules that can be played
-  by experienced and new players, with enough slack that new players will not get overwhelmed if they make
-  game-play mistakes.
-
+* :strong:`Royale`: This is a newer ruleset that takes many thoughts from :term:`LTT` and tries to create a
+  simpler set of rules for brand new Longturn players. The general idea is to create a set of rules that can
+  be played by experienced and new players, with enough slack that new players will not get overwhelmed if
+  they make game-play mistakes.
 
 .. _lt-game-guide-other-tutorials:
 
@@ -47,9 +42,10 @@ Here are links to some other tutorials. Your mileage may vary with some of them.
 * `LTX on Freeciv Fandom <https://freeciv.fandom.com/wiki/LongTurn_Experimental_ruleset>`_
 * `Intro to Freeciv on Freeciv Fandom <https://freeciv.fandom.com/wiki/Introduction_to_Freeciv>`_
 * `Game Manual on Freeciv Fandom <https://freeciv.fandom.com/wiki/Game_Manual>`_. Overall game mechanics for
-  the Classic ruleset. LTT/LTX rulesets are similar and are derived from the Civ2Civ3 ruleset. Topics include:
-  Terrain, Cities, Economy, Units, Combat, Diplomacy, Government, Technology, Wonders, and Buildings. Gives a
-  good overview of how the varying elements of a game work if you are new to Freeciv or Freeciv21.
+  the Classic ruleset. :term:`LTT`/:term:`LTX` rulesets are similar and are derived from the Civ2Civ3 ruleset.
+  Topics include: Terrain, Cities, Economy, Units, Combat, Diplomacy, Government, Technology, Wonders, and
+  Buildings. Gives a good overview of how the varying elements of a game work if you are new to Freeciv or
+  Freeciv21.
 * `Multiplayer Game Manual on Freeciv Fandom <https://freeciv.fandom.com/wiki/Multiplayer_Game_Manual>`_.
 * `Multiplayer Ruleset (cheat-sheet) on Freeciv Fandom <https://freeciv.fandom.com/wiki/Multiplayer_Ruleset>`_.
 * `How to Play Freeciv on Freeciv Fandom <https://freeciv.fandom.com/wiki/How_to_Play>`_.

--- a/docs/Playing/LT-Guide/late-game.rst
+++ b/docs/Playing/LT-Guide/late-game.rst
@@ -1,11 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 The Late-Game Strategy
 ***********************
@@ -41,7 +37,7 @@ than size 16. Once you learn :advance:`Explosives`, you can either use gold to u
 :unit:`Engineers` or allow :wonder:`Leonardo’s Workshop` to do it for you. Every tile should be grassland by
 now (or at least the majority of them). Use :unit:`Engineers` to cut down Mountains and Hills (ones without a
 special on them). Use the :unit:`Engineers` to get rid of Desert tiles (ones without a special on them). This
-is the time of the game where the majority of your cities should be at +20 food and growing every turn.
+is the time of the game where the majority of your cities should be at :math:`+20` food and growing every turn.
 
 This is also a time in the game where pollution can cause Global Warming. In :term:`LTT` and :term:`LTX`
 games, Global Warming is very powerful and can wreak havoc on your growth plans. Keep tiles clear of pollution

--- a/docs/Playing/LT-Guide/mid-game.rst
+++ b/docs/Playing/LT-Guide/mid-game.rst
@@ -1,11 +1,7 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Turn 20+: Mid-Game Strategy
 ***************************
@@ -131,7 +127,7 @@ Mid-Game Military
 This is the point in the game where some fighting often happens. You are going to be bumping up against your
 neighbors, they might have more land than you at this point. Just like with the notes about military
 aggression for the early game, any involvement in military conflict is taking away from growth. As with all
-things “Longturn”, there are tradeoffs.
+things Longturn, there are tradeoffs.
 
 A few thoughts about aggression at this stage of the game:
 

--- a/docs/Playing/LT-Guide/twenty-turns.rst
+++ b/docs/Playing/LT-Guide/twenty-turns.rst
@@ -1,23 +1,19 @@
 .. SPDX-License-Identifier: GPL-3.0-or-later
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 The Next 20 Turns
 *****************
 
-The early game is one of expansion. In most Longturn Traditional (LTT) or Longturn Experimental (LTX)
-multiplayer rules-based games you do not need to worry so much about putting a defender(s) into your new
-cities right away. Start with :unit:`Workers` to develop the land and build roads between cities. The quicker
-you can upgrade the :unit:`Tribal Workers` to regular :unit:`Workers` is also important. The
+The early game is one of expansion. In most Longturn Traditional (:term:`LTT`) or Longturn Experimental
+(:term:`LTX`) multiplayer rules-based games you do not need to worry so much about putting a defender(s) into
+your new cities right away. Start with :unit:`Workers` to develop the land and build roads between cities. The
+quicker you can upgrade the :unit:`Tribal Workers` to regular :unit:`Workers` is also important. The
 :unit:`Tribal Workers` do not gain veteran status and actually have less “work points” than regular
 :unit:`Workers`. Refer to `Managing your Workforce`_ below for more information.
 
-.. note::
+.. note:
   Many early forms of government support martial law to help with happiness. This is definitely a place where
   some kind of military unit is very important. See `Early Government`_ section below.
 
@@ -39,7 +35,7 @@ This is a good opportunity to do two things:
    territory. This is the best way to A) not aggravate your neighbor and B) keep your :unit:`Explorers` alive.
 
 #. In the game, open the diplomacy screen via the “meet” button on the
-   :ref:`Nations view <game-manual-nations-and-diplomacy-view>` and ask to swap embassies. Many players will
+   :ref:`Nations View <game-manual-nations-and-diplomacy-view>` and ask to swap embassies. Many players will
    agree to the sharing of embassies as it gives important information that both sides can equally use. This
    is why it is important to do #1 first, so you have already started a dialog with your neighbor.
 
@@ -52,8 +48,8 @@ shared border, on a tile inside your border, to act as a sentry.
   :term:`LTT` and "War" for :term:`LTX` rulesets. When you meet a player and establish a contact embassy, you
   will automatically go into Armistice or War with that player.
 
-  This setting comes from the ``initial_diplomatic_state`` setting in the :file:`game.ruleset` ruleset file
-  and is not shown in game help.
+  This setting comes from the ``initial_diplomatic_state`` setting in the :file:`game.ruleset`
+  :ref:`ruleset file <modding-rulesets>` and is not shown in game help.
 
 
 Deciding on an Initial Strategy
@@ -73,79 +69,80 @@ For example Tribal has better production at the expense of science (bulbs) outpu
 
 This table provides a side-by-side comparison of Despotism vs Tribal for a complete picture.
 
-+-------------------------+----------------------------------------+----------------------------------------+
-| Area                    | Despotism                              | Tribal                                 |
-+=========================+========================================+========================================+
-| General                 | Your capital city gets a +75% bonus to | Each city gets 1 extra content         |
-|                         | gold production.                       | citizen.                               |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Veteran Chance          | No change from baseline chance.        | Increases by half the chance of land   |
-|                         |                                        | units getting the next veteran level   |
-|                         |                                        | after a battle.                        |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Unit Support            | Each city can **support up to 2 units  | Each city can **support up to 2 units  |
-|                         | for free**; further units each cost 1  | for free**; further units each cost 1  |
-|                         | **gold** per turn.                     | **shield** per turn.                   |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Aggression              | Unlike later governments, military     | Unlike later governments, military     |
-|                         | units do not cause unhappiness even    | units do not cause unhappiness even    |
-|                         | when deployed aggressively.            | when deployed aggressively.            |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Corruption              | Base **corruption is 20%**. This       | Base **corruption is 30%** (the        |
-|                         | increases with distance from the       | highest under any government). This    |
-|                         | capital (half as fast with             | increases with distance from the       |
-|                         | :advance:`The Corporation`).           | capital (half as fast with             |
-|                         |                                        | :advance:`The Corporation`).           |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Corruption Increase Per | 2%                                     | 2%                                     |
-| Tile Away from Capital  |                                        |                                        |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Waste                   | Base **production waste is 10%**. This | There is no base level of production   |
-|                         | increases with distance from the       | waste, but an increasing amount with   |
-|                         | capital (half as fast with             | distance from the capital (half as     |
-|                         | :advance:`Trade`).                     | fast with :advance:`Trade`).           |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Waste Increase Per Tile | 2%                                     | 2%                                     |
-| Away from Capital       |                                        |                                        |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Trade Loss              | Trade production will suffer some      | Trade production will suffer some      |
-|                         | losses.                                | losses.                                |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Production Loss         | Shield production will suffer a small  | None                                   |
-|                         | amount of losses.                      |                                        |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Unit Upkeep             | Each of your cities will avoid paying  | Each of your cities will avoid paying  |
-|                         | **2 Gold upkeep** for your units.      | **3 Shield upkeep** for your units.    |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Civil War Chance        | If you lose your capital, the chance   | If you lose your capital, the chance   |
-|                         | of **civil war is 40%**.               | of **civil war is 45%**.               |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Empire Size Penalty     | You can have up to 10 cities before an | You can have up to 12 cities before an |
-|                         | additional unhappy citizen appears in  | additional unhappy citizen appears in  |
-|                         | each city due to civilization size.    | each city due to civilization size.    |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Empire Size Penalty     | After the first unhappy citizen due to | After the first unhappy citizen due to |
-| Step                    | civilization size, for **each 10**     | civilization size, for **each 14**     |
-|                         | **additional cities** another unhappy  | **additional cities** another unhappy  |
-|                         | citizen will appear.                   | citizen will appear.                   |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Max Sci/Lux/Tax Rate    | The maximum rate you can set for       | The maximum rate you can set for       |
-|                         | science, gold, or luxuries is 60%.     | science, gold, or luxuries is 60%.     |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Martial Law Effect      | Your units may impose martial law.     | Your units may impose martial law.     |
-|                         | Each military unit inside a city will  | Each military unit inside a city will  |
-|                         | force **1 unhappy citizen** to become  | force **2 unhappy citizen** to become  |
-|                         | content.                               | content.                               |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Max Martial Law         | A **maximum of 20 units** in each      | A **maximum of 3 units** in each       |
-|                         | city can enforce martial law.          | city can enforce martial law.          |
-+-------------------------+----------------------------------------+----------------------------------------+
-| Despotism Penalty       | Each worked tile that gives more than  | Each worked tile that gives more than  |
-|                         | 2 Food, Shield, or Trade will suffer a | 2 Food, Shield, or Trade will suffer a |
-|                         | -1 penalty, unless the city working it | -1 penalty, unless the city working it |
-|                         | is celebrating. (Cities below size 3   | is celebrating. (Cities below size 3   |
-|                         | will not celebrate.)                   | will not celebrate.)                   |
-+-------------------------+----------------------------------------+----------------------------------------+
+.. list-table:: Despotism vs Tribal
+  :widths: 20 40 40
+  :header-rows: 1
+
+  * - Area
+    - Despotism
+    - Tribal
+  * - General
+    - Your capital city gets a +75% bonus to gold production.
+    - Each city gets 1 extra content citizen.
+  * - Veteran Chance
+    - No change from baseline chance.
+    - Increases by half the chance of land units getting the next veteran level after a battle.
+  * - Unit Support
+    - Each city can **support up to 2 units for free**; further units each cost 1 **gold** per turn.
+    - Each city can **support up to 2 units for free**; further units each cost 1 **shield** per turn.
+  * - Aggression
+    - Unlike later governments, military units do not cause unhappiness even when deployed aggressively.
+    - Unlike later governments, military units do not cause unhappiness even when deployed aggressively.
+  * - Corruption
+    - Base **corruption is 20%**. This increases with distance from the capital (half as fast with
+      :advance:`The Corporation`).
+    - Base **corruption is 30%** (the highest under any government). This increases with distance from the
+      capital (half as fast with :advance:`The Corporation`).
+  * - Corruption Increase Per Tile Away from Capital
+    - 2%
+    - 2%
+  * - Waste
+    - Base **production waste is 10%**. This increases with distance from the capital (half as fast with
+      :advance:`Trade`).
+    - There is no base level of production waste, but an increasing amount with distance from the capital
+      (half as fast with :advance:`Trade`).
+  * - Waste Increase Per Tile Away from Capital
+    - 2%
+    - 2%
+  * - Trade Loss
+    - Trade production will suffer some losses.
+    - Trade production will suffer some losses.
+  * - Production Loss
+    - Shield production will suffer a small amount of losses.
+    - **None**.
+  * - Unit Upkeep
+    - Each of your cities will avoid paying **2 Gold upkeep** for your units.
+    - Each of your cities will avoid paying **3 Shield upkeep** for your units.
+  * - Civil War Chance
+    - If you lose your capital, the chance of **civil war is 40%**.
+    - If you lose your capital, the chance of **civil war is 45%**.
+  * - Empire Size Penalty
+    - You can have up to **10 cities** before an additional unhappy citizen appears in each city due to
+      civilization size.
+    - You can have up to **12 cities** before an additional unhappy citizen appears in each city due to
+      civilization size.
+  * - Empire Size Penalty Step
+    - After the first unhappy citizen due to civilization size, for **each 10 additional cities** another
+      unhappy citizen will appear.
+    - After the first unhappy citizen due to civilization size, for **each 14 additional cities** another
+      unhappy citizen will appear.
+  * - Max Sci/Lux/Tax Rate
+    - The maximum rate you can set for Science, Gold, or Luxuries is 60%.
+    - The maximum rate you can set for Science, Gold, or Luxuries is 60%.
+  * - Martial Law Effect
+    - Your units may impose martial law. Each military unit inside a city will force **1 unhappy citizen** to
+      become content.
+    - Your units may impose martial law. Each military unit inside a city will force **2 unhappy citizens** to
+      become content.
+  * - Max Martial Law
+    - A **maximum of 20 units** in each city can enforce martial law.
+    - A **maximum of 3 units** in each city can enforce martial law.
+  * - Despotism Penalty
+    - Each worked tile that gives more than 2 Food, Shield, or Trade will suffer a -1 penalty, unless the city
+      working it is celebrating. (Cities below size 3 will not celebrate.)
+    - Each worked tile that gives more than 2 Food, Shield, or Trade will suffer a -1 penalty, unless the city
+      working it is celebrating. (Cities below size 3 will not celebrate.)
+
 
 The First Research Target
 -------------------------
@@ -188,6 +185,8 @@ take.
   players learn varying technologies they get cheaper for everyone else following a formula.
 
 
+.. _lt-guide-settler-race:
+
 The Settler Race
 ----------------
 
@@ -201,10 +200,9 @@ Here are some tips to keep in mind:
 * :unit:`Settlers` cost two citizen population, so a city must be size 3 to complete the production of one
   :unit:`Settlers`.
 
-* Production happens before growth during :doc:`/Playing/turn-change` cycle processing. This means that if
-  the city will grow to size 3 at :term:`TC` and also finish production of the :unit:`Settlers` at :term:`TC`,
-  the city will grow, but the :unit:`Settlers` **will not** be produced until the next :term:`TC` with some
-  shield waste.
+* Production happens before growth during :doc:`/Playing/turn-change`. This means that if the city will grow
+  to size 3 at :term:`TC` and also finish production of the :unit:`Settlers` at :term:`TC`, the city will
+  grow, but the :unit:`Settlers` **will not** be produced until the next :term:`TC` with some shield waste.
 
 * You can rush-buy :unit:`Settlers` with Gold. Many players will do this the same turn that the city grows to
   size 3 so the :unit:`Settlers` will be finished at :term:`TC`. This is a good approach to keep from running
@@ -227,7 +225,7 @@ Pumping Settlers
 The concept of "Settler Pumping" is probably not new to veteran players, however newer Longturn players may
 need some extra information. The idea is to push :unit:`Settlers` from every city. Nothing else is produced at
 this phase of the game. Produce them as quickly as possible taking into account growth and production rates.
-If needed store shields in more expensive units to allow a city to grow to size 3 and then change production.
+If needed, store shields in more expensive units to allow a city to grow to size 3 and then change production.
 
 Treat this aspect of the game similar to the United States "Manifest Destiny" period in the mid-19th century.
 You want to spam :unit:`Settlers` so you can grab as much land as possible.
@@ -249,117 +247,98 @@ player can build are very important to a successful civilization’s early growt
 
 This table provides some information on the important wonders before the :advance:`Gunpowder` age.
 
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| Tech  | Wonder          | Required                     | Benefits                       | Notes                           |
-| Tree  |                 | /                            |                                |                                 |
-| Level |                 | Obsolete                     |                                |                                 |
-+=======+=================+==============================+================================+=================================+
-| 1     | Ħal Saflieni    | :advance:`Ceremonial Burial` | The city having it will get +6 | Built in the city with best     |
-|       | Hypogeum        | /                            | additional luxury and will     | production as it's simply a +6  |
-|       |                 | :advance:`Bronze Working`    | celebrate after size 3.        | Lux adder and not based on city |
-|       |                 |                              |                                | size. The city will celebrate   |
-|       |                 |                              |                                | early by giving a small science |
-|       |                 |                              |                                | (bulbs) boost.                  |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 1     | Mausoleum of    | :advance:`Ceremonial Burial` | :improvement:`City Walls`      | :improvement:`Courthouses` are  |
-|       | Mausolos        | /                            | and :improvement:`Courthouses` | a **must** to reduce waste and  |
-|       |                 | :advance:`Republic`          | each make one unhappy citizen  | corruption.                     |
-|       |                 |                              | content.                       | :improvement:`City Walls` are   |
-|       |                 |                              |                                | very important for defense at   |
-|       |                 |                              |                                | all stages of the game, except  |
-|       |                 |                              |                                | the late game when the power of |
-|       |                 |                              |                                | the units makes them pretty     |
-|       |                 |                              |                                | much impossible to defend       |
-|       |                 |                              |                                | against.                        |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 1     | Hanging Gardens | :advance:`Pottery`           | Makes one unhappy citizen      | Good to put in a big city and   |
-|       |                 | /                            | content in every city. This    | really helps with empire size   |
-|       |                 | :advance:`Explosives`        | wonder also makes two content  | issues.                         |
-|       |                 |                              | citizens happy in the city     |                                 |
-|       |                 |                              | where it is located.           |                                 |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 1     | Colossus        | :advance:`Bronze Working`    | Each tile around the city      | :advance:`Bronze Working`       |
-|       |                 | /                            | where this wonder is built     | obsoletes the                   |
-|       |                 | :advance:`Invention`         | that is already generating     | :wonder:`Ħal Saflieni Hypogeum` |
-|       |                 |                              | some trade produces one extra  | , which is often built in your  |
-|       |                 |                              | trade resource.                | capital city. You will want to  |
-|       |                 |                              |                                | replace the                     |
-|       |                 |                              |                                | :wonder:`Ħal Saflieni Hypogeum` |
-|       |                 |                              |                                | with the :wonder:`Colossus` as  |
-|       |                 |                              |                                | soon as you can to continue to  |
-|       |                 |                              |                                | get the Trade (Luxury Goods)    |
-|       |                 |                              |                                | benefits. Depending on the size |
-|       |                 |                              |                                | of your capital, you may        |
-|       |                 |                              |                                | actually see a higher level of  |
-|       |                 |                              |                                | effect.                         |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 2     | Pyramids        | :advance:`Mathematics`       | Each tile produces +1 Shield,  | Building :wonder:`Pyramids` is  |
-|       |                 | /                            | eliminates the Despotism       | a **must** as soon as possible, |
-|       |                 | :advance:`Railroad`          | penalty.                       | especially if you do not plan   |
-|       |                 |                              |                                | to go straight to Monarchy. It  |
-|       |                 |                              |                                | is possible to have             |
-|       |                 |                              |                                | :wonder:`Pyramids` by T15.      |
-|       |                 |                              |                                | Build it in the highest         |
-|       |                 |                              |                                | production city.                |
-|       |                 |                              |                                | :wonder:`Pyramids` are also     |
-|       |                 |                              |                                | important when you are in       |
-|       |                 |                              |                                | Anarchy switching to another    |
-|       |                 |                              |                                | form of government (Republic,   |
-|       |                 |                              |                                | Democracy, or Federation) so    |
-|       |                 |                              |                                | you do not suffer the Despotism |
-|       |                 |                              |                                | penalty.                        |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 2     | Temple of       | :advance:`Mysticism`         | Makes 2 additional unhappy     | :improvement:`Temples` are a    |
-|       | Artemis         | /                            | citizens content in every city | **must** before Republic or     |
-|       |                 | :advance:`Theology`          | with a :improvement:`Temple`.  | Democracy. This wonder will     |
-|       |                 |                              |                                | help your cities to celebrate   |
-|       |                 |                              |                                | when the time is right.         |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 2     | Statue of Zeus  | :advance:`Polytheism`        | Eliminates 1 unhappy citizen   | Citizen happiness is an         |
-|       |                 | /                            | due to military units abroad,  | important aspect of the early   |
-|       |                 | :advance:`Gunpowder`         | plus each city also avoids one | game. This wonder continues to  |
-|       |                 |                              | shield of upkeep for units.    | keep all your citizens happy as |
-|       |                 |                              |                                | cities grow in size. The second |
-|       |                 |                              |                                | aspect (shield upkeep) is huge  |
-|       |                 |                              |                                | if you are Tribal and/or        |
-|       |                 |                              |                                | Republic.                       |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 3     | Copernicus'     | :advance:`Astronomy`         | Each tile worked by the city   | Another good one for a big city |
-|       | Observatory     | /                            | where this wonder is built     | to get a boost to science       |
-|       |                 | :advance:`University`        | produces one extra research    | (bulb) output.                  |
-|       |                 |                              | point.                         |                                 |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 4     | Sun Tzu's War   | :advance:`Feudalism`         | All your new military land     | This means that with a          |
-|       | Academy         | /                            | units start with an additional | :improvement:`Barracks` in the  |
-|       |                 | :advance:`Metallurgy`        | veteran level.                 | city, all your units will be    |
-|       |                 |                              |                                | Veteran 2 (175%) right away     |
-|       |                 |                              |                                | after production.               |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 5     | King Richard's  | :advance:`Chivalry`          | Reduces the unhappiness caused | The primary benefit of this     |
-|       | Crusade         | /                            | by aggressively deployed       | wonder is the reduction of gold |
-|       |                 | :advance:`Navigation`        | military units owned by the    | upkeep for military units. With |
-|       |                 |                              | city by 1. Under governments   | Monarchy, unit upkeep is in     |
-|       |                 |                              | where unit upkeep is paid in   | Gold. This wonder helps your    |
-|       |                 |                              | gold, it gives two free gold   | treasury greatly.               |
-|       |                 |                              | per city towards upkeep every  |                                 |
-|       |                 |                              | turn.                          |                                 |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 5     | Leonardo's      | :advance:`Invention`         | Upgrades two obsolete units    | At about this stage of the      |
-|       | Workshop        | /                            | per game turn.                 | game, most players will have a  |
-|       |                 | :advance:`Combustion`        |                                | collection of older units that  |
-|       |                 |                              |                                | have upgrades available. This   |
-|       |                 |                              |                                | wonder helps the player         |
-|       |                 |                              |                                | automatically upgrade old units |
-|       |                 |                              |                                | to newer versions for free      |
-|       |                 |                              |                                | every turn.                     |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
-| 5     | Verrocchio's    | :advance:`Invention`         | Upgrades one obsolete unit     | This is a **Great Wonder**, so  |
-|       | Workshop        | /                            | per turn.                      | only a single player can build  |
-|       |                 | :advance:`Industrialization` |                                | it. However, if you are able to |
-|       |                 |                              |                                | get it first, you will have an  |
-|       |                 |                              |                                | advantage in the free unit      |
-|       |                 |                              |                                | upgrade path.                   |
-+-------+-----------------+------------------------------+--------------------------------+---------------------------------+
+.. list-table:: Important Early Wonders
+  :widths: 6 19 25 25 25
+  :header-rows: 1
+
+  * - Tech Tree Level
+    - Wonder
+    - Required / Obsolete
+    - Benefits
+    - Notes
+  * - 1
+    - :wonder:`Ħal Saflieni Hypogeum`
+    - :advance:`Ceremonial Burial` / :advance:`Bronze Working`
+    - The city having it will get :math:`+6` additional Luxury and will celebrate after size 3.
+    - Build in the city with best production as it is simply a :math:`+6` Luxury adder and not based on city
+      size. The city will celebrate early by giving a small Science (bulbs) boost.
+  * - 1
+    - :wonder:`Mausoleum of Mausolos`
+    - :advance:`Ceremonial Burial` / :advance:`The Republic`
+    - :improvement:`City Walls` and :improvement:`Courthouses` each make one unhappy citizen content.
+    - :improvement:`Courthouses` are a **must** to reduce waste and corruption. :improvement:`City Walls` are
+      very important for defense at all stages of the game, except the late game when the power of the units
+      makes them pretty much impossible to defend against.
+  * - 1
+    - :wonder:`Hanging Gardens`
+    - :advance:`Pottery` / :advance:`Explosives`
+    - Makes one unhappy citizen content in every city. This wonder also makes two content citizens happy in
+      the city where it is located.
+    - Good to put in a big city and really helps with empire size issues.
+  * - 1
+    - :wonder:`Colossus`
+    - :advance:`Bronze Working` / :advance:`Invention`
+    - Each tile around the city where this wonder is built that is already generating some Trade produces one
+      extra Trade resource.
+    - :advance:`Bronze Working` obsoletes the :wonder:`Ħal Saflieni Hypogeum`, which is often built in your
+      capital city. You will want to replace the :wonder:`Ħal Saflieni Hypogeum` with the :wonder:`Colossus`
+      as soon as you can to continue to get the Trade (Luxury Goods) benefits. Depending on the size of your
+      capital, you may actually see a higher level of effect.
+  * - 2
+    - :wonder:`Pyramids`
+    - :advance:`Mathematics` / :advance:`Railroad`
+    - Each tile produces :math:`+1` Shield, eliminates the Despotism penalty.
+    - Building :wonder:`Pyramids` is a **must** as soon as possible, especially if you do not plan to go
+      straight to Monarchy. It is possible to have the :wonder:`Pyramids` by ``T15``. Build it in the highest
+      production city. The :wonder:`Pyramids` are also important when you are in Anarchy switching to another
+      form of government (e.g. Republic, Democracy, or Federation) so you do not suffer the Despotism penalty.
+  * - 2
+    - :wonder:`Temple of Artemis`
+    - :advance:`Mysticism` / :advance:`Theology`
+    - Makes 2 additional unhappy citizens content in every city with a :improvement:`Temple`.
+    - :improvement:`Temples` are a **must** before Republic or Democracy. This wonder will help your cities to
+      celebrate when the time is right.
+  * - 2
+    - :wonder:`Statue of Zeus`
+    - :advance:`Polytheism` / :advance:`Gunpowder`
+    - Eliminates 1 unhappy citizen due to military units abroad, plus each city also avoids 1 Shield of upkeep
+      for units.
+    - Citizen happiness is an important aspect of the early game. This wonder continues to keep your citizens
+      happy as cities grow in size. The second aspect (Shield upkeep) is huge  if you are Tribal and/or
+      Republic.
+  * - 3
+    - :wonder:`Copernicus' Observatory`
+    - :advance:`Astronomy` / :advance:`University`
+    - Each tile worked by the city where this wonder is built produces one extra research point.
+    - Another good one for a big city to get a boost to Science (bulb) output.
+  * - 4
+    - :wonder:`Sun Tzu's War Academy`
+    - :advance:`Feudalism` / :advance:`Metallurgy`
+    - All your new military land units start with an additional veteran level.
+    - This means that with a :improvement:`Barracks` in the city, all your units will be Veteran 2 (175%)
+      right away after production.
+  * - 5
+    - :wonder:`King Richard's Crusade`
+    - :advance:`Chivalry` / :advance:`Navigation`
+    - Reduces the unhappiness caused by aggressively deployed military units owned by the city by 1. Under
+      governments where unit upkeep is paid in gold, it gives two free gold per city towards upkeep every
+      turn.
+    - The primary benefit of this wonder is the reduction of gold upkeep for military units. With Monarchy,
+      unit upkeep is in Gold. This wonder helps your treasury greatly.
+  * - 5
+    - :wonder:`Leonardo's Workshop`
+    - :advance:`Invention` / :advance:`Combustion`
+    - Upgrades two obsolete units per game turn.
+    - At about this stage of the game, most players will have a collection of older units that have upgrades
+      available. This wonder helps the player automatically upgrade old units to newer versions for free every
+      turn.
+  * - 5
+    - :wonder:`Verrocchio's Workshop`
+    - :advance:`Invention` / :advance:`Industrialization`
+    - Upgrades one obsolete unit per turn.
+    - This is a **Great Wonder**, so only a single player can build it. However, if you are able to get it
+      first, you will have an advantage in the free unit upgrade path.
+
 
 .. note::
   When thinking about Small and Great Wonders. Keep attention to what obsoletes them. For example, if you
@@ -396,16 +375,16 @@ in the early game. Here are a few points on things to think about:
 
 * All cities should mostly concentrate on max food for growth. Where you micromanage is around the time for
   the city to grow to the next size. Any more food that is produced at a new city size is wasted. For example:
-  if you only need one food to grow, but the city is producing +2 food, then you will lose the extra food to
-  waste at :term:`TC`. Instead move your citizens around in the city dialog to get the city to only produce +1
-  food and eliminate the waste.
+  if you only need one food to grow, but the city is producing :math:`+2` food, then you will lose the extra
+  food to waste at :term:`TC`. Instead move your citizens around in the city dialog to get the city to only
+  produce :math:`+1` food and eliminate the waste.
 
   .. tip::
     The larger the city the more opportunity for more production. Do not drastically slow down growth simply
     for production. Concentrate on growth instead as production comes with the larger size. Larger cities also
-    produce more gold and research bulbs!
+    produce more Gold and research bulbs!
 
-* You get a free Granary "effect" up to size 5, so be sure to keep an eye out and build
+* You get a free Granary "effect" up to size 5, so be sure to keep an eye out and build a
   :improvement:`Granary` in your cities at the same time or before size 5. Production occurs before city
   growth during the turn change process. If you do not build :improvement:`Granary` your growth will stall
   significantly.
@@ -425,13 +404,13 @@ in the early game. Here are a few points on things to think about:
     unhappiness in a city while you build other items (such as finishing a :unit:`Settlers`, which will drop
     the city size down making the :improvement:`Temple` unnecessary).
 
-* City Improvements that increase luxury will then create bulbs, gold and happiness.
+* City Improvements that increase Luxury will then create bulbs, gold and happiness.
 
 * You need :unit:`Workers`, :unit:`Workers`, and more :unit:`Workers`. Cities become very powerful the larger
   they are. The more you can put :unit:`Workers` to “work” on the tiles around your cities the better.
-  Irrigate grass, irrigate swamp to grassland, cut down forest and convert to grassland, and then convert
-  plains to grassland. Irrigated grassland produces +3 food per turn and +4 with Farmland (with
-  :advance:`Refrigeration`).
+  Irrigate Grassland, irrigate Swamp to Grassland, cut down Forest and convert to Grassland, and then convert
+  Plains to Grassland. Irrigated Grassland produces :math:`+3` food per turn and :math:`+4` with Farmland
+  (with :advance:`Refrigeration`).
 
   .. tip::
     Do not forget to upgrade the 5 :unit:`Tribal Workers` to full :unit:`Workers` as soon as you can manage.
@@ -446,21 +425,22 @@ Some notes on determining what to build in your cities:
 * Pay close attention to the effect varying city improvements will give you to determine if something is worth
   building or not. Think of it as a cost vs benefit analysis.
 
-  * An example will help. Imagine you have a city of size 4 that produces +2 Trade and another city that is
-    size 7 and produces +10 Trade. You have learned :advance:`Currency` and want to build a
-    :improvement:`Marketplace` in all your cities (a good goal). A :improvement:`Marketplace` costs 45 shields
-    to produce and gives a 50% Tax (Trade/Luxury Goods) bonus to the city. For the first city you will only
-    get +1 more Trade and the second you will get +5 more. This means you have a 1:45 Trade:Production ratio
-    in the first city and a 5:45 Trade:Production ratio in the second. Obviously build (or even buy) the
-    :improvement:`Marketplace` in the bigger city and hold off on it in the smaller city. Build :unit:`Workers`
-    instead in the smaller city as they cost 20 and have more utility.
+  * An example will help. Imagine you have a city of size 4 that produces :math:`+2` Trade and another city
+    that is size 7 and produces :math:`+10` Trade. You have learned :advance:`Currency` and want to build a
+    :improvement:`Marketplace` in all your cities (a good goal). A :improvement:`Marketplace` costs 45 Shields
+    to produce and gives a 50% Tax (Trade / Luxury Goods) bonus to the city. For the first city you will only
+    get :math:`+1` more Trade and the second you will get :math:`+5` more. This means you have a 1:45
+    Trade:Production ratio in the first city and a 5:45 Trade:Production ratio in the second. Obviously build
+    (or even buy) the :improvement:`Marketplace` in the bigger city and hold off on it in the smaller city.
+    Build :unit:`Workers` instead in the smaller city as they cost 20 Shields and have more utility.
 
-  * Another example was given earlier, but good to repeat here. A :improvement:`Temple` costs 25 shields for a
+  * Another example was given earlier, but good to repeat here. A :improvement:`Temple` costs 25 Shields for a
     single happy citizen and a :unit:`Warrior` costs 10 for the same effect and has more utility.
 
 .. note::
   If you have not figured it out yet, Longturn games are **math heavy**.
 
+.. _lt-guide-manage-workforce:
 
 Managing Your Workforce
 -----------------------
@@ -488,32 +468,35 @@ The veteran levels for :term:`LTT`/:term:`LTX` are:
 
 This table shows what effect veteran levels have on all units except :unit:`Diplomats` and :unit:`Spies`.
 
-+------------+-------------------+------------------+-------------------------------------+
-| Vet Level  | Combat Strength   | Move Bonus       | Promotion Chance (%)                |
-|            |                   |                  +-------------+-----------------------+
-|            |                   |                  | In Combat   | By Working (per turn) |
-+============+===================+==================+=============+=======================+
-| Green      | :math:`1` x       | :math:`0`        | :math:`50%` | :math:`9%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Veteran 1  | :math:`1.5` x     | :math:`^1/_3`    | :math:`45%` | :math:`6%`            |
-|            | (from Green)      | (from Green)     |             |                       |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Veteran 2  | :math:`1.75` x    | :math:`^2/_3`    | :math:`40%` | :math:`6%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Veteran 3  | :math:`2` x       | :math:`1`        | :math:`35%` | :math:`6%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Hardened 1 | :math:`2.25` x    | :math:`1\:^1/_3` | :math:`30%` | :math:`5%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Hardened 2 | :math:`2.5` x     | :math:`1\:^2/_3` | :math:`25%` | :math:`5%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Hardened 3 | :math:`2.75` x    | :math:`2`        | :math:`20%` | :math:`4%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Elite 1    | :math:`3` x       | :math:`2\:^1/_3` | :math:`15%` | :math:`4%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Elite 2    | :math:`3.25` x    | :math:`2\:^2/_3` | :math:`10%` | :math:`3%`            |
-+------------+-------------------+------------------+-------------+-----------------------+
-| Elite 3    | :math:`3.5` x     | :math:`3`        | :math:`0`   | :math:`0`             |
-+------------+-------------------+------------------+-------------+-----------------------+
+.. table:: Veteran Levels
+  :widths: auto
+
+  +------------+-------------------+------------------+-------------------------------------+
+  | Vet Level  | Combat Strength   | Move Bonus       | Promotion Chance (%)                |
+  |            |                   |                  +-------------+-----------------------+
+  |            |                   |                  | In Combat   | By Working (per turn) |
+  +============+===================+==================+=============+=======================+
+  | Green      | :math:`1` x       | :math:`0`        | 50%         | 9%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 1  | :math:`1.5` x     | :math:`^1/_3`    | 45%         | 6%                    |
+  |            | (from Green)      | (from Green)     |             |                       |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 2  | :math:`1.75` x    | :math:`^2/_3`    | 40%         | 6%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 3  | :math:`2` x       | :math:`1`        | 35%         | 6%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 1 | :math:`2.25` x    | :math:`1\:^1/_3` | 30%         | 5%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 2 | :math:`2.5` x     | :math:`1\:^2/_3` | 25%         | 5%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 3 | :math:`2.75` x    | :math:`2`        | 20%         | 4%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 1    | :math:`3` x       | :math:`2\:^1/_3` | 15%         | 4%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 2    | :math:`3.25` x    | :math:`2\:^2/_3` | 10%         | 3%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 3    | :math:`3.5` x     | :math:`3`        | 0           | 0                     |
+  +------------+-------------------+------------------+-------------+-----------------------+
 
 The working capacity of each :unit:`Workers` is given by the base movement points. In the
 :term:`LTT`/:term:`LTX` rulesets, :unit:`Tribal Workers` have a base work rate of two (2) in :term:`LTT` and
@@ -529,8 +512,8 @@ as you can, that extra move point is huge over the long turn.
   rate remains the same all the time.
 
 Each terrain requires a different amount of work to build infrastructure on it. For example, if you
-go to the help entry of :title-reference:`grasslands` (by going to Help > Terrain > Grasslands), you will see
-something like the screenshot below:
+go to the help entry of :title-reference:`grasslands` (by going to
+:menuselection:`Help --> Terrain --> Grasslands`), you will see something like the screenshot below:
 
 .. _Work Points:
 .. figure:: /_static/images/how-to-play/work-points.png

--- a/docs/Playing/faq.rst
+++ b/docs/Playing/faq.rst
@@ -4,11 +4,7 @@
 .. SPDX-FileCopyrightText: louis94 <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: Tobias Rehbein <tobias.rehbein@web.de>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 Frequently Asked Questions (FAQ)
 ********************************
@@ -132,14 +128,15 @@ between your two consecutive logins. Once a player has made all of their moves, 
 before they can move again. This does mean that a player can move a unit just before :term:`TC` and just
 after and in between your two logins. In short, a player cannot :emphasis:`move twice` until you do.
 
-The primary server setting to mitigate the :term:`TC` problem is called ``unitwaittime``, which imposes a
-minimum time between moves of a single unit on successive turns. This setting is used to prevent a varying
-collection of what the Longturn community calls "turn change shenanigans". For example, one such issue is
-moving a :unit:`Worker` into enemy territory just before :term:`TC` and giving it orders to build a road.
-After :term:`TC` you go in and capture a city using the road for move benefit. Without ``unitwaittime`` you
-would be able to move the :unit:`Worker` back to safety immediately, thereby preventing it from being captured
-or destroyed. With ``unitwaittime`` enabled, you have to wait the requisite amount of time. This makes the
-game harder, but also more fair since not everyone can be online at every :term:`TC`.
+The primary :ref:`server setting <server-option-unitwaittime>` to mitigate the :term:`TC` problem is
+called ``unitwaittime``, which imposes a minimum time between moves of a single unit on successive turns. This
+setting is used to prevent a varying collection of what the Longturn community calls "turn change shenanigans".
+For example, one such issue is moving a :unit:`Worker` into enemy territory just before :term:`TC` and giving
+it orders to build a road. After :term:`TC` you go in and capture a city using the road for move benefit.
+Without ``unitwaittime`` you would be able to move the :unit:`Worker` back to safety immediately, thereby
+preventing it from being captured or destroyed. With ``unitwaittime`` enabled, you have to wait the requisite
+amount of time. This makes the game harder, but also more fair since not everyone can be online at every
+:term:`TC`.
 
 .. Note::
   The ``unitwaittime`` setting is really only used in Longturn multi-player games and is not enabled/used for
@@ -211,11 +208,7 @@ Do things that give more trade only give this bonus if there is already at least
 
 The short answer is yes in :term:`LTT`. This is a ruleset configured item.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Diplomacy
 ---------
@@ -308,11 +301,7 @@ The :ref:`Nations and Diplomacy <game-manual-nations-and-diplomacy-view>` View (
 technology advance information if you have an embassy with the target nation. To see what is going on, select
 a nation and look at the bottom of the page.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Game Map and Tilesets
 ---------------------
@@ -352,11 +341,7 @@ Can one use a hexagonal tileset for iso-hex maps and vice versa?
 
 See the question `Can one use a regular square tileset for iso-square maps and vice versa?`_ above.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Cities and Terrain
 ------------------
@@ -366,7 +351,7 @@ This subsection of the Gameplay section is a discussion around cities and the te
 My irrigated grassland produces only 2 food. Is this a bug?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-No, it is not -- it is a feature. Your government is probably Despotism, which has a -1 output penalty
+No, it is not --- it is a feature. Your government is probably Despotism, which has a :math:`-1` output penalty
 whenever a tile produces more than 2 units of food, production, or trade. You should change your government.
 See the in-game help on :title-reference:`Government` for more detail to get rid of this penalty.
 
@@ -462,7 +447,7 @@ There are at least the following differences:
   a ruleset configurable item.
 * Some ships cannot travel on deep ocean (such as :unit:`Triremes`)
 * Shallow ocean has a 10% defense bonus.
-* Ocean tiles allow you to build :improvement:`Harbor`, giving +1 food. The :improvement:`Harbor` city
+* Ocean tiles allow you to build :improvement:`Harbor`, giving :math:`+1` food. The :improvement:`Harbor` city
   improvement often comes with the discovery of :advance:`Seafaring` in most rulesets, but this is a ruleset
   configurable item.
 
@@ -499,13 +484,14 @@ and then add Farmland on top of it, just like any other regular tile.
 Does the city tile have any production bonuses?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A city tile has a +1 production bonus, added after any other bonuses (such as Railroad).
+A city tile has a :math:`+1` production bonus, added after any other bonuses (such as Railroad).
 
 Does LTT have the extra food from rivers on a desert tile when irrigated, like other rulesets have?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Yes, an irrigated desert tile with a river gives an extra +1 food in addition to the regular irrigation food
-bonus. This is a game engine (server) item and is not driven by a ruleset, such as :term:`LTT`.
+Yes, an irrigated desert tile with a river gives an extra :math:`+1` food in addition to the regular
+irrigation food bonus. This is a game engine (server) item and is not driven by a ruleset, such as
+:term:`LTT`.
 
 Is there any penalty when changing a city production task?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -542,11 +528,7 @@ Can you build a hill under a city?
 
 Yes, you sure can!
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Units - General
 ---------------
@@ -569,10 +551,8 @@ What is a unit’s terraforming speed based on?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is based on the base amount of :term:`MP`'s for that unit and veteran level bonus. The base terraforming
-duration is specified in the ruleset files.
-
-.. todo::
-  This is discussed in detail in a forthcoming LTT Gamer's Manual. Update this entry at that time.
+duration is specified in the ruleset files. See :ref:`managing your workforce <lt-guide-manage-workforce>` in
+the :title-reference:`Longturn Game Playing Guide`.
 
 Can workers do all land conversions? Or are most land conversions locked behind engineers?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -614,31 +594,35 @@ to gain an upgrade via experience. The experience depends on the unit and what t
 :unit:`Worker` gains experience by creating terrain infrastructure, or a :unit:`Phalanx` gains experience
 during both defense and offense (attack) movements. See the following table:
 
-+-----------------+-------------------+------------------+------------------------+
-|                 |                   |                  | Promotion Chance       |
-| Level           | Combat Strength   | Move Bonus       +-----------+------------+
-|                 |                   |                  | In Combat | By Working |
-+=================+===================+==================+===========+============+
-| Green           | 1x                | 0                | 50        | 9          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Veteran 1 (v)   | 1.5x (from Green) | 1/3 (from Green) | 45        | 6          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Veteran 2 (vv)  | 1.75x             | 2/3              | 40        | 6          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Veteran 3 (vvv) | 2x                | 1                | 35        | 6          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Hardened 1 (h1) | 2.25x             | 1 1/3            | 30        | 5          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Hardened 2 (h2) | 2.5x              | 1 2/3            | 25        | 5          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Hardened 3 (h3) | 2.75x             | 2                | 20        | 4          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Elite 1 (e1)    | 3x                | 2 1/3            | 15        | 4          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Elite 2 (e2)    | 3.25x             | 2 2/3            | 10        | 3          |
-+-----------------+-------------------+------------------+-----------+------------+
-| Elite 3 (e3)    | 3.5x              | 3                | 0         | 0          |
-+-----------------+-------------------+------------------+-----------+------------+
+.. table:: Veteran Levels
+  :widths: auto
+
+  +------------+-------------------+------------------+-------------------------------------+
+  | Vet Level  | Combat Strength   | Move Bonus       | Promotion Chance (%)                |
+  |            |                   |                  +-------------+-----------------------+
+  |            |                   |                  | In Combat   | By Working (per turn) |
+  +============+===================+==================+=============+=======================+
+  | Green      | :math:`1` x       | :math:`0`        | 50%         | 9%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 1  | :math:`1.5` x     | :math:`^1/_3`    | 45%         | 6%                    |
+  |            | (from Green)      | (from Green)     |             |                       |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 2  | :math:`1.75` x    | :math:`^2/_3`    | 40%         | 6%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Veteran 3  | :math:`2` x       | :math:`1`        | 35%         | 6%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 1 | :math:`2.25` x    | :math:`1\:^1/_3` | 30%         | 5%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 2 | :math:`2.5` x     | :math:`1\:^2/_3` | 25%         | 5%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Hardened 3 | :math:`2.75` x    | :math:`2`        | 20%         | 4%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 1    | :math:`3` x       | :math:`2\:^1/_3` | 15%         | 4%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 2    | :math:`3.25` x    | :math:`2\:^2/_3` | 10%         | 3%                    |
+  +------------+-------------------+------------------+-------------+-----------------------+
+  | Elite 3    | :math:`3.5` x     | :math:`3`        | 0           | 0                     |
+  +------------+-------------------+------------------+-------------+-----------------------+
 
 Is it possible to change a unit’s home city?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -647,7 +631,7 @@ To be clear, a unit's "home city" is the city that produced it.
 
 It is possible when the unit is moved to a city that is not its current home city. You then get an option to
 change the home city. With the unit in a city you can either use shortcut key “h” or
-:guilabel:`Unit --> Set Home City` to re-home the unit to the city it is inside.
+:menuselection:`Unit --> Set Home City` to re-home the unit to the city it is inside.
 
 .. Note::
   Some rulesets allow "unhomed" units. These kind of units will never have a home city and you cannot change
@@ -660,11 +644,7 @@ After. For example, you can beat an enemy attacking unit with a queued :term:`Go
 rush-buying a defensive unit (it will get built first during normal :doc:`turn change processing
 </Playing/turn-change>`), and the attacking unit will move after that.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Units - Military
 ----------------
@@ -700,19 +680,65 @@ the Longturn Community enjoys playing. As in the game of Chess, the "board" does
 must gauge the risk-reward ratios of your moves and counter-moves. This is the same in Freeciv21. The game
 will not do the math for you. This table should help you in doing the math:
 
-+---------------------------------------+-----------------+------------------+-----------------+----------------------+-----------+-----------+--------------------+-------------------+
-| Terrain                               | Open (Sentried) | Open (Fortified) | Fortress (Open) | Fortress (Fortified) | City <= 8 | City >= 9 | City <= 8 w/ Walls | City >=9 w/ Walls |
-+=======================================+=================+==================+=================+======================+===========+===========+====================+===================+
-| Grass, Plains, Desert, Tundra, Desert | 1.0x            | 1.5x             | 2.0x            | 3.0x                 | 2.25x     | 3.0x      | 3.75x              | 4.5x              |
-+---------------------------------------+-----------------+------------------+-----------------+----------------------+-----------+-----------+--------------------+-------------------+
-| Forest, Jungle, Swamp                 | 1.25x           | 1.88x            | 2.5x            | 3.75x                | 2.81x     | 3.75x     | 4.69x              | 5.63x             |
-+---------------------------------------+-----------------+------------------+-----------------+----------------------+-----------+-----------+--------------------+-------------------+
-| Hills                                 | 1.5x            | 2.25x            | 3.0x            | 4.5x                 | 3.38x     | 4.5x      | 5.63x              | 6.75x             |
-+---------------------------------------+-----------------+------------------+-----------------+----------------------+-----------+-----------+--------------------+-------------------+
-| Mountains                             | 2.0x            | 3.0x             | 4.0x            | 6.0x                 | N/A       | N/A       | N/A                | N/A               |
-+---------------------------------------+-----------------+------------------+-----------------+----------------------+-----------+-----------+--------------------+-------------------+
-| w/ River                              | +1.25x on top of the other modifiers above                                                                                                   |
-+---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. list-table:: Important Early Wonders
+  :widths: auto
+  :header-rows: 1
+
+  * - Terrain
+    - Open (Sentried)
+    - Open (Fortified)
+    - Fortress (Open)
+    - Fortress (Fortified)
+    - City <= 8
+    - City >= 9
+    - City <= 8 w/ Walls
+    - City >=9 w/ Walls
+  * - Grass, Plains, Desert, Tundra, Desert
+    - 1.0x
+    - 1.5x
+    - 2.0x
+    - 3.0x
+    - 2.25x
+    - 3.0x
+    - 3.75x
+    - 4.5x
+  * - Forest, Jungle, Swamp
+    - 1.25x
+    - 1.88x
+    - 2.5x
+    - 3.75x
+    - 2.81x
+    - 3.75x
+    - 4.69x
+    - 5.63x
+  * - Hills
+    - 1.5x
+    - 2.25x
+    - 3.0x
+    - 4.5x
+    - 3.38x
+    - 4.5x
+    - 5.63x
+    - 6.75x
+  * - Mountains
+    - 2.0x
+    - 3.0x
+    - 4.0x
+    - 6.0x
+    - N/A
+    - N/A
+    - N/A
+    - N/A
+  * - w/ River
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
+    - +1.25x on top of the other modifiers above
 
 .. Tip::
   The legacy Freeciv WiKi gives some good information in the Game Manual about Terrain here:
@@ -777,11 +803,7 @@ When a city is captured, all units homed in that city that are currently in anot
 Any units not in a native city (e.g. your own city) are lost. This includes allied cities or outside of any
 city in the field.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Other
 -----
@@ -857,11 +879,7 @@ This only works after you can beat the :term:`AI`, of course.
 Another idea is to create starting situations in which the players are already fully developed. Refer to the
 section on :ref:`scenarios <modding-scenarios>`.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Non-Gameplay Specific Questions
 ===============================
@@ -931,10 +949,9 @@ Does capturing work like Freeciv-Web?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Unit capturing is ruleset defined. Capturing in :term:`LTT` works slightly differently than in the :term:`MP2`
-ruleset used at Freeciv-Web.
-You can capture any “capturable” unit with a “capturer” unit, if the target is alone on a tile. Units
-that are “capturable” have a mention of this in their help text. Units that are “capturers” also have a
-mention of this in their help text.
+ruleset used at Freeciv-Web. You can capture any “capturable” unit with a “capturer” unit, if the target is
+alone on a tile. Units that are “capturable” have a mention of this in their help text. Units that are
+“capturers” also have a mention of this in their help text.
 
 .. Tip::
   You can also capture units from boats. Guard your coastal workers.
@@ -943,9 +960,9 @@ mention of this in their help text.
 Where do I go to see the rules for a game? Like how big a victory alliance can be?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All rules and winning conditions are posted to the `https://forum.longturn.net/index.php <forums>`_ under the
-Games index. Each game has a section for varying posts related to the game. Winning conditions are also often
-posted on the Longturn Discord `https://discord.gg/98krqGm <server>`_ in the channel for the game.
+All rules and winning conditions are posted to game page on https://longturn.net. Each game has a page for
+information related to the game. Winning conditions are posted here and also often on the Longturn Discord
+`https://discord.gg/98krqGm <server>`_ in the dedicated channel for the game.
 
 Does the Nations view show whether the player is idling?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -991,11 +1008,7 @@ Technically yes, they are enabled. However in reality they are not enabled, beca
 distance is 999. They are overpowered and would cause game balance issues in the multi-player environments
 targeted by :term:`LTT`.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Game Interface Configuration
 ----------------------------
@@ -1003,20 +1016,20 @@ Game Interface Configuration
 How do I make the font bigger for help text?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can change a collection of fonts and font sizes by going to :guilabel:`Game --> Set local options` and
-then clicking on the :guilabel:`Fonts` tab.
+You can change a collection of fonts and font sizes by going to :menuselection:`Game --> Set local options`
+and then clicking on the :guilabel:`Fonts` tab.
 
 Is it possible to save login info in the game so it does not have to be entered each time?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Yes, you can set a number of items by going to :guilabel:`Game --> Set local options` and then clicking on
-the :guilabel:`Network` tab. You can set the server, port and username. You cannot save the password as that
-is a security risk.
+Yes, you can set a number of items by going to :menuselection:`Game --> Set local options` and then clicking
+on the :guilabel:`Network` tab. You can set the server, port and username. You cannot save the password as
+that is a security risk.
 
 Where can I turn off “connected / disconnected” messages filling up the chat window?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can adjust a collection of things by going to :guilabel:`Game --> Messages`. Anything checked in the
+You can adjust a collection of things by going to :menuselection:`Game --> Messages`. Anything checked in the
 ``out`` column will go to the :guilabel:`server/chatline` widget of the game interface. Anything in the
 ``mes`` column will show in the :guilabel:`messages` widget. Lastly, anything checked in the ``pop`` column
 will produce a pop-up window message.
@@ -1033,7 +1046,7 @@ How do I enable/disable sound or music support?
 
 The game can be started without sound by supplying the command-line arguments :literal:`-P none`.
 The default sound plugin can also be configured in the game settings by going to
-:guilabel:`Game -->Set local options` and then clicking on the :guilabel:`Sound` tab.
+:menuselection:`Game -->Set local options` and then clicking on the :guilabel:`Sound` tab.
 
 If the game was compiled with sound support, it will be enabled by default. All pre-compiled
 packages provided by the Longturn community come with sound support enabled.
@@ -1058,11 +1071,7 @@ Again, this is easiest if the ruleset is available through the
 If the ruleset you want is not available via the modpack installer, you will have to install it by hand from
 somewhere. To do that is beyond the scope of this FAQ.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Community
 ---------
@@ -1105,11 +1114,7 @@ Patches and bug reports are best reported to the Freeciv21 bug tracking system a
 https://github.com/longturn/freeciv21/issues/new/choose. For more information, have a look at
 :doc:`/Contributing/bugs`.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Technical Stuff
 ---------------
@@ -1240,11 +1245,7 @@ not help. If you find your game running too slow, these may be the reasons:
 * :strong:`Network`: Any modern internet connection will suffice to play Freeciv21. Even mobile hot-spots
   provide enough bandwidth.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 Windows
 -------
@@ -1260,15 +1261,9 @@ OK, I have downloaded and installed it, how do I run it?
 
 See the document about :doc:`/Getting/windows-install`.
 
-.. raw:: html
-
-    <embed>
-        <hr>
-    </embed>
+|hr|
 
 macOS
 -----
 
 Pre-compiled binaries in a :file:`*.dmg` file can be downloaded from https://github.com/longturn/freeciv21/releases.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/Playing/how-to-play.rst
+++ b/docs/Playing/how-to-play.rst
@@ -4,11 +4,7 @@
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 .. SPDX-FileCopyrightText: David Koníř <david.konir@gmail.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
+.. include:: /global-include.rst
 
 How to Play Freeciv21
 *********************
@@ -151,7 +147,7 @@ trade. This area is called the *Working Radius*. This output can be increased by
 improved with Irrigation (increasing food output), Roads (allowing units to move faster and in some cases
 increasing trade), and Mines (increasing production), among other improvements. The ability to do some
 improvements on some tiles may require a technology advance to be learned by your scientists.
-See :title-reference:`Help --> Terrain --> Terrain Alterations` for more information.
+See :menuselection:`Help --> Terrain --> Terrain Alterations` for more information.
 
 .. _how-to-play-city-placement:
 
@@ -174,13 +170,13 @@ good to discuss here in the early game.
   :menuselection:`Game --> Load Another Tileset` and picking ``Hexemplio`` from the list.
 
 Let us first talk about two concepts: *Vision Radius* and *Working Radius*. Each city has a vision radius and
-a working radius. The vision radius is the tiles that the citizens of a city can see on the map. If an enemy
-unit comes within the vision radius of a city, a sentried unit inside of the city will wake up and alert you.
-Within the vision radius is the smaller working radius. When thinking of city planning, you should be most
-concerned with the working radius of a city. These are the tiles that the citizens of your cities manage to
-extract Resources (Shields, Food, and Trade). When the working radius of a city overlaps with that of another
-city, only one city at a time can manage that tile. This is another one of those *balance* items in playing
-Freeciv21.
+a working radius. The vision radius is the tiles that the citizens of a city can see on the map (typically
+viewed as well-lit or bright tiles vs dark tiles). If an enemy unit comes within the vision radius of a city,
+a sentried unit inside of the city will wake up and alert you. Within the vision radius is the smaller working
+radius. When thinking of city planning, you should be most concerned with the working radius of a city. These
+are the tiles that the citizens of your cities manage to extract Resources (Shields, Food, and Trade). When
+the working radius of a city overlaps with that of another city, only one city at a time can manage that tile.
+This is another one of those *balance* items in playing Freeciv21.
 
 When you have a :unit:`Settler` selected, it will have a red outline shown on the map. This is the city's
 working radius if you placed the :unit:`Settler` at that spot with the :menuselection:`Work --> Build City`
@@ -269,12 +265,12 @@ Entertainer when you take a citizen off the land.
 If you click on the central tile of the land (the "City Center"), the citizens will be rearranged to maximize
 food production. You will also want to look at the level of food in the Granary and the amount of surplus food
 the city is producing each turn. The city will lose excess food at turn change. For example: The Granary in
-the city has 18/20 food (needs two food to grow to next city size) and the city is currently producing +4 food
-surplus each turn. This means that at turn change you will lose 2 food as waste at turn change. This is a good
-opportunity to move the citizens around to get food to +2 surplus. This could be accomplished by taking a
-citizen off a tile producing 2 food and turn it into a Taxman for a turn to get gold. At turn change, open the
-city and restore the citizen to farming. This kind of individual city management style is called
-"micro-management" and is a very powerful mechanism of game play.
+the city has :math:`^{18}/_{20}` food (needs two food to grow to next city size) and the city is currently
+producing :math:`+4` food surplus each turn. This means that at turn change you will lose 2 food as waste at
+turn change. This is a good opportunity to move the citizens around to get food to :math:`+2` surplus. This
+could be accomplished by taking a citizen off a tile producing 2 food and turn it into a Taxman for a turn to
+get gold. At turn change, open the city and restore the citizen to farming. This kind of individual city
+management style is called "micro-management" and is a very powerful mechanism of game play.
 
 The golden rule of taking care of a city is that there should be at least as many happy citizens as unhappy
 citizens. A city where this is not the case falls into disorder. Such cities are labeled with a raised fist or
@@ -297,7 +293,7 @@ receives no benefit and once established, cannot be revoked.
 If you are in contact with another player, then you can arrange a diplomatic meeting. From the
 :ref:`Nations and Diplomacy View <game-manual-nations-and-diplomacy-view>`, this is done by selecting the
 nation with whom you wish to meet and clicking :guilabel:`Meet`. If the entry under the embassy column is not
-blank and the other player is connected (or is a server AI) then a treaty dialog will pop up.
+blank and the other player is connected (or is a server :term:`AI`) then a treaty dialog will pop up.
 
 In this dialog you can negotiate an exchange of assets (maps, vision, advances, cities, or gold), embassies,
 or relationship pacts such as a Cease-fire or Peace. The list of items that can be traded through diplomacy is
@@ -310,7 +306,7 @@ relations with others. Under authoritarian governments such as monarchy you can 
 the representative governments (Republic and Democracy) have a senate which will block the unprovoked
 cancellation of a treaty, unless a foreign :unit:`Diplomat` or :unit:`Spy` sparks a diplomatic incident. The
 only way to dissolve a pact in this situation is to dissolve your government by going into anarchy. The
-details of pacts are described in the :title-reference:`Help --> Diplomacy` section.
+details of pacts are described in the :menuselection:`Help --> Diplomacy` section.
 
 A few notes:
 
@@ -336,7 +332,7 @@ Things to Keep in Mind
 ----------------------
 
 * What the next advance you will need is.
-* What your tax, luxury goods and research rates are currently set to.
+* What your Tax, Luxury Goods, and Research rates are currently set to.
 * Treaties are often broken, so do not neglect defense!
 * Some wonders can be made obsolete by a new technology.
 

--- a/docs/Playing/index.rst
+++ b/docs/Playing/index.rst
@@ -1,8 +1,12 @@
+.. SPDX-License-Identifier: GPL-3.0-or-later
+.. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+
 Playing
 =======
 
-The Playing category is an area for documentation editors to provide tips and tricks on ways to play
-Freeciv21 and any of the varying rulesets that the Longturn.net community likes to play.
+The Playing category is an area for documentation editors to provide tips and tricks on ways to play Freeciv21
+and any of the varying rulesets that the Longturn.net community likes to play.
 
 
 .. toctree::

--- a/docs/Playing/turn-change.rst
+++ b/docs/Playing/turn-change.rst
@@ -3,12 +3,7 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
+.. include:: /global-include.rst
 
 The Turn Change Sequence
 ************************

--- a/docs/README
+++ b/docs/README
@@ -3,6 +3,11 @@ Root of sphinx-build files here for the Longturn Documentation Project
 
 To create a local test build run this command from this same directory
 
-    sphinx-build -b html . ../build/docs
+    cd build
+    python -m virtualenv venv
+    source venv/bin/activate
+    pip install -r ../docs/requirements.txt
 
-and then open ../build/docs/index.html in your browser of choice
+    sphinx-build -b html ../docs ./docs/
+
+and then open build/docs/index.html in your browser of choice

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,152 +1,152 @@
 /* set a custom font face to match in game standard font */
 @font-face {
-    font-family: Libertinus Sans;
-    font-weight: normal;
-    font-style: normal;
-    src: url(./LibertinusSans-Regular.woff2);
+  font-family: Libertinus Sans;
+  font-weight: normal;
+  font-style: normal;
+  src: url(./LibertinusSans-Regular.woff2);
 }
 
 @font-face {
-    font-family: Libertinus Sans;
-    font-weight: bold;
-    font-style: normal;
-    src: url(./LibertinusSans-Bold.woff2);
+  font-family: Libertinus Sans;
+  font-weight: bold;
+  font-style: normal;
+  src: url(./LibertinusSans-Bold.woff2);
 }
 
 @font-face {
-    font-family: Libertinus Sans;
-    font-weight: normal;
-    font-style: italic;
-    src: url(./LibertinusSans-Italic.woff2);
+  font-family: Libertinus Sans;
+  font-weight: normal;
+  font-style: italic;
+  src: url(./LibertinusSans-Italic.woff2);
 }
 
 /* set the base body tags font */
 body {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 18px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 18px;
 }
 
 p {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 18px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 18px;
 }
 
 h1 {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 28px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 28px;
 }
 
 h2 {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 26px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 26px;
 }
 
 h3 {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 24px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 24px;
 }
 
 h4 {
-    font-family: Libertinus Sans, sans-serif;
-    font-size: 22px;
+  font-family: Libertinus Sans, sans-serif;
+  font-size: 22px;
 }
 
 /* add whitespace between list items */
-li {
+li, div[*wy-grid-for-nav] li {
   margin-bottom: 7px;
 }
 
-li ol li {
+li ol li, div[*wy-grid-for-nav] li {
   margin-bottom: 7px;
 }
 
-li ul li {
+li ul li, div[*wy-grid-for-nav] li {
   margin-bottom: 7px;
 }
 
-.toctree-wrapper li, .current li {
-    margin-bottom: 3px;
+.current li, div[*wy-grid-for-nav] li {
+  margin-bottom: 3px;
 }
 
 /* set the font of the side nav bar header */
 .wy-side-nav-search {
-    font-family: Libertinus Sans, sans-serif;
+  font-family: Libertinus Sans, sans-serif;
 }
 
 .pre, code, pre {
-    font-size: 15px;
+  font-size: 15px;
 }
 
 .rst-content .linenodiv pre, .rst-content div[class^="highlight"] pre, .rst-content pre.literal-block {
-    font-size: 15px;
+  font-size: 15px;
 }
 
 .rst-content span[class^="math"] {
-    font-size: 16px;
+  font-size: 16px;
 }
 
 /* fix for overlapping inline code blocks in tables */
 html.writer-html5 .rst-content table.docutils :is(td, th) > p :is(.pre, code, pre) {
-    line-height: 1.25rem;
+  line-height: 1.25rem;
 }
 
 /* override table width restrictions */
 .wy-table-responsive table td, .wy-table-responsive table th {
-    white-space: normal;
+  white-space: normal;
 }
 
 .wy-table-responsive {
-    margin-bottom: 24px;
-    max-width: 100%;
+  margin-bottom: 24px;
+  max-width: 100%;
 }
 
 /* no wrapping in builtin roles */
 .guilabel {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 /* format for custom interpretive text roles */
 .unit {
-    border: 1px solid #64b9b9;
-    background: #8ff9db;
-    font-size:80%;
-    font-weight:700;
-    border-radius:4px;
-    padding:2px 6px;
-    margin:auto 2px
+  border: 1px solid #64b9b9;
+  background: #8ff9db;
+  font-size:80%;
+  font-weight:700;
+  border-radius:4px;
+  padding:2px 6px;
+  margin:auto 2px
 }
 
 .improvement {
-    border: 1px solid #aa9f61;
-    background: #f7e68b;
-    font-size:80%;
-    font-weight:700;
-    border-radius:4px;
-    padding:2px 6px;
-    margin:auto 2px
+  border: 1px solid #aa9f61;
+  background: #f7e68b;
+  font-size:80%;
+  font-weight:700;
+  border-radius:4px;
+  padding:2px 6px;
+  margin:auto 2px
 }
 
 .wonder {
-    border: 1px solid #a069c6;
-    background: #e2b3f7;
-    font-size:80%;
-    font-weight:700;
-    border-radius:4px;
-    padding:2px 6px;
-    margin:auto 2px
+  border: 1px solid #a069c6;
+  background: #e2b3f7;
+  font-size:80%;
+  font-weight:700;
+  border-radius:4px;
+  padding:2px 6px;
+  margin:auto 2px
 }
 
 .advance {
-    border: 1px solid #aa726f;
-    background: #f4bab7;
-    font-size:80%;
-    font-weight:700;
-    border-radius:4px;
-    padding:2px 6px;
-    margin:auto 2px
+  border: 1px solid #aa726f;
+  background: #f4bab7;
+  font-size:80%;
+  font-weight:700;
+  border-radius:4px;
+  padding:2px 6px;
+  margin:auto 2px
 }
 
 /* add an underline for the title-reference interpretive text role */
 cite {
-    text-decoration: underline;
+  text-decoration: underline;
 }

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -53,7 +53,7 @@ h4 {
 
 /* add whitespace between list items */
 li {
-    margin-bottom: 7px;
+  margin-bottom: 7px;
 }
 
 li ol li {
@@ -98,7 +98,6 @@ html.writer-html5 .rst-content table.docutils :is(td, th) > p :is(.pre, code, pr
 .wy-table-responsive {
     margin-bottom: 24px;
     max-width: 100%;
-    overflow: visible;
 }
 
 /* no wrapping in builtin roles */

--- a/docs/global-include.rst
+++ b/docs/global-include.rst
@@ -1,0 +1,24 @@
+.. SPDX-License-Identifier: GPL-3.0-or-later
+.. SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+..
+    Global Includes File, should be added to the top of any .rst file so that we include a standard set of
+    repeatable code blocks with one line. Add this line to the top of an .rst file below the SPDX header:
+
+    .. include:: /global-include.rst
+
+.. Custom Interpretive Text Roles for longturn.net/Freeciv21
+.. role:: unit
+.. role:: improvement
+.. role:: wonder
+.. role:: advance
+
+.. Registered symbol
+.. |reg| unicode:: U+000AE .. REGISTERED SIGN
+
+.. horizontal rule
+.. |hr| raw:: html
+
+    <embed>
+        <hr>
+    </embed>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,13 +3,6 @@
 .. SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 .. SPDX-FileCopyrightText: louis94 <m_louis30@yahoo.com>
 
-.. Custom Interpretive Text Roles for longturn.net/Freeciv21
-.. role:: unit
-.. role:: improvement
-.. role:: wonder
-.. role:: advance
-
-
 Welcome to the Freeciv21 manual
 *******************************
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx<7.2  # See #2023
+sphinx
 sphinx_rtd_theme
 sphinx_last_updated_by_git


### PR DESCRIPTION
No top level issue. I took the time to do some cleanup after I noticed a collection of things while writing the LT Gamer's guide. This PR:

- Includes a new `global-includes` file that we can use at the top of each file. Makes it much easier to include a standard block.
- Fixes some issues w/ how tables were formatted. Had a bug in our custom `.css`.
- Ensures every table has a numref
- Many updates to the style guide
- Moved some tables to a `list-table` type. Fixes #1731, and makes managing the large tables in the LT Gamer's guide much simpler going forward.
- Stop pinning Sphinx to <7.2.