### PR TITLE
Add unit help link to info tile popup

### DIFF
--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -92,6 +92,50 @@ void update_help_fonts()
 }
 
 /**
+   Create a link into the help system for the entry with the given name and
+   help page type hpt.
+
+   The link is intended to be handled by the follow_help_link function.
+ */
+QString create_help_link(const char *name, help_page_type hpt)
+{
+  QString s;
+  s = QString(name).toHtmlEscaped().replace(QLatin1String(" "),
+                                            QLatin1String("&nbsp;"));
+  return "<a href=" + QString::number(hpt) + "," + s + ">" + s + "</a>";
+}
+
+/**
+   Open a link created by the create_help_link function.
+
+   The link consists of two parts, the name and help page type of the entry
+   that should be opened.
+ */
+void follow_help_link(const QString &link)
+{
+  QStringList sl;
+  int n;
+  QString st;
+  enum help_page_type type;
+
+  sl = link.split(QStringLiteral(","));
+  n = sl.at(0).toInt();
+  type = static_cast<help_page_type>(n);
+  st = sl.at(1);
+  st = st.replace("\u00A0", QLatin1String(" "));
+
+  if (strcmp(qUtf8Printable(st), REQ_LABEL_NEVER) != 0
+      && strcmp(qUtf8Printable(st),
+                skip_intl_qualifier_prefix(REQ_LABEL_NONE))
+             != 0
+      && strcmp(qUtf8Printable(st),
+                advance_name_translation(advance_by_number(A_NONE)))
+             != 0) {
+    popup_help_dialog_typed(qUtf8Printable(st), type);
+  }
+}
+
+/**
    Constructor for help dialog
  */
 help_dialog::help_dialog(QWidget *parent) : qfc_dialog(parent)
