### PR TITLE
Remove the bought shields penalty after conquest

### DIFF
--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -3254,6 +3254,7 @@ static void nullify_caravan_and_disband_plus(struct city *pcity)
 void nullify_prechange_production(struct city *pcity)
 {
   nullify_caravan_and_disband_plus(pcity);
+  pcity->bought_shields = 0;
   pcity->before_change_shields = 0;
 }
 


### PR DESCRIPTION
Conquest removes all shields from the city production. This means the penalty on bought shields is no longer needed.

Not resetting to zero resulted in negative shields with the following sequence of events:
1. Player A buys something
2. Player B conquers the city (the shield stock becomes 0)
3. Player B changes production
4. The bought shields penalty is deduced from the empty shield stock
5. Negative shields!

This is needed in a few more cases such as sabotage. Implement the change in nullify_prechange_production that is already used when changing production.

Noticed by TriClad in Sim06.

Backport recommended.