### PR TITLE
Proof of Concept: Links from tile info popup into help

### DIFF
--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -91,6 +91,38 @@ void update_help_fonts()
   }
 }
 
+QString create_help_link(const char *name, help_page_type hpt)
+{
+  QString s;
+  s = QString(name).toHtmlEscaped().replace(QLatin1String(" "),
+                                            QLatin1String("&nbsp;"));
+  return "<a href=" + QString::number(hpt) + "," + s + ">" + s + "</a>";
+}
+
+void follow_help_link(const QString &link)
+{
+  QStringList sl;
+  int n;
+  QString st;
+  enum help_page_type type;
+
+  sl = link.split(QStringLiteral(","));
+  n = sl.at(0).toInt();
+  type = static_cast<help_page_type>(n);
+  st = sl.at(1);
+  st = st.replace("\u00A0", QLatin1String(" "));
+
+  if (strcmp(qUtf8Printable(st), REQ_LABEL_NEVER) != 0
+      && strcmp(qUtf8Printable(st),
+                skip_intl_qualifier_prefix(REQ_LABEL_NONE))
+             != 0
+      && strcmp(qUtf8Printable(st),
+                advance_name_translation(advance_by_number(A_NONE)))
+             != 0) {
+    popup_help_dialog_typed(qUtf8Printable(st), type);
+  }
+}
+
 /**
    Constructor for help dialog
  */