@@ -715,10 +759,7 @@ void help_widget::add_extras_of_act_for_terrain(struct terrain *pterr,
  */
 QString help_widget::link_me(const char *str, help_page_type hpt)
 {
-  QString s;
-  s = QString(str).toHtmlEscaped().replace(QLatin1String(" "),
-                                           QLatin1String("&nbsp;"));
-  return " <a href=" + QString::number(hpt) + "," + s + ">" + s + "</a> ";
+  return " " + create_help_link(str, hpt) + " ";
 }
 
 /**
@@ -735,31 +776,11 @@ void help_widget::add_info_separator()
 void help_widget::info_panel_done() { info_layout->addStretch(); }
 
 /**
-   Hyperlink clicked, link has 2 variables, string(name of given help)
-   and int(help_page_type)
+   Hyperlink clicked, open the corresponding entry.
  */
 void help_widget::anchor_clicked(const QString &link)
 {
-  QStringList sl;
-  int n;
-  QString st;
-  enum help_page_type type;
-
-  sl = link.split(QStringLiteral(","));
-  n = sl.at(0).toInt();
-  type = static_cast<help_page_type>(n);
-  st = sl.at(1);
-  st = st.replace("\u00A0", QLatin1String(" "));
-
-  if (strcmp(qUtf8Printable(st), REQ_LABEL_NEVER) != 0
-      && strcmp(qUtf8Printable(st),
-                skip_intl_qualifier_prefix(REQ_LABEL_NONE))
-             != 0
-      && strcmp(qUtf8Printable(st),
-                advance_name_translation(advance_by_number(A_NONE)))
-             != 0) {
-    popup_help_dialog_typed(qUtf8Printable(st), type);
-  }
+  follow_help_link(link);
 }
 
 /**

--- a/client/helpdlg.h
+++ b/client/helpdlg.h
@@ -135,6 +135,8 @@ public:
   struct unit_type *utype_max_values();
 };
 
+QString create_help_link(const char *name, help_page_type hpt);
+void follow_help_link(const QString &link);
 void update_help_fonts();
 void popup_help_dialog_typed(const char *item, help_page_type htype);
 void popdown_help_dialog();

--- a/client/helpdlg.h
+++ b/client/helpdlg.h
@@ -127,8 +127,6 @@ private:
 
 public slots:
   void set_topic(const help_item *item);
-private slots:
-  void anchor_clicked(const QString &link);
 
 public:
   struct terrain *terrain_max_values();

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -762,7 +762,7 @@ void hud_units::update_actions()
   img = cropped_img.scaledToHeight(height() - 5, Qt::SmoothTransformation);
   pix = QPixmap::fromImage(img);
   tile_label.setPixmap(pix);
-  unit_label.setToolTip(popup_info_text(punit->tile));
+  unit_label.setToolTip(popup_info_text(punit->tile, false));
   tile_label.setToolTip(popup_terrain_info(punit->tile));
   wwidth = wwidth + pix.width();
   delete tile_pixmap;

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -384,7 +384,7 @@ void map_view::shortcut_released(Qt::MouseButton bt)
   auto md = QApplication::keyboardModifiers();
   auto pos = mapFromGlobal(QCursor::pos()) / scale();
 
-  if (info_tile::shown()) {
+  if (info_tile::shown() && !info_tile::under_mouse()) {
     popdown_tile_info();
   }
 

--- a/client/mapctrl.cpp
+++ b/client/mapctrl.cpp
@@ -384,10 +384,6 @@ void map_view::shortcut_released(Qt::MouseButton bt)
   auto md = QApplication::keyboardModifiers();
   auto pos = mapFromGlobal(QCursor::pos()) / scale();
 
-  if (info_tile::shown() && !info_tile::under_mouse()) {
-    popdown_tile_info();
-  }
-
   auto sc = fc_shortcuts::sc()->get_shortcut(SC_SELECT_BUTTON);
   if (bt == sc.buttons && md == sc.modifiers) {
     if (king()->trade_gen.hover_city || king()->rallies.hover_city) {

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -534,7 +534,7 @@ const QString popup_info_text(struct tile *ptile, bool with_links)
     }
   }
 
-  return str.trimmed().remove(QRegularExpression("<br>$"));
+  return str.trimmed().remove(QRegularExpression(QStringLiteral("<br>$")));
 }
 
 #define FAR_CITY_SQUARE_DIST (2 * (6 * 6))

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -11,6 +11,9 @@
 #include <math.h> // ceil
 #include <string.h>
 
+// Qt
+#include <QRegularExpression>
+
 // utility
 #include "astring.h"
 #include "fcintl.h"
@@ -156,11 +159,11 @@ const QString popup_info_text(struct tile *ptile)
   bool first;
 
   index_to_map_pos(&tile_x, &tile_y, tile_index(ptile));
-  str = QString(_("Location: (%1, %2) [%3]\n"))
+  str = QString(_("Location: (%1, %2) [%3]<br>"))
             .arg(QString::number(tile_x), QString::number(tile_y),
                  QString::number(tile_continent(ptile)));
   index_to_native_pos(&nat_x, &nat_y, tile_index(ptile));
-  str += QString(_("Native coordinates: (%1, %2)\n"))
+  str += QString(_("Native coordinates: (%1, %2)<br>"))
              .arg(QString::number(nat_x), QString::number(nat_y));
 
   if (client_tile_get_known(ptile) == TILE_UNKNOWN) {
@@ -168,9 +171,9 @@ const QString popup_info_text(struct tile *ptile)
     return str.trimmed();
   }
   str += QString(_("Terrain: %1")).arg(tile_get_info_text(ptile, true, 0))
-         + qendl();
+         + qbr();
   str += QString(_("Food/Prod/Trade: %1")).arg(get_tile_output_text(ptile))
-         + qendl();
+         + qbr();
   first = true;
   extra_type_iterate(pextra)
   {
@@ -179,8 +182,8 @@ const QString popup_info_text(struct tile *ptile)
       if (!first) {
         str += QStringLiteral(",%1").arg(extra_name_translation(pextra));
       } else {
-        str += QStringLiteral("%1").arg(extra_name_translation(pextra))
-               + qendl();
+        str +=
+            QStringLiteral("%1").arg(extra_name_translation(pextra)) + qbr();
         first = false;
       }
     }
@@ -193,11 +196,11 @@ const QString popup_info_text(struct tile *ptile)
     get_full_nation(nation, sizeof(nation), owner);
 
     if (nullptr != client.conn.playing && owner == client.conn.playing) {
-      str += QString(_("Our territory")) + qendl();
+      str += QString(_("Our territory")) + qbr();
     } else if (nullptr != owner && nullptr == client.conn.playing) {
       // TRANS: "Territory of <username> (<nation + team>)"
       str +=
-          QString(_("Territory of %1 (%2)")).arg(username, nation) + qendl();
+          QString(_("Territory of %1 (%2)")).arg(username, nation) + qbr();
     } else if (nullptr != owner) {
       struct player_diplstate *ds =
           player_diplstate_get(client.conn.playing, owner);
@@ -210,7 +213,7 @@ const QString popup_info_text(struct tile *ptile)
             QString(PL_("Territory of %1 (%2) (%3 turn cease-fire)",
                         "Territory of %1 (%2) (%3 turn cease-fire)", turns))
                 .arg(username, nation, QString::number(turns))
-            + qendl();
+            + qbr();
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
         /* TRANS: "Territory of <username> (<nation + team>)
@@ -219,7 +222,7 @@ const QString popup_info_text(struct tile *ptile)
             QString(PL_("Territory of %1 (%2) (%3 turn armistice)",
                         "Territory of %1 (%2) (%3 turn armistice)", turns))
                 .arg(username, nation, QString::number(turns))
-            + qendl();
+            + qbr();
       } else {
         int type = ds->type;
         /* TRANS: "Territory of <username>
@@ -227,10 +230,10 @@ const QString popup_info_text(struct tile *ptile)
         str +=
             QString(_("Territory of %1 (%2 | %3)"))
                 .arg(username, nation, diplo_nation_plural_adjectives[type])
-            + qendl();
+            + qbr();
       }
     } else {
-      str += QString(_("Unclaimed territory")) + qendl();
+      str += QString(_("Unclaimed territory")) + qbr();
     }
   }
   if (pcity) {
@@ -247,7 +250,7 @@ const QString popup_info_text(struct tile *ptile)
       // TRANS: "City: <city name> | <username> (<nation + team>)"
       str += QString(_("City: %1 | %2 (%3)"))
                  .arg(city_name_get(pcity), username, nation)
-             + qendl();
+             + qbr();
     } else {
       struct player_diplstate *ds =
           player_diplstate_get(client_player(), owner);
@@ -260,7 +263,7 @@ const QString popup_info_text(struct tile *ptile)
                            "City: %1 | %2 (%3, %4 turn cease-fire)", turns))
                    .arg(city_name_get(pcity), username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
 
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
@@ -271,14 +274,14 @@ const QString popup_info_text(struct tile *ptile)
                            "City: %1 | %2 (%3, %4 turn armistice)", turns))
                    .arg(city_name_get(pcity), username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else {
         /* TRANS: "City: <city name> | <username>
          * (<nation + team>, <diplomatic state>)" */
         str += QString(_("City: %1 | %2 (%3, %4)"))
                    .arg(city_name_get(pcity), username, nation,
                         diplo_city_adjectives[ds->type])
-               + qendl();
+               + qbr();
       }
     }
     if (can_player_see_units_in_city(client_player(), pcity)) {
@@ -314,7 +317,7 @@ const QString popup_info_text(struct tile *ptile)
     if (!improvements.isEmpty()) {
       // TRANS: %s is a list of "and"-separated improvements.
       str += QString(_("   with %1.")).arg(strvec_to_and_list(improvements))
-             + qendl();
+             + qbr();
     }
 
     for (const auto &pfocus_unit : get_units_in_focus()) {
@@ -328,7 +331,7 @@ const QString popup_info_text(struct tile *ptile)
                    .arg(city_name_get(hcity),
                         QString::number(
                             trade_base_between_cities(hcity, pcity)))
-               + qendl();
+               + qbr();
       }
     }
   }
