### PR TITLE
Add clang CMake Preset

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+# clang-tidy config file for Freeciv21
+
+# Include more checks over time
+Checks: >
+  -*,
+  misc-include-cleaner
+
+InheritParentConfig: true
+
+# We really only have .h files, but including all possible variations
+HeaderFileExtensions:
+  - h
+  - hh
+  - hpp
+  - hxx
+
+# We really only have .cpp files, but including all possible variations
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+
+HeaderFilterRegex: ''
+
+ExcludeHeaderFilterRegex: ''
+
+FormatStyle: file
+
+SystemHeaders: false
+
+UseColor: true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,7 @@
       "name": "ASan",
       "displayName": "Build Everything in debug mode with ASan and ccache",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build",
+      "binaryDir": "${sourceDir}/build-asan",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_CXX_FLAGS": "-O2 -DGLIBCXX_ASSERTIONS -fsanitize=address -fsanitize=leak -fsanitize=undefined -fsanitize-address-use-after-scope -fsanitize-recover=all",
@@ -88,6 +88,24 @@
       "environment": {
         "CXX": "clazy",
         "CLAZY_CHECKS": "level2,no-qstring-allocations,no-ctor-missing-parent-argument,no-missing-qobject-macro"
+      }
+    },
+    {
+      "name": "clang",
+      "displayName": "Build with Clang and clang-tidy checks included at compile tile.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-clang",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_C_CLANG_TIDY": "clang-tidy",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
+        "FREECIV_ENABLE_TOOLS": "ON",
+        "FREECIV_ENABLE_SERVER": "ON",
+        "FREECIV_ENABLE_CLIENT": "ON",
+        "FREECIV_ENABLE_NLS": "OFF"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,7 +105,7 @@
         "FREECIV_ENABLE_TOOLS": "ON",
         "FREECIV_ENABLE_SERVER": "ON",
         "FREECIV_ENABLE_CLIENT": "ON",
-        "FREECIV_ENABLE_NLS": "OFF"
+        "FREECIV_ENABLE_NLS": "ON"
       }
     },
     {


### PR DESCRIPTION
Part of #2464. 

The idea is to enable clang as the compiler and include checks into the build system. We can add more checks as we clean up code as refactoring continues.