### PR TITLE
Remove deprecated qAsConst

### DIFF
--- a/ai/default/aisettler.cpp
+++ b/ai/default/aisettler.cpp
@@ -211,7 +211,7 @@ cityresult::cityresult(struct tile *ptile)
  */
 cityresult::~cityresult()
 {
-  for (const auto &ptdc : qAsConst(tdc_hash)) {
+  for (const auto &ptdc : std::as_const(tdc_hash)) {
     delete[] ptdc;
   }
 }
@@ -1142,7 +1142,7 @@ void dai_auto_settler_reset(struct ai_type *ait, struct player *pplayer)
   ai->settler->cache.save = 0;
 #endif // FREECIV_DEBUG
 
-  for (const auto *ptdc : qAsConst(*ai->settler->tdc_hash)) {
+  for (const auto *ptdc : std::as_const(*ai->settler->tdc_hash)) {
     delete[] ptdc;
   }
   ai->settler->tdc_hash->clear();

--- a/client/attribute.cpp
+++ b/client/attribute.cpp
@@ -70,7 +70,7 @@ void attribute_init() {}
  */
 void attribute_free()
 {
-  for (auto *at : qAsConst(*attribute_hash)) {
+  for (auto *at : std::as_const(*attribute_hash)) {
     delete[] static_cast<char *>(at);
   }
   attribute_hash->clear();
@@ -114,7 +114,7 @@ static enum attribute_serial serialize_hash(attributeHash *hash,
   total_length += entries * (4 + 4 + 4 + 2 + 2); // value_size + key
   i = 0;
 
-  for (auto *pvalue : qAsConst(*hash)) {
+  for (auto *pvalue : std::as_const(*hash)) {
     struct data_in din;
 
     dio_input_init(&din, pvalue, 4);

--- a/client/citydlg.cpp
+++ b/client/citydlg.cpp
@@ -2294,7 +2294,7 @@ void city_font_update()
 
   auto f = fcFont::instance()->getFont(fonts::notify_label);
 
-  for (auto i : qAsConst(l)) {
+  for (auto i : std::as_const(l)) {
     if (i->property(fonts::notify_label).isValid()) {
       i->setFont(f);
     }

--- a/client/dialogs.cpp
+++ b/client/dialogs.cpp
@@ -1718,7 +1718,7 @@ void popup_action_selection(struct unit *actor_unit,
   unit_act = qdef_act::action()->vs_unit_get();
   city_act = qdef_act::action()->vs_city_get();
 
-  for (auto caras : qAsConst(king()->trade_gen.lines)) {
+  for (auto caras : std::as_const(king()->trade_gen.lines)) {
     if (caras.autocaravan == actor_unit) {
       int i;
       if (nullptr != game_unit_by_number(actor_unit->id)

--- a/client/editor.cpp
+++ b/client/editor.cpp
@@ -643,7 +643,8 @@ static void popup_properties(struct tile *ptile)
   tiles = tile_list_new();
 
   if (editor_tile_is_selected(ptile)) {
-    for (const auto *sel_tile : qAsConst(*editor->selected_tile_table)) {
+    for (const auto *sel_tile :
+         std::as_const(*editor->selected_tile_table)) {
       if (can_edit_tile_properties(const_cast<tile *>(sel_tile))) {
         tile_list_append(tiles, const_cast<tile *>(sel_tile));
       }
@@ -1140,7 +1141,7 @@ void editor_apply_tool_to_selection()
   }
 
   connection_do_buffer(&client.conn);
-  for (const auto *ptile : qAsConst(*editor->selected_tile_table)) {
+  for (const auto *ptile : std::as_const(*editor->selected_tile_table)) {
     editor_apply_tool(ptile, true);
   }
   editor_notify_edit_finished();
@@ -1957,7 +1958,7 @@ const struct tile *editor_get_selection_center()
 
   origin = map_pos_to_tile(&(wld.map), 0, 0);
   fc_assert_ret_val(origin, nullptr);
-  for (const auto *ptile : qAsConst(*editor->selected_tile_table)) {
+  for (const auto *ptile : std::as_const(*editor->selected_tile_table)) {
     map_distance_vector(&dx, &dy, origin, ptile);
     xsum += dx;
     ysum += dy;

--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -142,7 +142,7 @@ void load_fonts()
   const auto il =
       find_files_in_path(get_data_dirs(), QStringLiteral("fonts"), false);
   if (!il.isEmpty()) {
-    for (const auto &info : qAsConst(il)) {
+    for (const auto &info : std::as_const(il)) {
       QDirIterator iterator(
           info.absolutePath(),
           {QStringLiteral("*.otf"), QStringLiteral("*.ttf")}, QDir::Files,

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -265,7 +265,7 @@ void help_dialog::make_tree()
   struct terrain *pterrain;
   struct unit_type *f_type;
 
-  for (const auto *pitem : qAsConst(*help_nodes)) {
+  for (const auto *pitem : std::as_const(*help_nodes)) {
     const char *s;
     int last;
     title = pitem->topic;
@@ -585,19 +585,19 @@ void help_widget::update_fonts()
   l = findChildren<QWidget *>();
 
   auto f = fcFont::instance()->getFont(fonts::notify_label);
-  for (auto i : qAsConst(l)) {
+  for (auto i : std::as_const(l)) {
     if (i->property(fonts::help_label).isValid()) {
       i->setFont(f);
     }
   }
   f = fcFont::instance()->getFont(fonts::help_text);
-  for (auto i : qAsConst(l)) {
+  for (auto i : std::as_const(l)) {
     if (i->property(fonts::help_text).isValid()) {
       i->setFont(f);
     }
   }
   f = fcFont::instance()->getFont(fonts::default_font);
-  for (auto i : qAsConst(l)) {
+  for (auto i : std::as_const(l)) {
     if (i->property(fonts::default_font).isValid()) {
       i->setFont(f);
     }

--- a/client/hudwidget.cpp
+++ b/client/hudwidget.cpp
@@ -981,7 +981,7 @@ int unit_actions::update_actions()
   clear_layout();
   setUpdatesEnabled(false);
 
-  for (auto *a : qAsConst(actions)) {
+  for (auto *a : std::as_const(actions)) {
     delete a;
   }
   qDeleteAll(actions);
@@ -1143,7 +1143,7 @@ int unit_actions::update_actions()
       this, fcIcons::instance()->getIcon(QStringLiteral("done")),
       SC_DONE_MOVING));
 
-  for (auto *a : qAsConst(actions)) {
+  for (auto *a : std::as_const(actions)) {
     const auto shortcut =
         fc_shortcuts::sc()->get_shortcut(a->action_shortcut);
     if (shortcut.is_valid()) {
@@ -1656,7 +1656,7 @@ void hud_battle_log::update_size()
   king()->qt_settings.battlelog_scale = scale;
   delete layout();
   main_layout = new QVBoxLayout;
-  for (auto *hudc : qAsConst(lhuc)) {
+  for (auto *hudc : std::as_const(lhuc)) {
     hudc->set_scale(scale);
     main_layout->addWidget(hudc);
     hudc->set_fading(1.0);
@@ -1694,7 +1694,7 @@ void hud_battle_log::add_combat_info(hud_unit_combat *huc)
     hudc = lhuc.takeLast();
     delete hudc;
   }
-  for (auto *hudc : qAsConst(lhuc)) {
+  for (auto *hudc : std::as_const(lhuc)) {
     main_layout->addWidget(hudc);
     hudc->set_fading(1.0);
   }
@@ -1743,10 +1743,10 @@ void hud_battle_log::moveEvent(QMoveEvent *event)
 void hud_battle_log::timerEvent(QTimerEvent *event)
 {
   if (m_timer.elapsed() > 4000 && m_timer.elapsed() < 20000) {
-    for (auto *hudc : qAsConst(lhuc)) {
+    for (auto *hudc : std::as_const(lhuc)) {
       if (hudc->get_focus()) {
         m_timer.restart();
-        for (auto *hupdate : qAsConst(lhuc)) {
+        for (auto *hupdate : std::as_const(lhuc)) {
           hupdate->set_fading(1.0);
         }
         return;
@@ -1764,7 +1764,7 @@ void hud_battle_log::timerEvent(QTimerEvent *event)
  */
 void hud_battle_log::showEvent(QShowEvent *event)
 {
-  for (auto *hupdate : qAsConst(lhuc)) {
+  for (auto *hupdate : std::as_const(lhuc)) {
     hupdate->set_fading(1.0);
   }
   m_timer.restart();

--- a/client/menu.cpp
+++ b/client/menu.cpp
@@ -163,7 +163,7 @@ void gov_menu::create()
   int gov_count, i;
 
   // Clear any content
-  for (auto *action : qAsConst(actions)) {
+  for (auto *action : std::as_const(actions)) {
     removeAction(action);
     action->deleteLater();
   }
@@ -243,7 +243,7 @@ QSet<gov_menu *> gov_menu::instances = QSet<gov_menu *>();
  */
 void gov_menu::create_all()
 {
-  for (gov_menu *m : qAsConst(instances)) {
+  for (gov_menu *m : std::as_const(instances)) {
     m->create();
   }
 }
@@ -253,7 +253,7 @@ void gov_menu::create_all()
  */
 void gov_menu::update_all()
 {
-  for (gov_menu *m : qAsConst(instances)) {
+  for (gov_menu *m : std::as_const(instances)) {
     m->update();
   }
 }
@@ -283,7 +283,7 @@ static void reset_menu_and_sub_menues(QMenu *menu)
 {
   QList<QAction *> actions = menu->actions();
   // Delete each existing menu item.
-  for (auto *action : qAsConst(actions)) {
+  for (auto *action : std::as_const(actions)) {
     if (action->menu() != nullptr) {
       // Delete the sub menu
       reset_menu_and_sub_menues(action->menu());
@@ -437,7 +437,7 @@ void go_act_menu::update()
    * at the current tile is pointless since it should be performed at the
    * target tile. */
   QList<QAction *> keys = items.keys();
-  for (QAction *item : qAsConst(keys)) {
+  for (QAction *item : std::as_const(keys)) {
     if (units_can_do_action(get_units_in_focus(), items.value(item), true)) {
       item->setVisible(true);
       can_do_something = true;
@@ -473,7 +473,7 @@ QSet<go_act_menu *> go_act_menu::instances;
  */
 void go_act_menu::reset_all()
 {
-  for (go_act_menu *m : qAsConst(instances)) {
+  for (go_act_menu *m : std::as_const(instances)) {
     m->reset();
   }
 }
@@ -483,7 +483,7 @@ void go_act_menu::reset_all()
  */
 void go_act_menu::update_all()
 {
-  for (go_act_menu *m : qAsConst(instances)) {
+  for (go_act_menu *m : std::as_const(instances)) {
     m->update();
   }
 }
@@ -1367,7 +1367,7 @@ void mr_menu::update_roads_menu()
     return;
   }
   QList<QAction *> actions = roads_menu->actions();
-  for (auto *act : qAsConst(actions)) {
+  for (auto *act : std::as_const(actions)) {
     removeAction(act);
     act->deleteLater();
   }
@@ -1416,7 +1416,7 @@ void mr_menu::update_bases_menu()
   }
 
   QList<QAction *> actions = bases_menu->actions();
-  for (auto *act : qAsConst(actions)) {
+  for (auto *act : std::as_const(actions)) {
     removeAction(act);
     act->deleteLater();
   }
@@ -1459,7 +1459,7 @@ void mr_menu::nonunit_sensitivity()
 {
   QMultiHash<munit, QAction *>::iterator i;
   QList<munit> keys = menu_list.keys();
-  for (munit key : qAsConst(keys)) {
+  for (munit key : std::as_const(keys)) {
     i = menu_list.find(key);
     while (i != menu_list.end() && i.key() == key) {
       switch (key) {
@@ -1531,7 +1531,7 @@ void mr_menu::menus_sensitive()
   }
 
   /** Disable first all sensitive menus */
-  for (QAction *a : qAsConst(menu_list)) {
+  for (QAction *a : std::as_const(menu_list)) {
     a->setEnabled(false);
   }
 
@@ -1552,7 +1552,7 @@ void mr_menu::menus_sensitive()
   units_all_same_tile = units_on_the_same_tile(punits);
 
   keys = menu_list.keys();
-  for (munit key : qAsConst(keys)) {
+  for (munit key : std::as_const(keys)) {
     i = menu_list.find(key);
     while (i != menu_list.end() && i.key() == key) {
       switch (key) {
@@ -2195,7 +2195,7 @@ void mr_menu::slot_autocaravan()
   punit = head_of_units_in_focus();
   homecity = game_city_by_number(punit->homecity);
   home_tile = homecity->tile;
-  for (auto gilles : qAsConst(king()->trade_gen.lines)) {
+  for (auto gilles : std::as_const(king()->trade_gen.lines)) {
     if ((gilles.t1 == home_tile || gilles.t2 == home_tile)
         && gilles.autocaravan == nullptr) {
       // send caravan
@@ -2645,9 +2645,9 @@ void mr_menu::tileset_custom_load()
 
   // Gather the list of tilesets
   QStringList tilesets;
-  for (auto const &s : qAsConst(sl)) {
+  for (auto const &s : std::as_const(sl)) {
     poption = optset_option_by_name(client_optset, qUtf8Printable(s));
-    for (const auto &name : qAsConst(*get_tileset_list(poption))) {
+    for (const auto &name : std::as_const(*get_tileset_list(poption))) {
       tilesets.append(name);
     }
   }
@@ -2658,7 +2658,7 @@ void mr_menu::tileset_custom_load()
                  tilesets.end());
 
   // Add the buttons
-  for (const auto &name : qAsConst(tilesets)) {
+  for (const auto &name : std::as_const(tilesets)) {
     but = new QPushButton(name);
     connect(but, &QAbstractButton::clicked, this,
             &mr_menu::load_new_tileset);

--- a/client/optiondlg.cpp
+++ b/client/optiondlg.cpp
@@ -50,7 +50,7 @@ QString split_text(const QString &text, bool cut)
   int j = 0;
 
   sl = text.split(QStringLiteral("\n"));
-  for (const QString &s : qAsConst(sl)) {
+  for (const QString &s : std::as_const(sl)) {
     st = s;
     while (st.count() >= 80) {
       str = st.left(80);
@@ -91,7 +91,7 @@ QString cut_helptext(const QString &text)
 
   // Remove all lines from help which has '*' in first 3 chars
   sl = text.split('\n');
-  for (const QString &s : qAsConst(sl)) {
+  for (const QString &s : std::as_const(sl)) {
     if (s.count() > 2) {
       if (s.at(0) != '*' && s.at(1) != '*' && s.at(2) != '*') {
         ret_str = ret_str + s + '\n';

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -660,7 +660,7 @@ void fc_game_tab_widget::current_changed(int index)
     return;
   }
 
-  for (auto *sw : qAsConst(queen()->top_bar_wdg->objects)) {
+  for (auto *sw : std::as_const(queen()->top_bar_wdg->objects)) {
     sw->update();
   }
   currentWidget()->hide();

--- a/client/page_pregame.cpp
+++ b/client/page_pregame.cpp
@@ -411,7 +411,7 @@ void page_pregame::start_page_menu(QPoint pos)
     return;
   }
 
-  for (auto *item : qAsConst(sel_items)) {
+  for (auto *item : std::as_const(sel_items)) {
     qvar = item->data(0, Qt::UserRole);
     qvar2 = item->data(1, Qt::UserRole);
 

--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -158,7 +158,7 @@ void fcUdpScan::readPendingDatagrams()
   while (hasPendingDatagrams()) {
     bool add = true;
     QNetworkDatagram qn = receiveDatagram();
-    for (auto const &d : qAsConst(datagram_list)) {
+    for (auto const &d : std::as_const(datagram_list)) {
       QByteArray d1 = d.data();
       QByteArray d2 = qn.data();
       if (d1.data() == d2.data()) {
@@ -191,7 +191,7 @@ enum server_scan_status fcUdpScan::get_server_list(struct server_scan *scan)
 
   struct server *pserver;
 
-  for (auto const &datagram : qAsConst(datagram_list)) {
+  for (auto const &datagram : std::as_const(datagram_list)) {
     if (datagram.isNull() || !datagram.isValid()) {
       continue;
     }

--- a/client/themes.cpp
+++ b/client/themes.cpp
@@ -225,7 +225,7 @@ QStringList get_useable_themes_in_directory(QString &directory)
   sl << dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
   name = QString(directory);
 
-  for (auto const &str : qAsConst(sl)) {
+  for (auto const &str : std::as_const(sl)) {
 #ifdef Q_OS_WIN
     // "System" creates endless problems on Windows, see #1287 #756
     if (str == QStringLiteral("System")) {

--- a/client/themes_common.cpp
+++ b/client/themes_common.cpp
@@ -79,7 +79,7 @@ const QVector<QString> *get_themes_list(const struct option *poption)
 {
   if (themes_list->isEmpty()) {
     for (int i = 0; i < num_directories; i++) {
-      for (const auto &theme : qAsConst(directories[i].themes)) {
+      for (const auto &theme : std::as_const(directories[i].themes)) {
         bool found = false;
         for (int k = 0; k < themes_list->count(); k++) {
           if (themes_list->at(k) == theme) {

--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -2692,6 +2692,7 @@ void finish_loading_sprites(struct tileset *t)
  */
 void tileset_load_tiles(struct tileset *t)
 {
+  fc_assert_ret(t != nullptr);
   tileset_lookup_sprite_tags(t);
   finish_loading_sprites(t);
 }

--- a/client/tileset/tilespec.cpp
+++ b/client/tileset/tilespec.cpp
@@ -736,7 +736,7 @@ const QVector<QString> *get_tileset_list(const struct option *poption)
 
   QVector<QString> *list = fileinfolist(get_data_dirs(), TILESPEC_SUFFIX);
   tilesets[idx]->clear();
-  for (const auto &file : qAsConst(*list)) {
+  for (const auto &file : std::as_const(*list)) {
     struct tileset *t = tileset_read_toplevel(file, false, topo);
     if (t) {
       tilesets[idx]->append(file);
@@ -862,7 +862,7 @@ bool tilespec_try_read(const QString &tileset_name, bool verbose,
     QVector<QString> *list = fileinfolist(get_data_dirs(), TILESPEC_SUFFIX);
 
     original = false;
-    for (const auto &file : qAsConst(*list)) {
+    for (const auto &file : std::as_const(*list)) {
       struct tileset *t =
           tileset_read_toplevel(qUtf8Printable(file), false, topo_id);
 
@@ -1040,7 +1040,7 @@ bool tilespec_reread(const QString &name, bool game_fully_initialized)
 
   // New style notifications. See QApplication::setStyle for inspiration
   auto widgets = QApplication::allWidgets();
-  for (auto *w : qAsConst(widgets)) {
+  for (auto *w : std::as_const(widgets)) {
     if (w->windowType() != Qt::Desktop) {
       QEvent e(TilesetChanged);
       QApplication::sendEvent(w, &e);
@@ -1113,7 +1113,7 @@ static QPixmap *load_gfx_file(const char *gfx_filename)
   // it). This dramatically improves tileset loading performance on Windows.
   supported.prepend("png");
 
-  for (auto gfx_fileext : qAsConst(supported)) {
+  for (auto gfx_fileext : std::as_const(supported)) {
     QString real_full_name;
     QString full_name =
         QStringLiteral("%1.%2").arg(gfx_filename, gfx_fileext.data());
@@ -2689,7 +2689,7 @@ static void tileset_lookup_sprite_tags(struct tileset *t)
  */
 void finish_loading_sprites(struct tileset *t)
 {
-  for (auto *sf : qAsConst(*t->specfiles)) {
+  for (auto *sf : std::as_const(*t->specfiles)) {
     if (sf->big_sprite) {
       delete sf->big_sprite;
       sf->big_sprite = nullptr;
@@ -3287,7 +3287,7 @@ void tileset_free_tiles(struct tileset *t)
     t->sprite_hash = nullptr;
   }
 
-  for (auto *ss : qAsConst(*t->small_sprites)) {
+  for (auto *ss : std::as_const(*t->small_sprites)) {
     if (ss->file) {
       delete[] ss->file;
     }
@@ -3296,7 +3296,7 @@ void tileset_free_tiles(struct tileset *t)
   }
   t->small_sprites->clear();
 
-  for (auto *sf : qAsConst(*t->specfiles)) {
+  for (auto *sf : std::as_const(*t->specfiles)) {
     delete[] sf->file_name;
     if (sf->big_sprite) {
       delete sf->big_sprite;

--- a/client/tradecalculation.cpp
+++ b/client/tradecalculation.cpp
@@ -64,11 +64,11 @@ void trade_generator::add_all_cities()
  */
 void trade_generator::clear_trade_planing()
 {
-  for (auto *pcity : qAsConst(virtual_cities)) {
+  for (auto *pcity : std::as_const(virtual_cities)) {
     destroy_city_virtual(pcity);
   }
   virtual_cities.clear();
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     delete tc;
   }
   cities.clear();
@@ -95,7 +95,7 @@ void trade_generator::add_tile(struct tile *ptile)
   struct city *pcity;
   pcity = tile_city(ptile);
 
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (pcity != nullptr) {
       if (tc->city == pcity) {
         remove_city(pcity);
@@ -123,7 +123,7 @@ void trade_generator::add_tile(struct tile *ptile)
  */
 void trade_generator::remove_city(struct city *pcity)
 {
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (tc->city->tile == pcity->tile) {
       cities.removeAll(tc);
       queen()->chat->append(
@@ -139,7 +139,7 @@ void trade_generator::remove_city(struct city *pcity)
  */
 void trade_generator::remove_virtual_city(tile *ptile)
 {
-  for (auto *c : qAsConst(virtual_cities)) {
+  for (auto *c : std::as_const(virtual_cities)) {
     if (c->tile == ptile) {
       virtual_cities.removeAll(c);
       queen()->chat->append(
@@ -147,7 +147,7 @@ void trade_generator::remove_virtual_city(tile *ptile)
     }
   }
 
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (tc->city->tile == ptile) {
       cities.removeAll(tc);
       return;
@@ -169,19 +169,19 @@ void trade_generator::calculate()
     tdone = true;
     std::shuffle(cities.begin(), cities.end(), g);
     lines.clear();
-    for (auto *tc : qAsConst(cities)) {
+    for (auto *tc : std::as_const(cities)) {
       tc->pos_cities.clear();
       tc->new_tr_cities.clear();
       tc->curr_tr_cities.clear();
     }
-    for (auto *tc : qAsConst(cities)) {
+    for (auto *tc : std::as_const(cities)) {
       tc->trade_num = city_num_trade_routes(tc->city);
       tc->poss_trade_num = 0;
       tc->pos_cities.clear();
       tc->new_tr_cities.clear();
       tc->curr_tr_cities.clear();
       tc->done = false;
-      for (auto *ttc : qAsConst(cities)) {
+      for (auto *ttc : std::as_const(cities)) {
         if (!have_cities_trade_route(tc->city, ttc->city)
             && can_establish_trade_route(tc->city, ttc->city)) {
           tc->poss_trade_num++;
@@ -196,7 +196,7 @@ void trade_generator::calculate()
     discard();
     find_certain_routes();
 
-    for (auto *tc : qAsConst(cities)) {
+    for (auto *tc : std::as_const(cities)) {
       if (!tc->done) {
         tdone = false;
       }
@@ -205,7 +205,7 @@ void trade_generator::calculate()
       break;
     }
   }
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (!tc->done) {
       char text[1024];
       fc_snprintf(text, sizeof(text),
@@ -229,7 +229,7 @@ int trade_generator::find_over_max(struct city *pcity = nullptr)
 {
   int max = 0;
 
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (pcity != tc->city) {
       max = qMax(max, tc->over_max);
     }
@@ -245,7 +245,7 @@ trade_city *trade_generator::find_most_free()
   trade_city *rc = nullptr;
   int max = 0;
 
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (max < tc->over_max) {
       max = tc->over_max;
       rc = tc;
@@ -309,11 +309,11 @@ bool trade_generator::discard_any(trade_city *tc, int freeroutes)
  */
 void trade_generator::find_certain_routes()
 {
-  for (auto *tc : qAsConst(cities)) {
+  for (auto *tc : std::as_const(cities)) {
     if (tc->done || tc->over_max > 0) {
       continue;
     }
-    for (auto *ttc : qAsConst(cities)) {
+    for (auto *ttc : std::as_const(cities)) {
       if (ttc->done || ttc->over_max > 0 || tc == ttc || tc->done
           || tc->over_max > 0) {
         continue;

--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -110,7 +110,7 @@ void units_select::create_pixmap()
     pix = new QPixmap(column_count * item_size.width(),
                       row_count * item_size.height());
     pix->fill(Qt::transparent);
-    for (auto *punit : qAsConst(unit_list)) {
+    for (auto *punit : std::as_const(unit_list)) {
       unit_pixmap = new QPixmap(tileset_unit_width(tileset),
                                 tileset_unit_height(tileset));
       unit_pixmap->fill(Qt::transparent);

--- a/client/update_queue.cpp
+++ b/client/update_queue.cpp
@@ -86,7 +86,7 @@ void update_queue::wq_run_requests(waitingQueue &hash, int request_id)
     return;
   }
   list = hash.value(request_id);
-  for (auto wq_data : qAsConst(*list)) {
+  for (auto wq_data : std::as_const(*list)) {
     push(wq_data->callback, wq_data_extract(wq_data));
   }
   hash.remove(request_id);
@@ -125,8 +125,8 @@ void update_queue::init()
     data_destroy(pair.second);
   }
 
-  for (auto a : qAsConst(wq_processing_finished)) {
-    for (auto data : qAsConst(*a)) {
+  for (auto a : std::as_const(wq_processing_finished)) {
+    for (auto data : std::as_const(*a)) {
       wq_data_destroy(data);
     }
   }
@@ -185,7 +185,7 @@ void update_queue::push(uq_callback_t callback,
                         struct update_queue_data *uq_data)
 {
   struct update_queue_data *uqr_data = nullptr;
-  for (auto p : qAsConst(queue)) {
+  for (auto p : std::as_const(queue)) {
     if (p.first == callback)
       uqr_data = p.second;
   }
@@ -212,7 +212,7 @@ void update_queue::add(uq_callback_t callback, void *data)
 // Returns whether this callback is listed in the update queue.
 bool update_queue::has_callback(uq_callback_t callback)
 {
-  for (auto pair : qAsConst(queue)) {
+  for (auto pair : std::as_const(queue)) {
     if (pair.first == callback)
       return true;
   }
@@ -224,7 +224,7 @@ bool update_queue::has_callback_full(uq_callback_t callback,
                                      uq_free_fn_t *free_data_func)
 {
   struct update_queue_data *uq_data = nullptr;
-  for (auto p : qAsConst(queue)) {
+  for (auto p : std::as_const(queue)) {
     if (p.first == callback)
       uq_data = p.second;
   }

--- a/client/views/view_cities.cpp
+++ b/client/views/view_cities.cpp
@@ -490,7 +490,7 @@ void city_widget::display_list_menu(const QPoint)
   if (selected_cities.isEmpty()) {
     select_only = true;
   }
-  for (auto *pcity : qAsConst(selected_cities)) {
+  for (auto *pcity : std::as_const(selected_cities)) {
     sell_gold = sell_gold + pcity->client.buy_cost;
   }
   if (!can_client_issue_orders()) {
@@ -896,7 +896,7 @@ void city_widget::select_same_island()
       continue;
     }
     pcity = reinterpret_cast<city *>(qvar.value<void *>());
-    for (auto *pscity : qAsConst(selected_cities)) {
+    for (auto *pscity : std::as_const(selected_cities)) {
       if (nullptr != pcity
           && (tile_continent(pcity->tile) == tile_continent(pscity->tile))) {
         selection.append(QItemSelectionRange(i));
@@ -1190,7 +1190,7 @@ void city_widget::cities_selected(const QItemSelection &sl,
   if (indexes.isEmpty()) {
     return;
   }
-  for (auto i : qAsConst(indexes)) {
+  for (auto i : std::as_const(indexes)) {
     qvar = i.data(Qt::UserRole);
     if (qvar.isNull()) {
       continue;

--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -78,7 +78,7 @@ void draw_calculated_trade_routes(QPainter *painter)
   auto color = get_color(tileset, COLOR_MAPVIEW_TRADE_ROUTES_NO_BUILT);
   // Draw calculated trade routes
   if (gui_options->draw_city_trade_routes) {
-    for (auto qgilles : qAsConst(king()->trade_gen.lines)) {
+    for (auto qgilles : std::as_const(king()->trade_gen.lines)) {
       base_map_distance_vector(&dx, &dy, TILE_XY(qgilles.t1),
                                TILE_XY(qgilles.t2));
       map_to_gui_vector(tileset, &w, &h, dx, dy);
@@ -116,7 +116,7 @@ void draw_calculated_trade_routes(QPainter *painter)
     }
   }
   // Draw virtual cities
-  for (auto *pcity : qAsConst(king()->trade_gen.virtual_cities)) {
+  for (auto *pcity : std::as_const(king()->trade_gen.virtual_cities)) {
     float canvas_x, canvas_y;
     if (pcity->tile != nullptr
         && tile_to_canvas_pos(&canvas_x, &canvas_y, pcity->tile)) {
@@ -173,7 +173,7 @@ void map_view::update_cursor(enum cursor_type ct)
 void map_view::hide_all_fcwidgets()
 {
   QList<fcwidget *> fcl = this->findChildren<fcwidget *>();
-  for (auto *widget : qAsConst(fcl)) {
+  for (auto *widget : std::as_const(fcl)) {
     if (widget->isVisible()) {
       widget->hide();
       m_hidden_fcwidgets.push_back(widget);

--- a/client/views/view_map_common.cpp
+++ b/client/views/view_map_common.cpp
@@ -2054,7 +2054,7 @@ void mapdeco_init()
  */
 void mapdeco_free()
 {
-  for (auto *a : qAsConst(*mapdeco_gotoline)) {
+  for (auto *a : std::as_const(*mapdeco_gotoline)) {
     delete a;
     a = nullptr;
   }
@@ -2112,7 +2112,7 @@ bool mapdeco_is_crosshair_set(const struct tile *ptile)
  */
 void mapdeco_clear_crosshairs()
 {
-  for (const auto *ptile : qAsConst(*mapdeco_crosshair_set)) {
+  for (const auto *ptile : std::as_const(*mapdeco_crosshair_set)) {
     refresh_tile_mapcanvas(ptile, false);
   }
   mapdeco_crosshair_set->clear();

--- a/client/views/view_nations.cpp
+++ b/client/views/view_nations.cpp
@@ -627,11 +627,11 @@ void plr_widget::nation_selected(const QItemSelection &sl,
     advance_iterate_end;
     sorted_list_a.sort(Qt::CaseInsensitive);
     sorted_list_b.sort(Qt::CaseInsensitive);
-    for (auto const &res : qAsConst(sorted_list_a)) {
+    for (auto const &res : std::as_const(sorted_list_a)) {
       techs_known = techs_known + QStringLiteral("<i>") + res.toHtmlEscaped()
                     + "," + QStringLiteral("</i>") + sp;
     }
-    for (auto const &res : qAsConst(sorted_list_b)) {
+    for (auto const &res : std::as_const(sorted_list_b)) {
       techs_unknown = techs_unknown + QStringLiteral("<i>")
                       + res.toHtmlEscaped() + "," + QStringLiteral("</i>")
                       + sp;
@@ -665,7 +665,7 @@ void plr_widget::nation_selected(const QItemSelection &sl,
     }
     advance_iterate_end;
     sorted_list_a.sort(Qt::CaseInsensitive);
-    for (auto const &res : qAsConst(sorted_list_a)) {
+    for (auto const &res : std::as_const(sorted_list_a)) {
       tech_str = tech_str + QStringLiteral("<i>") + res.toHtmlEscaped() + ","
                  + QStringLiteral("</i>") + sp;
     }

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -75,7 +75,7 @@ void free_help_texts()
   if (!help_nodes) {
     return;
   }
-  for (const auto *ptmp : qAsConst(*help_nodes)) {
+  for (const auto *ptmp : std::as_const(*help_nodes)) {
     delete[] ptmp->topic;
     delete[] ptmp->text;
     delete ptmp;
@@ -467,7 +467,7 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
     data_dirs_info += _("This instance of Freeciv21 searches the following "
                         "directories for data files:");
     data_dirs_info += "\n\n";
-    for (const auto &path : qAsConst(get_data_dirs())) {
+    for (const auto &path : std::as_const(get_data_dirs())) {
       QFileInfo info(path + "/");
       data_dirs_info += "* " + info.absolutePath() + " ";
       if (!info.exists()) {
@@ -993,7 +993,7 @@ void boot_help_texts(const nation_set *nations_to_show,
               pitem->topic = qstrdup(name);
               if (pmul->helptext) {
                 const char *sep = "";
-                for (const auto &text : qAsConst(*pmul->helptext)) {
+                for (const auto &text : std::as_const(*pmul->helptext)) {
                   cat_snprintf(help_text_buffer, sizeof(help_text_buffer),
                                "%s%s", sep, qUtf8Printable(text));
                   sep = "\n\n";
@@ -1125,7 +1125,7 @@ get_help_item_spec(const char *name, enum help_page_type htype, int *pos)
 
   idx = 0;
 
-  for (const auto *ptmp : qAsConst(*help_nodes)) {
+  for (const auto *ptmp : std::as_const(*help_nodes)) {
     char *p = ptmp->topic;
 
     while (*p == ' ') {
@@ -1195,7 +1195,7 @@ char *helptext_building(char *buf, size_t bufsz, struct player *pplayer,
   }
 
   if (nullptr != pimprove->helptext) {
-    for (const auto &text : qAsConst(*pimprove->helptext)) {
+    for (const auto &text : std::as_const(*pimprove->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -1662,7 +1662,7 @@ char *helptext_unit(char *buf, size_t bufsz, struct player *pplayer,
   cat_snprintf(buf, bufsz, _("* Belongs to %s unit class."),
                uclass_name_translation(pclass));
   if (nullptr != pclass->helptext) {
-    for (const auto &text : qAsConst(*pclass->helptext)) {
+    for (const auto &text : std::as_const(*pclass->helptext)) {
       cat_snprintf(buf, bufsz, "\n%s\n", _(qUtf8Printable(text)));
     }
   } else {
@@ -2870,7 +2870,7 @@ char *helptext_unit(char *buf, size_t bufsz, struct player *pplayer,
     }
   }
   if (nullptr != utype->helptext) {
-    for (const auto &text : qAsConst(*utype->helptext)) {
+    for (const auto &text : std::as_const(*utype->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3103,7 +3103,7 @@ void helptext_advance(char *buf, size_t bufsz, struct player *pplayer,
     if (strlen(buf) > 0) {
       CATLSTR(buf, bufsz, "\n");
     }
-    for (const auto &text : qAsConst(*vap->helptext)) {
+    for (const auto &text : std::as_const(*vap->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3209,7 +3209,7 @@ void helptext_terrain(char *buf, size_t bufsz, struct player *pplayer,
     if (buf[0] != '\0') {
       CATLSTR(buf, bufsz, "\n");
     }
-    for (const auto &text : qAsConst(*pterrain->helptext)) {
+    for (const auto &text : std::as_const(*pterrain->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3423,7 +3423,7 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
   }
 
   if (pextra->helptext != nullptr) {
-    for (const auto &text : qAsConst(*pextra->helptext)) {
+    for (const auto &text : std::as_const(*pextra->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3859,7 +3859,7 @@ void helptext_goods(char *buf, size_t bufsz, struct player *pplayer,
   buf[0] = '\0';
 
   if (nullptr != pgood->helptext) {
-    for (const auto &text : qAsConst(*pgood->helptext)) {
+    for (const auto &text : std::as_const(*pgood->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3911,7 +3911,7 @@ void helptext_specialist(char *buf, size_t bufsz, struct player *pplayer,
   buf[0] = '\0';
 
   if (nullptr != pspec->helptext) {
-    for (const auto &text : qAsConst(*pspec->helptext)) {
+    for (const auto &text : std::as_const(*pspec->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }
@@ -3951,7 +3951,7 @@ void helptext_government(char *buf, size_t bufsz, struct player *pplayer,
   buf[0] = '\0';
 
   if (nullptr != gov->helptext) {
-    for (const auto &text : qAsConst(*gov->helptext)) {
+    for (const auto &text : std::as_const(*gov->helptext)) {
       cat_snprintf(buf, bufsz, "%s\n\n", _(qUtf8Printable(text)));
     }
   }

--- a/common/map.cpp
+++ b/common/map.cpp
@@ -507,7 +507,7 @@ void map_free(struct civ_map *fmap)
     fmap->tiles = nullptr;
 
     if (fmap->startpos_table) {
-      for (auto *a : qAsConst(*fmap->startpos_table)) {
+      for (auto *a : std::as_const(*fmap->startpos_table)) {
         startpos_destroy(a);
       }
       delete fmap->startpos_table;
@@ -1456,7 +1456,7 @@ bool startpos_pack(const struct startpos *psp,
   packet->exclude = psp->exclude;
   BV_CLR_ALL(packet->nations);
 
-  for (const auto *pnation : qAsConst(*psp->nations)) {
+  for (const auto *pnation : std::as_const(*psp->nations)) {
     BV_SET(packet->nations, nation_index(pnation));
   }
   return true;

--- a/common/mapimg.cpp
+++ b/common/mapimg.cpp
@@ -628,7 +628,7 @@ bool mapimg_define(const char *maparg, bool check)
   // get map options
   mapargs = QString(maparg).split(QStringLiteral(":"));
 
-  for (const auto &str : qAsConst(mapargs)) {
+  for (const auto &str : std::as_const(mapargs)) {
     // split map options into variable and value
     mapopts = str.split(QStringLiteral("="));
 

--- a/common/networking/packets.cpp
+++ b/common/networking/packets.cpp
@@ -775,7 +775,7 @@ const struct packet_handlers *packet_handlers_get(const char *capability)
   tokens = QString(capability).split(QRegularExpression("[ \t\n,]+"));
   tokens.sort();
 
-  for (const auto &str : qAsConst(tokens)) {
+  for (const auto &str : std::as_const(tokens)) {
     if (!has_capability(qUtf8Printable(str), packet_functional_capability)) {
       continue;
     }

--- a/common/scriptcore/luascript_func.cpp
+++ b/common/scriptcore/luascript_func.cpp
@@ -154,7 +154,7 @@ void luascript_func_add(struct fc_lua *fcl, const char *func_name,
 void luascript_func_free(struct fc_lua *fcl)
 {
   if (fcl && fcl->funcs) {
-    for (auto *a : qAsConst(*fcl->funcs)) {
+    for (auto *a : std::as_const(*fcl->funcs)) {
       func_destroy(a);
     }
     delete fcl->funcs;

--- a/common/scriptcore/luascript_signal.cpp
+++ b/common/scriptcore/luascript_signal.cpp
@@ -110,7 +110,7 @@ void luascript_signal_emit_valist(struct fc_lua *fcl,
 
   psignal = fcl->signals_hash->value(signal_name, nullptr);
   if (psignal) {
-    for (auto *pcallback : qAsConst(*psignal->callbacks)) {
+    for (auto *pcallback : std::as_const(*psignal->callbacks)) {
       va_list args_cb;
 
       va_copy(args_cb, args);
@@ -239,7 +239,7 @@ void luascript_signal_callback(struct fc_lua *fcl, const char *signal_name,
   psignal = fcl->signals_hash->value(signal_name, nullptr);
   if (psignal) {
     // check for a duplicate callback
-    for (auto *pcallback : qAsConst(*psignal->callbacks)) {
+    for (auto *pcallback : std::as_const(*psignal->callbacks)) {
       if (!strcmp(pcallback->name, callback_name)) {
         pcallback_found = pcallback;
         break;
@@ -285,7 +285,7 @@ bool luascript_signal_callback_defined(struct fc_lua *fcl,
   psignal = fcl->signals_hash->value(signal_name, nullptr);
   if (psignal) {
     // check for a duplicate callback
-    for (auto *pcallback : qAsConst(*psignal->callbacks)) {
+    for (auto *pcallback : std::as_const(*psignal->callbacks)) {
       if (!strcmp(pcallback->name, callback_name)) {
         return true;
       }
@@ -316,7 +316,7 @@ void luascript_signal_free(struct fc_lua *fcl)
   if (!fcl || !fcl->signals_hash) {
     return;
   }
-  for (auto *nissan : qAsConst(*fcl->signals_hash)) {
+  for (auto *nissan : std::as_const(*fcl->signals_hash)) {
     signal_destroy(nissan);
   }
   delete fcl->signals_hash;

--- a/server/edithand.cpp
+++ b/server/edithand.cpp
@@ -101,7 +101,7 @@ void edithand_send_initial_packets(struct conn_list *dest)
   }
 
   // Send map start positions.
-  for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+  for (auto *psp : std::as_const(*wld.map.startpos_table)) {
     if (psp->exclude) {
       continue;
     }

--- a/server/fcdb.cpp
+++ b/server/fcdb.cpp
@@ -146,7 +146,7 @@ void fcdb_free(void)
 {
   script_fcdb_free();
 
-  for (auto popt : qAsConst(fcdb_config)) {
+  for (auto popt : std::as_const(fcdb_config)) {
     // Dangling pointers freed below
     delete[] popt->value;
     delete popt;

--- a/server/gamehand.cpp
+++ b/server/gamehand.cpp
@@ -439,7 +439,7 @@ void init_new_game()
   targeted_list = startpos_list_new();
   flexible_list = startpos_list_new();
 
-  for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+  for (auto *psp : std::as_const(*wld.map.startpos_table)) {
     if (psp->exclude) {
       continue;
     }
@@ -1115,7 +1115,7 @@ static void send_ruleset_choices(struct connection *pc)
 
   ruleset_choices = get_init_script_choices();
 
-  for (const auto &s : qAsConst(*ruleset_choices)) {
+  for (const auto &s : std::as_const(*ruleset_choices)) {
     const int maxlen = sizeof packet.rulesets[i];
     if (i >= MAX_NUM_RULESETS) {
       qDebug("Can't send more than %d ruleset names to client, "

--- a/server/generator/startpos.cpp
+++ b/server/generator/startpos.cpp
@@ -239,7 +239,7 @@ static bool is_valid_start_pos(const struct tile *ptile, const void *dataptr)
   // Don't start too close to someone else.
   cont_size = get_continent_size(cont);
   island = islands + islands_index[cont];
-  for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+  for (auto *psp : std::as_const(*wld.map.startpos_table)) {
     if (psp->exclude) {
       continue;
     }

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -8182,7 +8182,7 @@ static void send_ruleset_governments(struct conn_list *dest)
 
     // Send one packet_government_ruler_title per ruler title.
 
-    for (auto *pruler_title : qAsConst(*government_ruler_titles(&g))) {
+    for (auto *pruler_title : std::as_const(*government_ruler_titles(&g))) {
       {
         const struct nation_type *pnation = ruler_title_nation(pruler_title);
 

--- a/server/savegame/savegame3.cpp
+++ b/server/savegame/savegame3.cpp
@@ -2812,7 +2812,7 @@ static void sg_save_map_startpos(struct savedata *saving)
   secfile_insert_int(saving->file, map_startpos_count(),
                      "map.startpos_count");
 
-  for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+  for (auto *psp : std::as_const(*wld.map.startpos_table)) {
     int nat_x, nat_y;
     if (psp->exclude) {
       continue;
@@ -2832,7 +2832,7 @@ static void sg_save_map_startpos(struct savedata *saving)
       char nation_names[MAX_LEN_NAME * nations->size()];
 
       nation_names[0] = '\0';
-      for (const auto *pnation : qAsConst(*nations)) {
+      for (const auto *pnation : std::as_const(*nations)) {
         if ('\0' == nation_names[0]) {
           fc_strlcpy(nation_names, nation_rule_name(pnation),
                      sizeof(nation_names));

--- a/server/srv_main.cpp
+++ b/server/srv_main.cpp
@@ -2260,7 +2260,7 @@ void update_nations_with_startpos()
          * If there are no start positions for a nation, remove it from the
          * available set. */
         pnation.server.no_startpos = true;
-        for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+        for (auto *psp : std::as_const(*wld.map.startpos_table)) {
           if (psp->exclude) {
             continue;
           }
@@ -2645,7 +2645,7 @@ static void generate_players()
     int i, min;
 
     // Initialization.
-    for (auto *psp : qAsConst(*wld.map.startpos_table)) {
+    for (auto *psp : std::as_const(*wld.map.startpos_table)) {
       if (psp->exclude) {
         continue;
       }

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -2466,7 +2466,7 @@ static bool team_command(struct connection *caller, char *str, bool check)
     arg =
         QString(buf).split(QRegularExpression(REG_EXP), Qt::SkipEmptyParts);
     remove_quotes(arg);
-    for (const auto &a : qAsConst(arg)) {
+    for (const auto &a : std::as_const(arg)) {
       qInfo() << a;
     }
   }
@@ -6868,7 +6868,7 @@ static void show_rulesets(struct connection *caller)
   cmd_reply(CMD_LIST, caller, C_COMMENT, horiz_line);
 
   serv_list = get_init_script_choices();
-  for (const auto &s : qAsConst(*serv_list)) {
+  for (const auto &s : std::as_const(*serv_list)) {
     cmd_reply(CMD_LIST, caller, C_COMMENT, "%s", qUtf8Printable(s));
   }
   delete serv_list;

--- a/utility/shared.cpp
+++ b/utility/shared.cpp
@@ -540,7 +540,7 @@ const QStringList &get_data_dirs()
       data_dir_names = default_data_path();
       data_dir_names.removeDuplicates();
     }
-    for (const auto &name : qAsConst(data_dir_names)) {
+    for (const auto &name : std::as_const(data_dir_names)) {
       qDebug() << "Data path component:" << name;
     }
   }
@@ -570,7 +570,7 @@ const QStringList &get_save_dirs()
       save_dir_names = default_save_path();
       save_dir_names.removeDuplicates();
     }
-    for (const auto &name : qAsConst(save_dir_names)) {
+    for (const auto &name : std::as_const(save_dir_names)) {
       qDebug() << "Save path component:" << name;
     }
   }
@@ -601,7 +601,7 @@ const QStringList &get_scenario_dirs()
       scenario_dir_names = default_scenario_path();
       scenario_dir_names.removeDuplicates();
     }
-    for (const auto &name : qAsConst(scenario_dir_names)) {
+    for (const auto &name : std::as_const(scenario_dir_names)) {
       qDebug() << "Scenario path component:" << name;
     }
   }


### PR DESCRIPTION
It has been replaced by std::as_const in Qt 6, but the change can already be done in Qt 5. This was done using a simple search-and-replace.