@@ -336,12 +339,12 @@ const QString popup_info_text(struct tile *ptile)
     const char *infratext = get_infrastructure_text(ptile->extras);
 
     if (*infratext != '\0') {
-      str += QString(_("Infrastructure: %1")).arg(infratext) + qendl();
+      str += QString(_("Infrastructure: %1")).arg(infratext) + qbr();
     }
   }
   activity_text = concat_tile_activity_text(ptile);
   if (activity_text.length() > 0) {
-    str += QString(_("Activity: %1")).arg(activity_text) + qendl();
+    str += QString(_("Activity: %1")).arg(activity_text) + qbr();
   }
   if (punit && !pcity) {
     struct player *owner = unit_owner(punit);
@@ -354,7 +357,7 @@ const QString popup_info_text(struct tile *ptile)
     if (dt < 0 && !can_unit_move_now(punit)) {
       char buf[64];
       format_time_duration(-dt, buf, sizeof(buf));
-      str += _("Can move in ") + QString(buf) + qendl();
+      str += _("Can move in ") + QString(buf) + qbr();
     }
 
     auto unit_description = QString();
@@ -378,29 +381,29 @@ const QString popup_info_text(struct tile *ptile)
                  .arg(unit_description)
                  .arg(username)
                  .arg(nation)
-             + qendl();
+             + qbr();
 
       if (game.info.citizen_nationality
           && unit_nationality(punit) != unit_owner(punit)) {
         if (hcity != nullptr) {
-          /* TRANS: on own line immediately following \n, "from <city> |
+          /* TRANS: on own line immediately following <br>, "from <city> |
            * <nationality> people" */
           str +=
               QString(_("from %1 | %2 people"))
                   .arg(city_name_get(hcity),
                        nation_adjective_for_player(unit_nationality(punit)))
-              + qendl();
+              + qbr();
         } else {
           /* TRANS: Nationality of the people comprising a unit, if
            * different from owner. */
           str +=
               QString(_("%1 people"))
                   .arg(nation_adjective_for_player(unit_nationality(punit)))
-              + qendl();
+              + qbr();
         }
       } else if (hcity != nullptr) {
-        // TRANS: on own line immediately following \n, ... <city>
-        str += QString(_("from %1")).arg(city_name_get(hcity)) + qendl();
+        // TRANS: on own line immediately following <br>, ... <city>
+        str += QString(_("from %1")).arg(city_name_get(hcity)) + qbr();
       }
     } else if (nullptr != owner) {
       struct player_diplstate *ds =
@@ -414,7 +417,7 @@ const QString popup_info_text(struct tile *ptile)
                            "Unit: %1 | %2 (%3, %4 turn cease-fire)", turns))
                    .arg(unit_description, username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else if (ds->type == DS_ARMISTICE) {
         int turns = ds->turns_left;
 
@@ -424,14 +427,14 @@ const QString popup_info_text(struct tile *ptile)
                            "Unit: %1 | %2 (%3, %4 turn armistice)", turns))
                    .arg(unit_description, username, nation,
                         QString::number(turns))
