### PR TITLE
chatline: Split creation of unit links from tile/city links

### DIFF
--- a/client/chatline.cpp
+++ b/client/chatline.cpp
@@ -685,18 +685,37 @@ int chat_widget::default_size(int lines)
 }
 
 /**
- * Makes link to tile/unit or city
+ * Makes link to tile or city
  */
-void chat_widget::make_link(struct tile *ptile)
+void chat_widget::make_tile_link(struct tile *ptile)
+{
+  make_link(ptile, false);
+}
+
+/**
+ * Makes link to unit; falls back to linking tile or city if there is
+ * no unit to link.
+ */
+void chat_widget::make_unit_link(struct tile *ptile)
+{
+  make_link(ptile, true);
+}
+
+/**
+ * Makes a link to tile or city by default. If use_unit is true, a
+ * link to a unit is generated first, before falling back to the
+ * default behavior.
+ */
+void chat_widget::make_link(struct tile *ptile, bool use_unit)
 {
   struct unit *punit;
   QString buf;
 
   punit = find_visible_unit(ptile);
-  if (tile_city(ptile)) {
-    buf = city_link(tile_city(ptile));
-  } else if (punit) {
+  if (use_unit && punit) {
     buf = unit_link(punit);
+  } else if (tile_city(ptile)) {
+    buf = city_link(tile_city(ptile));
   } else {
     buf = tile_link(ptile);
   }

--- a/client/chatline.h
+++ b/client/chatline.h
@@ -106,7 +106,8 @@ public:
 
   void append(const QString &str);
   chat_input *chat_line;
-  void make_link(struct tile *ptile);
+  void make_tile_link(struct tile *ptile);
+  void make_unit_link(struct tile *ptile);
   void update_widgets();
   int default_size(int lines);
   void take_focus();
@@ -128,7 +129,7 @@ protected:
 private:
   void chat_message_received(const QString &message,
                              const struct text_tag_list *tags) override;
-
+  void make_link(struct tile *ptile, bool use_unit);
   bool m_chat_visible = true;
   QTextBrowser *chat_output;
   QPushButton *remove_links;

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -21,7 +21,6 @@
 #include "citydlg_common.h"
 #include "client_main.h"
 #include "fc_client.h"
-#include "mapctrl.h"
 #include "mapctrl_common.h"
 #include "messagewin.h"
 #include "page_game.h"

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -320,7 +320,13 @@ void map_view::shortcut_pressed(shortcut_id id)
 
   case SC_MAKE_LINK:
     if (ptile != nullptr) {
-      queen()->chat->make_link(ptile);
+      queen()->chat->make_tile_link(ptile);
+    }
+    break;
+
+  case SC_MAKE_UNIT_LINK:
+    if (ptile != nullptr) {
+      queen()->chat->make_unit_link(ptile);
     }
     break;
 

--- a/client/shortcuts.cpp
+++ b/client/shortcuts.cpp
@@ -27,7 +27,6 @@
 // client
 #include "fc_client.h"
 #include "hudwidget.h"
-#include "options.h"
 #include "page_game.h"
 #include "views/view_map.h"
 

--- a/client/shortcuts.cpp
+++ b/client/shortcuts.cpp
@@ -187,7 +187,11 @@ static std::vector<fc_shortcut> default_shortcuts()
       {SC_PILLAGE, fc_shortcut::keyboard, Qt::Key_P | Qt::ShiftModifier,
        Qt::AllButtons, Qt::NoModifier, _("Pillage")},
       {SC_FALLOUT, fc_shortcut::keyboard, Qt::Key_N, Qt::AllButtons,
-       Qt::NoModifier, _("Clean Nuclear Fallout")}};
+       Qt::NoModifier, _("Clean Nuclear Fallout")},
+      {SC_MAKE_UNIT_LINK, fc_shortcut::mouse, QKeySequence(),
+       Qt::RightButton,
+       Qt::ControlModifier | Qt::AltModifier | Qt::ShiftModifier,
+       _("Show link to unit")}};
 }
 
 /**

--- a/client/shortcuts.h
+++ b/client/shortcuts.h
@@ -92,6 +92,7 @@ enum shortcut_id {
   SC_GOJOINCITY = 58,
   SC_PILLAGE = 59,
   SC_FALLOUT = 60,
+  SC_MAKE_UNIT_LINK = 61,
 };
 
 /**************************************************************************

--- a/docs/Manuals/Game/shortcut-options.rst
+++ b/docs/Manuals/Game/shortcut-options.rst
@@ -361,3 +361,8 @@ Clean Nuclear Fallout
   Instruct a unit to clean nuclear fallout on a tile.
 
   Default: ``N``
+
+Show link to unit
+  Copies a link to a unit to the :guilabel:`Server Chat/Command Line` widget on the main map.
+
+  Default: ``Ctrl+Alt+Shift`` plus Right mouse button


### PR DESCRIPTION
Splits the functionality to create unit links for the chatline from the functionality to create tile/city links. This allows the user to create a tile link for a tile, even if it is occupied by a unit.

| Shortcut           | Old behavior                   | New behavior                   |
| ------------------ | ------------------------------ | ------------------------------ |
| Ctrl-Alt-RMB       | Link to (unit -> city -> tile) | Link to (city ->tile)          |
| Ctrl-Alt-Shift-RMB | ./.                            | Link to (unit -> city -> tile) |

It is possible to restore the old behavior by rebinding the shortcuts.

No documentation changes are required, as this matches the existing chatline documentation in `data/helpdata.txt`.

Closes #2524