@@ -715,10 +747,7 @@ void help_widget::add_extras_of_act_for_terrain(struct terrain *pterr,
  */
 QString help_widget::link_me(const char *str, help_page_type hpt)
 {
-  QString s;
-  s = QString(str).toHtmlEscaped().replace(QLatin1String(" "),
-                                           QLatin1String("&nbsp;"));
-  return " <a href=" + QString::number(hpt) + "," + s + ">" + s + "</a> ";
+  return " " + create_help_link(str, hpt) + " ";
 }
 
 /**
@@ -740,26 +769,7 @@ void help_widget::info_panel_done() { info_layout->addStretch(); }
  */
 void help_widget::anchor_clicked(const QString &link)
 {
-  QStringList sl;
-  int n;
-  QString st;
-  enum help_page_type type;
-
-  sl = link.split(QStringLiteral(","));
-  n = sl.at(0).toInt();
-  type = static_cast<help_page_type>(n);
-  st = sl.at(1);
-  st = st.replace("\u00A0", QLatin1String(" "));
-
-  if (strcmp(qUtf8Printable(st), REQ_LABEL_NEVER) != 0
-      && strcmp(qUtf8Printable(st),
-                skip_intl_qualifier_prefix(REQ_LABEL_NONE))
-             != 0
-      && strcmp(qUtf8Printable(st),
-                advance_name_translation(advance_by_number(A_NONE)))
-             != 0) {
-    popup_help_dialog_typed(qUtf8Printable(st), type);
-  }
+  follow_help_link(link);
 }
 
 /**

--- a/client/helpdlg.h
+++ b/client/helpdlg.h
@@ -138,3 +138,5 @@ public:
 void update_help_fonts();
 void popup_help_dialog_typed(const char *item, help_page_type htype);
 void popdown_help_dialog();
+QString create_help_link(const char *name, help_page_type hpt);
+void follow_help_link(const QString &link);

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -384,7 +384,7 @@ void map_view::shortcut_released(Qt::MouseButton bt)
   auto md = QApplication::keyboardModifiers();
   auto pos = mapFromGlobal(QCursor::pos()) / scale();
 
-  if (info_tile::shown()) {
+  if (info_tile::shown() && !info_tile::under_mouse()) {
     popdown_tile_info();
   }
 

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -183,19 +183,20 @@ const QString popup_info_text(struct tile *ptile)
       str += QString("/%1").arg(create_help_link(extra, HELP_EXTRA));
     }
     if (info->resource) {
-      str += QString(" (%1)").arg(create_help_link(info->resource, HELP_EXTRA));
+      str +=
+          QString(" (%1)").arg(create_help_link(info->resource, HELP_EXTRA));
     }
     if (!info->nuisances.empty()) {
       bool first_nuisance = true;
       str += QString(" [");
       for (auto nuisance : info->nuisances) {
         if (first_nuisance) {
-	  first_nuisance = false;
+          first_nuisance = false;
         } else {
-	  str += QString("/");
+          str += QString("/");
         }
 
-	str += QString("%1").arg(create_help_link(nuisance, HELP_EXTRA));
+        str += QString("%1").arg(create_help_link(nuisance, HELP_EXTRA));
       }
       str += QString("]");
     }

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -11,6 +11,9 @@
 #include <math.h> // ceil
 #include <string.h>
 
+// Qt
+#include <QRegularExpression>
+
 // utility
 #include "astring.h"
 #include "fcintl.h"
@@ -156,21 +159,21 @@ const QString popup_info_text(struct tile *ptile)
   bool first;
 
   index_to_map_pos(&tile_x, &tile_y, tile_index(ptile));
-  str = QString(_("Location: (%1, %2) [%3]\n"))
+  str = QString(_("Location: (%1, %2) [%3]<br>"))
             .arg(QString::number(tile_x), QString::number(tile_y),
                  QString::number(tile_continent(ptile)));
   index_to_native_pos(&nat_x, &nat_y, tile_index(ptile));
-  str += QString(_("Native coordinates: (%1, %2)\n"))
+  str += QString(_("Native coordinates: (%1, %2)<br>"))
              .arg(QString::number(nat_x), QString::number(nat_y));
 
   if (client_tile_get_known(ptile) == TILE_UNKNOWN) {
     str += QString(_("Unknown"));
     return str.trimmed();
   }
-  str += QString(_("Terrain: %1")).arg(tile_get_info_text(ptile, true, 0))
-         + qendl();
+  str += QString(_("Terrain: <a href=\"test\">%1</a>")).arg(tile_get_info_text(ptile, true, 0))
+         + qbr();
   str += QString(_("Food/Prod/Trade: %1")).arg(get_tile_output_text(ptile))
-         + qendl();
+         + qbr();
   first = true;
   extra_type_iterate(pextra)
   {
@@ -180,7 +183,7 @@ const QString popup_info_text(struct tile *ptile)
         str += QStringLiteral(",%1").arg(extra_name_translation(pextra));
       } else {
         str += QStringLiteral("%1").arg(extra_name_translation(pextra))
-               + qendl();
+               + qbr();
         first = false;
       }
     }
@@ -193,11 +196,11 @@ const QString popup_info_text(struct tile *ptile)
     get_full_nation(nation, sizeof(nation), owner);
 
     if (nullptr != client.conn.playing && owner == client.conn.playing) {
-      str += QString(_("Our territory")) + qendl();
+      str += QString(_("Our territory")) + qbr();
     } else if (nullptr != owner && nullptr == client.conn.playing) {
       // TRANS: "Territory of <username> (<nation + team>)"
       str +=
-          QString(_("Territory of %1 (%2)")).arg(username, nation) + qendl();
+          QString(_("Territory of %1 (%2)")).arg(username, nation) + qbr();
     } else if (nullptr != owner) {
       struct player_diplstate *ds =
           player_diplstate_get(client.conn.playing, owner);
@@ -210,7 +213,7 @@ const QString popup_info_text(struct tile *ptile)
             QString(PL_("Territory of %1 (%2) (%3 turn cease-fire)",
                         "Territory of %1 (%2) (%3 turn cease-fire)", turns))
                 .arg(username, nation, QString::number(turns))
-            + qendl();
+            + qbr();
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
         /* TRANS: "Territory of <username> (<nation + team>)
@@ -219,7 +222,7 @@ const QString popup_info_text(struct tile *ptile)
             QString(PL_("Territory of %1 (%2) (%3 turn armistice)",
                         "Territory of %1 (%2) (%3 turn armistice)", turns))
                 .arg(username, nation, QString::number(turns))
-            + qendl();
+            + qbr();
       } else {
         int type = ds->type;
         /* TRANS: "Territory of <username>
@@ -227,10 +230,10 @@ const QString popup_info_text(struct tile *ptile)
         str +=
             QString(_("Territory of %1 (%2 | %3)"))
                 .arg(username, nation, diplo_nation_plural_adjectives[type])
-            + qendl();
+            + qbr();
       }
     } else {
-      str += QString(_("Unclaimed territory")) + qendl();
+      str += QString(_("Unclaimed territory")) + qbr();
     }
   }
   if (pcity) {
@@ -247,7 +250,7 @@ const QString popup_info_text(struct tile *ptile)
       // TRANS: "City: <city name> | <username> (<nation + team>)"
       str += QString(_("City: %1 | %2 (%3)"))
                  .arg(city_name_get(pcity), username, nation)
-             + qendl();
+             + qbr();
     } else {
       struct player_diplstate *ds =
           player_diplstate_get(client_player(), owner);
@@ -260,7 +263,7 @@ const QString popup_info_text(struct tile *ptile)
                            "City: %1 | %2 (%3, %4 turn cease-fire)", turns))
                    .arg(city_name_get(pcity), username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
 
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
@@ -271,14 +274,14 @@ const QString popup_info_text(struct tile *ptile)
                            "City: %1 | %2 (%3, %4 turn armistice)", turns))
                    .arg(city_name_get(pcity), username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else {
         /* TRANS: "City: <city name> | <username>
          * (<nation + team>, <diplomatic state>)" */
         str += QString(_("City: %1 | %2 (%3, %4)"))
                    .arg(city_name_get(pcity), username, nation,
                         diplo_city_adjectives[ds->type])
-               + qendl();
+               + qbr();
       }
     }
     if (can_player_see_units_in_city(client_player(), pcity)) {
@@ -314,7 +317,7 @@ const QString popup_info_text(struct tile *ptile)
     if (!improvements.isEmpty()) {
       // TRANS: %s is a list of "and"-separated improvements.
       str += QString(_("   with %1.")).arg(strvec_to_and_list(improvements))
-             + qendl();
+             + qbr();
     }
 
     for (const auto &pfocus_unit : get_units_in_focus()) {
@@ -328,7 +331,7 @@ const QString popup_info_text(struct tile *ptile)
                    .arg(city_name_get(hcity),
                         QString::number(
                             trade_base_between_cities(hcity, pcity)))
-               + qendl();
+               + qbr();
       }
     }
   }