-               + qendl();
+               + qbr();
       } else {
         /* TRANS: "Unit: <unit type> | <username> (<nation + team>,
          * <diplomatic state>)" */
         str += QString(_("Unit: %1 | %2 (%3, %4)"))
                    .arg(unit_description, username, nation,
                         diplo_city_adjectives[ds->type])
-               + qendl();
+               + qbr();
       }
     }
 
@@ -459,7 +462,7 @@ const QString popup_info_text(struct tile *ptile)
         str += QString(_("Chance to win: A:%1% D:%2%"))
                    .arg(QString::number(att_chance),
                         QString::number(def_chance))
-               + qendl();
+               + qbr();
       }
     }
 
@@ -486,22 +489,22 @@ const QString popup_info_text(struct tile *ptile)
         str += QStringLiteral(" (%1)").arg(veteran_name);
       }
     }
-    str += qendl();
+    str += qbr();
 
     if (!is_action_possible_on_unit(ACTION_SPY_BRIBE_UNIT, punit)) {
-      str += _("Bribing not possible.") + qendl();
+      str += _("Bribing not possible.") + qbr();
     } else if (unit_owner(punit) == client_player()
                || client_is_global_observer()) {
       // Show bribe cost for own units.
       str += QString(_("Probable bribe cost: %1"))
                  .arg(QString::number(unit_bribe_cost(punit, nullptr)))
-             + qendl();
+             + qbr();
     } else {
       // We can only give an (lower) boundary for units of other players.
       str +=
           QString(_("Estimated bribe cost: > %1"))
               .arg(QString::number(unit_bribe_cost(punit, client_player())))
-          + qendl();
+          + qbr();
     }
 
     if ((nullptr == client.conn.playing || owner == client.conn.playing)
@@ -512,7 +515,7 @@ const QString popup_info_text(struct tile *ptile)
     }
   }
 
