### PR TITLE
Bump the vcpkg config to use Qt 6

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,15 +3,15 @@
   "version-string": "3.0.0",
   "builtin-baseline": "23ceb9cbf9b6d32f485cf039547b70102a6ef9d8",
   "dependencies": [
-    "qt5-base",
-    "qt5-svg",
+    "qtbase",
+    "qtsvg",
     "openssl",
     "lua",
     {
       "name": "gettext",
       "features": [ "tools" ]
     },
-    "kf5archive",
+    "kf6archive",
     "sdl2-mixer",
     "sqlite3",
     {


### PR DESCRIPTION
On top of #2222. This is currently incomplete because vcpkg doesn't have KF6 packages.