@@ -336,12 +339,12 @@ const QString popup_info_text(struct tile *ptile)
     const char *infratext = get_infrastructure_text(ptile->extras);
 
     if (*infratext != '\0') {
-      str += QString(_("Infrastructure: %1")).arg(infratext) + qendl();
+      str += QString(_("Infrastructure: %1")).arg(infratext) + qbr();
     }
   }
   activity_text = concat_tile_activity_text(ptile);
   if (activity_text.length() > 0) {
-    str += QString(_("Activity: %1")).arg(activity_text) + qendl();
+    str += QString(_("Activity: %1")).arg(activity_text) + qbr();
   }
   if (punit && !pcity) {
     struct player *owner = unit_owner(punit);
@@ -354,7 +357,7 @@ const QString popup_info_text(struct tile *ptile)
     if (dt < 0 && !can_unit_move_now(punit)) {
       char buf[64];
       format_time_duration(-dt, buf, sizeof(buf));
-      str += _("Can move in ") + QString(buf) + qendl();
+      str += _("Can move in ") + QString(buf) + qbr();
     }
 
     auto unit_description = QString();
@@ -378,29 +381,29 @@ const QString popup_info_text(struct tile *ptile)
                  .arg(unit_description)
                  .arg(username)
                  .arg(nation)
-             + qendl();
+             + qbr();
 
       if (game.info.citizen_nationality
           && unit_nationality(punit) != unit_owner(punit)) {
         if (hcity != nullptr) {
-          /* TRANS: on own line immediately following \n, "from <city> |
+          /* TRANS: on own line immediately following <br>, "from <city> |
            * <nationality> people" */
           str +=
               QString(_("from %1 | %2 people"))
                   .arg(city_name_get(hcity),
                        nation_adjective_for_player(unit_nationality(punit)))
-              + qendl();
+              + qbr();
         } else {
           /* TRANS: Nationality of the people comprising a unit, if
            * different from owner. */
           str +=
               QString(_("%1 people"))
                   .arg(nation_adjective_for_player(unit_nationality(punit)))
-              + qendl();
+              + qbr();
         }
       } else if (hcity != nullptr) {
-        // TRANS: on own line immediately following \n, ... <city>
-        str += QString(_("from %1")).arg(city_name_get(hcity)) + qendl();
+        // TRANS: on own line immediately following <br>, ... <city>
+        str += QString(_("from %1")).arg(city_name_get(hcity)) + qbr();
       }
     } else if (nullptr != owner) {
       struct player_diplstate *ds =
@@ -414,7 +417,7 @@ const QString popup_info_text(struct tile *ptile)
                            "Unit: %1 | %2 (%3, %4 turn cease-fire)", turns))
                    .arg(unit_description, username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
 
@@ -424,14 +427,14 @@ const QString popup_info_text(struct tile *ptile)
                            "Unit: %1 | %2 (%3, %4 turn armistice)", turns))
                    .arg(unit_description, username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else {
         /* TRANS: "Unit: <unit type> | <username> (<nation + team>,
          * <diplomatic state>)" */
         str += QString(_("Unit: %1 | %2 (%3, %4)"))
                    .arg(unit_description, username, nation,
                         diplo_city_adjectives[ds->type])
-               + qendl();
+               + qbr();
       }
     }
 