-  return str.trimmed();
+  return str.trimmed().remove(QRegularExpression("<br>$"));
 }
 
 #define FAR_CITY_SQUARE_DIST (2 * (6 * 6))

--- a/client/text.cpp
+++ b/client/text.cpp
@@ -44,6 +44,8 @@
 #include "climisc.h"
 #include "control.h"
 #include "goto.h"
+#include "helpdata.h"
+#include "helpdlg.h"
 
 #include "text.h"
 
@@ -364,12 +366,14 @@ const QString popup_info_text(struct tile *ptile)
     if (punit->name.isEmpty()) {
       // TRANS: "Unit: <unit type> #<unit id>
       unit_description = QString(_("%1 #%2"))
-                             .arg(utype_name_translation(ptype))
+                             .arg(create_help_link(
+                                 utype_name_translation(ptype), HELP_UNIT))
                              .arg(punit->id);
     } else {
       // TRANS: "Unit: <unit type> #<unit id> "<unit name>"
       unit_description = QString(_("%1 #%2 \"%3\""))
-                             .arg(utype_name_translation(ptype))
+                             .arg(create_help_link(
+                                 utype_name_translation(ptype), HELP_UNIT))
                              .arg(punit->id)
                              .arg(punit->name);
     }

--- a/client/text.h
+++ b/client/text.h
@@ -22,7 +22,7 @@ struct player_spaceship;
   These functions return static strings with generally useful text.
 ****************************************************************************/
 const QString get_tile_output_text(const struct tile *ptile);
-const QString popup_info_text(struct tile *ptile);
+const QString popup_info_text(struct tile *ptile, bool with_links);
 const QString get_nearest_city_text(struct city *pcity, int sq_dist);
 const QString unit_description(const unit *punit);
 const QString get_airlift_text(const std::vector<unit *> &units,

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -17,6 +17,7 @@
 
 // Qt
 #include <QCommandLinkButton>
+#include <QCursor>
 #include <QMouseEvent>
 #include <QPainter>
 
@@ -666,6 +667,15 @@ void info_tile::drop()
 bool info_tile::shown() { return m_instance && m_instance->isVisible(); }
 
 /**
+ * Returns true, if the info tile is currently under the mouse cursor.
+ */
+bool info_tile::under_mouse()
+{
+  return m_instance->rect().contains(
+      m_instance->mapFromGlobal(QCursor::pos()));
+};
+
+/**
    Returns given instance
  */
 info_tile *info_tile::i(struct tile *p)
@@ -675,6 +685,11 @@ info_tile *info_tile::i(struct tile *p)
   }
   return m_instance;
 }
+
+/**
+ * Closes the info tile when the mouse leaves.
+ */
+void info_tile::leaveEvent(QEvent *event) { popdown_tile_info(); }
 
 /**
    Popups information label tile

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -20,6 +20,7 @@
 #include <QCursor>
 #include <QMouseEvent>
 #include <QPainter>
+#include <Qt>
 
 // utility
 #include "log.h"
@@ -614,6 +615,8 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
     : QLabel(parent), itile(ptile)
 {
   setFont(fcFont::instance()->getFont(fonts::notify_label));
+  setTextFormat(Qt::RichText);
+  setTextInteractionFlags(Qt::LinksAccessibleByMouse);
   setText(popup_info_text(itile).trimmed());
   setWordWrap(true);
 

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -33,6 +33,7 @@
 #include "colors_common.h"
 #include "fc_client.h"
 #include "fonts.h"
+#include "helpdlg.h"
 #include "hudwidget.h"
 #include "mapctrl_common.h"
 #include "mapview_g.h"
@@ -621,6 +622,17 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
   setWordWrap(true);
 
   calc_size();
+
+  connect(this, &QLabel::linkActivated, this, &info_tile::anchor_clicked);
+}
+
+/**
+   Called when a link in the info_tile has been clicked. Tries to open
+   the corresponding entry in the help system.
+ */
+void info_tile::anchor_clicked(const QString &link)
+{
+  follow_help_link(link);
 }
 
 /**

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -618,7 +618,7 @@ info_tile::info_tile(struct tile *ptile, QWidget *parent)
   setFont(fcFont::instance()->getFont(fonts::notify_label));
   setTextFormat(Qt::RichText);
   setTextInteractionFlags(Qt::LinksAccessibleByMouse);
-  setText(popup_info_text(itile).trimmed());
+  setText(popup_info_text(itile, true));
   setWordWrap(true);
 
   calc_size();

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -120,6 +120,7 @@ public:
   static info_tile *i(struct tile *p = nullptr);
   static void drop();
   static bool shown();
+  static bool under_mouse();
 
   struct tile *itile;
 
@@ -127,6 +128,9 @@ private:
   info_tile(struct tile *ptile, QWidget *parent = 0);
   static info_tile *m_instance;
   void calc_size();
+
+protected:
+  virtual void leaveEvent(QEvent *event) override;
 };
 
 void popdown_tile_info();

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -130,7 +130,7 @@ private:
   void calc_size();
 
 protected:
-  virtual void leaveEvent(QEvent *event) override;
+  void leaveEvent(QEvent *event) override;
 
 private slots:
   void anchor_clicked(const QString &link);

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -131,6 +131,9 @@ private:
 
 protected:
   virtual void leaveEvent(QEvent *event) override;
+
+private slots:
+  void anchor_clicked(const QString &link);
 };
 
 void popdown_tile_info();

--- a/client/views/view_map.h
+++ b/client/views/view_map.h
@@ -12,6 +12,7 @@
 // Qt
 #include <QFrame>
 #include <QLabel>
+#include <QMenu>
 #include <QPointer>
 #include <QPropertyAnimation>
 #include <QQueue>
@@ -112,31 +113,15 @@ private:
 /**************************************************************************
   Information label about clicked tile
 **************************************************************************/
