### PR TITLE
Fix loading resources from 2.6 saves in some rulesets

### DIFF
--- a/common/terrain.h
+++ b/common/terrain.h
@@ -35,7 +35,7 @@ enum special_river_move {
 // ===
 
 struct resource_type {
-
+  std::string rule_name;
   char id_old_save; // Single-character identifier used in old savegames.
 #define RESOURCE_NULL_IDENTIFIER '\0'
 #define RESOURCE_NONE_IDENTIFIER ' '


### PR DESCRIPTION
The savegame compatibility code was assuming that extras appeared in the same order as resources in the ruleset. This is obviously not always a valid assumption.

Fixes loading the SG4 scenario (I'll fix the ruleset so it works without this patch).

Backport suggested.