@@ -459,7 +462,7 @@ const QString popup_info_text(struct tile *ptile)
         str += QString(_("Chance to win: A:%1% D:%2%"))
                    .arg(QString::number(att_chance),
                         QString::number(def_chance))
-               + qendl();
+               + qbr();
       }
     }
 
@@ -486,22 +489,22 @@ const QString popup_info_text(struct tile *ptile)
         str += QStringLiteral(" (%1)").arg(veteran_name);
       }
     }
-    str += qendl();
+    str += qbr();
 
     if (!is_action_possible_on_unit(ACTION_SPY_BRIBE_UNIT, punit)) {
-      str += _("Bribing not possible.") + qendl();
+      str += _("Bribing not possible.") + qbr();
     } else if (unit_owner(punit) == client_player()
                || client_is_global_observer()) {
       // Show bribe cost for own units.
       str += QString(_("Probable bribe cost: %1"))
                  .arg(QString::number(unit_bribe_cost(punit, nullptr)))
-             + qendl();
+             + qbr();
     } else {
       // We can only give an (lower) boundary for units of other players.
       str +=
           QString(_("Estimated bribe cost: > %1"))
               .arg(QString::number(unit_bribe_cost(punit, client_player())))
-          + qendl();
+          + qbr();
     }
 
     if ((nullptr == client.conn.playing || owner == client.conn.playing)
@@ -512,7 +515,7 @@ const QString popup_info_text(struct tile *ptile)
     }
   }
 
-  return str.trimmed();
+  return str.trimmed().remove(QRegularExpression("<br>$"));
 }
 
 #define FAR_CITY_SQUARE_DIST (2 * (6 * 6))

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -17,6 +17,8 @@
 // utility
 #include "astring.h"
 #include "fcintl.h"
+#include "helpdata.h"
+#include "helpdlg.h"
 #include "log.h"
 #include "nation.h"
 #include "support.h"
@@ -176,12 +178,12 @@ const QString popup_info_text(struct tile *ptile)
     str += QString(_("Terrain:"));
 
     struct tile_info *info = tile_get_info(ptile);
-    str += QString(" <a href=\"test\">%1</a>").arg(info->name);
+    str += QString(" %1").arg(create_help_link(info->name, HELP_TERRAIN));
     for (auto extra : info->extras) {
-      str += QString("/<a href=\"test\">%1</a>").arg(extra);
+      str += QString("/%1").arg(create_help_link(extra, HELP_EXTRA));
     }
     if (info->resource) {
-      str += QString(" (<a href=\"test\">%1</a>)").arg(info->resource);
+      str += QString(" (%1)").arg(create_help_link(info->resource, HELP_EXTRA));
     }
     if (!info->nuisances.empty()) {
       bool first_nuisance = true;
@@ -193,7 +195,7 @@ const QString popup_info_text(struct tile *ptile)
 	  str += QString("/");
         }
 