-class info_tile : public QLabel {
+class info_tile : public QMenu {
   Q_OBJECT
   Q_DISABLE_COPY(info_tile);
 
 public:
-  static info_tile *i(struct tile *p = nullptr);
-  static void drop();
-  static bool shown();
-  static bool under_mouse();
-
-  struct tile *itile;
-
-private:
-  info_tile(struct tile *ptile, QWidget *parent = 0);
-  static info_tile *m_instance;
-  void calc_size();
-
-protected:
-  void leaveEvent(QEvent *event) override;
-
-private slots:
-  void anchor_clicked(const QString &link);
+  explicit info_tile(struct tile *ptile, QWidget *parent = 0);
+  virtual ~info_tile();
 };
 
-void popdown_tile_info();
 void popup_tile_info(struct tile *ptile);
 bool mapview_is_frozen();
 

--- a/docs/Manuals/Game/top-bar.rst
+++ b/docs/Manuals/Game/top-bar.rst
@@ -54,6 +54,10 @@ on Plains. The popup information widget gives a great deal of information about 
 terrain type, and infrastructure improvements made to the tile. If a unit is on the tile, as in our example,
 you are also given details about the unit.
 
+If you move the mouse pointer over the popup while the :ref:`Popup Tile Info Shortcut <shortcut-popup-tile-info>`
+is active, the popup will stay open after you release the shortcut, as long as the mouse remains over the
+popup. That allows you to click the links in the popup, that open the corresponding help entry.
+
 .. _Unit Information:
 .. figure:: /_static/images/gui-elements/unit-info.png
   :scale: 65%

--- a/utility/astring.cpp
+++ b/utility/astring.cpp
@@ -61,6 +61,11 @@ QString strvec_to_and_list(const QVector<QString> &psv)
 
 QString qendl() { return QStringLiteral("\n"); }
 
+/**
+   Returns a "<br>" literal.
+ */
+QString qbr() { return QStringLiteral("<br>"); }
+
 // break line after after n-th char
 QString break_lines(const QString &src, int after)
 {

--- a/utility/astring.h
+++ b/utility/astring.h
@@ -12,3 +12,4 @@ QString strvec_to_or_list(const QVector<QString> &psv);
 QString strvec_to_and_list(const QVector<QString> &psv);
 QString break_lines(const QString &src, int after);
 QString qendl();
+QString qbr();


### PR DESCRIPTION
This PR adds the infrastructure needed to support links, pointing to help pages, in the info tile popup and adds a first help link for the selected unit.

This is based on #2540 and more PRs will follow to add all the links demonstrated in the Proof of Concept, but I will need some time to clean things. But it's probably better to split up the PRs anyway to keep the reviews manageable.