### PR TITLE
Fix cycling through target units in choice_dialog

### DIFF
--- a/client/dialogs.h
+++ b/client/dialogs.h
@@ -26,6 +26,7 @@ class QGridLayout;
 class QHBoxLayout;
 class QItemSelection;
 class QKeyEvent;
+class QLabel;
 class QMouseEvent;
 class QObject;
 class QPaintEvent;
@@ -196,7 +197,7 @@ public:
 ***************************************************************************/
 class choice_dialog : public QWidget {
   Q_OBJECT
-  QPushButton *target_unit_button;
+  QLabel *target_unit_label;
   QVBoxLayout *layout;
   QHBoxLayout *unit_skip;
   QList<Choice_dialog_button *> buttons_list;


### PR DESCRIPTION
The "previous" and/or "next" buttons were doing something wrong when clicked repeatedly. A good old integer modulo will prevent that.

Improve the dialog by replacing a button without any action by a QLabel. Allocate QPixmaps on the stack as is idiomatic.

The dialog is still wrong in many different ways: among others, its message and buttons never change so it will happily let one "load" a unit into a Cannon (in this case it seems to pick a random unit on the tile). It also generates assertion errors because it asks the server for orders without going through the relevant routines in control.cpp.

See #2490. I couldn't reproduce the segfault but the assertions I get are at least always the same now (and these are harmless).

Backport suggested.