-	str += QString("<a href=\"test\">%1</a>").arg(nuisance);
+	str += QString("%1").arg(create_help_link(nuisance, HELP_EXTRA));
       }
       str += QString("]");
     }

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -397,12 +397,14 @@ const QString popup_info_text(struct tile *ptile)
     if (punit->name.isEmpty()) {
       // TRANS: "Unit: <unit type> #<unit id>
       unit_description = QString(_("%1 #%2"))
-                             .arg(utype_name_translation(ptype))
+                             .arg(create_help_link(
+                                 utype_name_translation(ptype), HELP_UNIT))
                              .arg(punit->id);
     } else {
       // TRANS: "Unit: <unit type> #<unit id> "<unit name>"
       unit_description = QString(_("%1 #%2 \"%3\""))
-                             .arg(utype_name_translation(ptype))
+                             .arg(create_help_link(
+                                 utype_name_translation(ptype), HELP_UNIT))
                              .arg(punit->id)
                              .arg(punit->name);
     }

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -37,6 +37,7 @@
 #include "map.h"
 #include "movement.h"
 #include "research.h"
+#include "terrain.h"
 #include "tile.h"
 #include "traderoutes.h"
 #include "unitlist.h"
@@ -369,10 +370,30 @@ const QString popup_info_text(struct tile *ptile)
     }
   }
   {
-    const char *infratext = get_infrastructure_text(ptile->extras);
+    {
+      std::list<const char *> *infras =
+          get_infrastructure_texts(ptile->extras);
 
-    if (*infratext != '\0') {
-      str += QString(_("Infrastructure: %1")).arg(infratext) + qbr();
+      if (!infras->empty()) {
+        str += QString("%1 ").arg(_("Infrastructure:"));
+
+        bool first_infra = true;
+        for (auto infra : *infras) {
+          if (first_infra) {
+            first_infra = false;
+          } else {
+            str += "/";
+          }
+
+          str += QString(create_help_link(infra, HELP_EXTRA));
+          delete infra;
+        }
+
+        str += qbr();
+      }
+
+      infras->clear();
+      delete infras;
     }
   }
   activity_text = concat_tile_activity_text(ptile);

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -35,6 +35,7 @@
 #include "map.h"
 #include "movement.h"
 #include "research.h"
+#include "tile.h"
 #include "traderoutes.h"
 #include "unitlist.h"
 
@@ -170,8 +171,37 @@ const QString popup_info_text(struct tile *ptile)
     str += QString(_("Unknown"));
     return str.trimmed();
   }
-  str += QString(_("Terrain: <a href=\"test\">%1</a>")).arg(tile_get_info_text(ptile, true, 0))
-         + qbr();
+
+  {
+    str += QString(_("Terrain:"));
+
+    struct tile_info *info = tile_get_info(ptile);
+    str += QString(" <a href=\"test\">%1</a>").arg(info->name);
+    for (auto extra : info->extras) {
+      str += QString("/<a href=\"test\">%1</a>").arg(extra);
+    }
+    if (info->resource) {
+      str += QString(" (<a href=\"test\">%1</a>)").arg(info->resource);
+    }
+    if (!info->nuisances.empty()) {
+      bool first_nuisance = true;
+      str += QString(" [");
+      for (auto nuisance : info->nuisances) {
+        if (first_nuisance) {
+	  first_nuisance = false;
+        } else {
+	  str += QString("/");
+        }
+
+	str += QString("<a href=\"test\">%1</a>").arg(nuisance);
+      }
+      str += QString("]");
+    }
+    tile_delete_info(info);
+
+    str += qbr();
+  }
+
   str += QString(_("Food/Prod/Trade: %1")).arg(get_tile_output_text(ptile))
          + qbr();
   first = true;
