### PR TITLE
Factor out demographic calculation so we can generalize

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
   commands.cpp
   connecthand.cpp
   console.cpp
+  demographic.cpp
   diplhand.cpp
   diplomats.cpp
   edithand.cpp

--- a/server/demographic.cpp
+++ b/server/demographic.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+// self
+#include "demographic.h"
+
+/**
+ * \class demographic
+ *
+ * Demographics are statistics providing information about players. Each
+ * demographic object contains the information for a piece of information.
+ */
+
+/**
+ * Constructs a demographic.
+ */
+demographic::demographic(const char *name, int (*get_value)(const player *),
+                         const char *(*get_text)(int value),
+                         bool larger_is_better)
+    : m_name(name), m_get_value(get_value), m_get_text(get_text),
+      m_larger_is_better(larger_is_better)
+{
+}
+
+/**
+ * Evaluates the current value of the demographic for a player.
+ */
+int demographic::evaluate(const player *pplayer) const
+{
+  return m_get_value(pplayer);
+}
+
+/**
+ * Turns a demographic value into displayable text.
+ */
+const char *demographic::text(int value) const { return m_get_text(value); }

--- a/server/demographic.h
+++ b/server/demographic.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#pragma once
+
+struct player;
+
+class demographic {
+public:
+  demographic(const char *name, int (*get_value)(const player *),
+              const char *(*get_text)(int value), bool larger_is_better);
+
+  /// Returns the untranslated name of this demographic.
+  const char *name() const { return m_name; }
+
+  int evaluate(const player *pplayer) const;
+  const char *text(int value) const;
+
+  /// Returns true \c lhs is worse (this usually means smaller) than \c rhs.
+  bool compare(int lhs, int rhs) const
+  {
+    return m_larger_is_better ? lhs < rhs : rhs < lhs;
+  }
+
+private:
+  const char *m_name;
+  int (*m_get_value)(const player *);
+  const char *(*m_get_text)(int value);
+  bool m_larger_is_better;
+};


### PR DESCRIPTION
This adds a new class, demographic, whose task is to compute a single line in the demographic report for a single player. It also knows how to format the text and how to sort values.

This is a first step towards unifying demographics, the end game report, historian reports, and the scorelog.

See #2020, #2110, #2114.