### PR TITLE
Fix disabling the last governor

### DIFF
--- a/client/attribute.cpp
+++ b/client/attribute.cpp
@@ -290,10 +290,6 @@ void attribute_flush()
     return;
   }
 
-  if (0 == attribute_hash->size()) {
-    return;
-  }
-
   pplayer->attribute_block.clear();
   serialize_hash(attribute_hash, pplayer->attribute_block);
   send_attribute_block(pplayer, &client.conn);


### PR DESCRIPTION
Disabling the governor in the last city that had one was broken because the attribute block was not sent to the server when empty. Now it is and removing the last governor is working again.

Closes #2472.

Backport requested -- this is a 3.1 blocker.