@@ -182,8 +212,8 @@ const QString popup_info_text(struct tile *ptile)
       if (!first) {
         str += QStringLiteral(",%1").arg(extra_name_translation(pextra));
       } else {
-        str += QStringLiteral("%1").arg(extra_name_translation(pextra))
-               + qbr();
+        str +=
+            QStringLiteral("%1").arg(extra_name_translation(pextra)) + qbr();
         first = false;
       }
     }

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -23,6 +23,7 @@
 #include <Qt>
 
 // utility
+#include "helpdlg.h"
 #include "log.h"
 // client
 #include "citybar.h"
@@ -621,6 +622,13 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
   setWordWrap(true);
 
   calc_size();
+
+  connect(this, &QLabel::linkActivated, this, &info_tile::anchor_clicked);
+}
+
+void info_tile::anchor_clicked(const QString &link)
+{
+  follow_help_link(link);
 }
 
 /**

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -20,6 +20,7 @@
 #include <QCursor>
 #include <QMouseEvent>
 #include <QPainter>
+#include <Qt>
 
 // utility
 #include "log.h"
@@ -614,6 +615,8 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
     : QLabel(parent), itile(ptile)
 {
   setFont(fcFont::instance()->getFont(fonts::notify_label));
+  setTextFormat(Qt::RichText);
+  setTextInteractionFlags(Qt::LinksAccessibleByMouse);
   setText(popup_info_text(itile).trimmed());
   setWordWrap(true);
 

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -617,7 +617,7 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
   setFont(fcFont::instance()->getFont(fonts::notify_label));
   setTextFormat(Qt::RichText);
   setTextInteractionFlags(Qt::LinksAccessibleByMouse);
-  setText(popup_info_text(itile).trimmed());
+  setText(popup_info_text(itile));
   setWordWrap(true);
 
   calc_size();

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -17,6 +17,7 @@
 
 // Qt
 #include <QCommandLinkButton>
+#include <QCursor>
 #include <QMouseEvent>
 #include <QPainter>
 
@@ -666,6 +667,16 @@ void info_tile::drop()
 bool info_tile::shown() { return m_instance && m_instance->isVisible(); }
 
 /**
+ * Returns true, if the info tile is currently under the mouse cursor.
+ * TODO: Support multiple screens.
+ */
+bool info_tile::under_mouse()
+{
+  return m_instance->rect().contains(
+      m_instance->mapFromGlobal(QCursor::pos()));
+};
+
+/**
    Returns given instance
  */
 info_tile *info_tile::i(struct tile *p)
@@ -675,6 +686,11 @@ info_tile *info_tile::i(struct tile *p)
   }
   return m_instance;
 }
+
+/**
+ * Closes the info tile when the mouse leaves.
+ */
+void info_tile::leaveEvent(QEvent *event) { popdown_tile_info(); }
 
 /**
    Popups information label tile

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -120,6 +120,7 @@ public:
   static info_tile *i(struct tile *p = nullptr);
   static void drop();
   static bool shown();
+  static bool under_mouse();
 
   struct tile *itile;
 
@@ -127,6 +128,9 @@ private:
   info_tile(struct tile *ptile, QWidget *parent = 0);
   static info_tile *m_instance;
   void calc_size();
+
+protected:
+  virtual void leaveEvent(QEvent *event) override;
 };
 
 void popdown_tile_info();

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -130,7 +130,7 @@ private:
   void calc_size();
 
 protected:
-  virtual void leaveEvent(QEvent *event) override;
+  void leaveEvent(QEvent *event) override;
 
 private slots:
   void anchor_clicked(const QString &link);

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -131,6 +131,9 @@ private:
 
 protected:
   virtual void leaveEvent(QEvent *event) override;
+
+private slots:
+  void anchor_clicked(const QString &link);
 };
 
 void popdown_tile_info();

--- a/common/terrain.cpp
+++ b/common/terrain.cpp
@@ -10,6 +10,7 @@
  */
 
 // utility
+#include "fc_types.h"
 #include "fcintl.h"
 #include "log.h" // fc_assert
 #include "rand.h"
@@ -385,19 +386,9 @@ int count_terrain_flag_near_tile(const struct tile *ptile,
   return count;
 }
 
-/**
-   Return a (static) string with extra(s) name(s):
-     eg: "Mine"
-     eg: "Road/Farmland"
-   This only includes "infrastructure", i.e., man-made extras.
- */
-const char *get_infrastructure_text(bv_extras extras)
+std::list<const char *> *get_infrastructure_texts(bv_extras extras)
 {
-  static char s[256];
-  char *p;
-  int len;
-
-  s[0] = '\0';
+  std::list<const char *> *texts = new std::list<const char *>;
 
   extra_type_iterate(pextra)
   {
@@ -417,17 +408,43 @@ const char *get_infrastructure_text(bv_extras extras)
       extra_type_iterate_end;
 
       if (!hidden) {
-        cat_snprintf(s, sizeof(s), "%s/", extra_name_translation(pextra));
+        texts->push_back(fc_strdup(extra_name_translation(pextra)));
       }
     }
   }
   extra_type_iterate_end;
+
+  return texts;
+}
+
+/**
+   Return a (static) string with extra(s) name(s):
+     eg: "Mine"
+     eg: "Road/Farmland"
+   This only includes "infrastructure", i.e., man-made extras.
+ */
+const char *get_infrastructure_text(bv_extras extras)
+{
+  static char s[256];
+  char *p;
+  int len;
+
+  s[0] = '\0';
+
+  std::list<const char *> *texts = get_infrastructure_texts(extras);
+  for (auto text : *texts) {
+    cat_snprintf(s, sizeof(s), "%s/", text);
+    delete text;
+  }
 
   len = qstrlen(s);
   p = s + len - 1;
   if (len > 0 && *p == '/') {
     *p = '\0';
   }
+
+  texts->clear();
+  delete texts;
 
   return s;
 }

--- a/common/terrain.h
+++ b/common/terrain.h
@@ -12,6 +12,8 @@
       \____/        ********************************************************/
 #pragma once
 
+#include <list>
+
 // utility
 #include "bitvector.h"
 #include "shared.h"
@@ -295,6 +297,7 @@ void resource_types_free();
 
 // Special helper functions
 const char *get_infrastructure_text(bv_extras extras);
+std::list<const char *> *get_infrastructure_texts(bv_extras extras);
 struct extra_type *get_preferred_pillage(bv_extras extras);
 
 int terrain_extra_build_time(const struct terrain *pterrain,

--- a/common/tile.h
+++ b/common/tile.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <list>
+
 // utility
 #include "bitvector.h"
 
@@ -57,6 +59,17 @@ struct tile {
   char *label; // nullptr for no label
   char *spec_sprite;
 };
+
+struct tile_info {
+  char *name;
+  char *resource;
+  std::list<char *> extras;
+  std::list<char *> nuisances;
+};
+
+// `struct tile_info` and related functions.
+struct tile_info *tile_get_info(const struct tile *ptile);
+void tile_delete_info(struct tile_info *info);
 
 // 'struct tile_list' and related functions.
 #define SPECLIST_TAG tile

--- a/utility/astring.cpp
+++ b/utility/astring.cpp
@@ -64,6 +64,8 @@ QString strvec_to_and_list(const QVector<QString> &psv)
 
 QString qendl() { return QStringLiteral("\n"); }
 
+QString qbr() { return QStringLiteral("<br>"); }
+
 // break line after after n-th char
 QString break_lines(const QString &src, int after)
 {

--- a/utility/astring.h
+++ b/utility/astring.h
@@ -18,3 +18,4 @@ QString strvec_to_or_list(const QVector<QString> &psv);
 QString strvec_to_and_list(const QVector<QString> &psv);
 QString break_lines(const QString &src, int after);
 QString qendl();
+QString qbr();


### PR DESCRIPTION
Current state: If you open a tile info popup and move your mouse over the popup while holding the trigger, the popup will stay open when you release the trigger. You can then click the various info links and the corresponding help entry is opened.