### PR TITLE
Store demographics values at TC and use them for the demographics report

### DIFF
--- a/common/player.h
+++ b/common/player.h
@@ -107,6 +107,7 @@ struct player_score {
   int game; // Total score you get in player dialog.
 
   /// Cached demographic values, indexed by their untranslated name.
+  /// \note Can be incomplete when loading from old saves.
   std::map<std::string, int> demographics;
 };
 

--- a/common/player.h
+++ b/common/player.h
@@ -19,6 +19,10 @@
 #include "tech.h"
 #include "traits.h"
 
+// std
+#include <map>
+#include <string>
+
 #define PLAYER_DEFAULT_TAX_RATE 0
 #define PLAYER_DEFAULT_SCIENCE_RATE 100
 #define PLAYER_DEFAULT_LUXURY_RATE 0
@@ -101,6 +105,9 @@ struct player_score {
                      * by combat or otherwise. */
   int culture;
   int game; // Total score you get in player dialog.
+
+  /// Cached demographic values, indexed by their untranslated name.
+  std::map<std::string, int> demographics;
 };
 
 struct player_ai {

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1062,8 +1062,25 @@ static void dem_line_item(char *outptr, size_t out_size,
                           struct player *pplayer, const demographic &demo,
                           bv_cols selcols)
 {
+  int value = -1;
+  if (!pplayer || BV_ISSET(selcols, DEM_COL_QUANTITY)
+      || BV_ISSET(selcols, DEM_COL_RANK)
+      || BV_ISSET(selcols, DEM_COL_BEST)) {
+    if (pplayer->score.demographics.count(demo.name()) > 0) {
+      value = pplayer->score.demographics[demo.name()];
+    } else {
+      // Fallback in case it's missing (e.g. save).
+      // TRANS: %s can be score, population, economics, etc.
+      qWarning(
+          _("Updating demographic \"%s\". The value may be different from "
+            "what it was at turn change."),
+          Q_(demo.name()));
+      value = demo.evaluate(pplayer);
+    }
+  }
+
   if (nullptr != pplayer && BV_ISSET(selcols, DEM_COL_QUANTITY)) {
-    const char *text = demo.text(demo.evaluate(pplayer));
+    const char *text = demo.text(value);
 
     cat_snprintf(outptr, out_size, " %s", text);
     cat_snprintf(outptr, out_size, "%*s",
@@ -1072,7 +1089,7 @@ static void dem_line_item(char *outptr, size_t out_size,
   }
 
   if (nullptr != pplayer && BV_ISSET(selcols, DEM_COL_RANK)) {
-    int basis = demo.evaluate(pplayer);
+    int basis = value;
     int place = 1;
 
     players_iterate(other)
@@ -1088,7 +1105,7 @@ static void dem_line_item(char *outptr, size_t out_size,
 
   if (nullptr == pplayer || BV_ISSET(selcols, DEM_COL_BEST)) {
     struct player *best_player = pplayer;
-    int best_value = nullptr != pplayer ? demo.evaluate(pplayer) : 0;
+    int best_value = nullptr != pplayer ? value : 0;
 
     players_iterate(other)
     {

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1062,10 +1062,11 @@ static void dem_line_item(char *outptr, size_t out_size,
                           struct player *pplayer, const demographic &demo,
                           bv_cols selcols)
 {
-  int value = -1;
-  if (!pplayer || BV_ISSET(selcols, DEM_COL_QUANTITY)
-      || BV_ISSET(selcols, DEM_COL_RANK)
-      || BV_ISSET(selcols, DEM_COL_BEST)) {
+  int value = 0;
+  if (pplayer
+      && (BV_ISSET(selcols, DEM_COL_QUANTITY)
+          || BV_ISSET(selcols, DEM_COL_RANK)
+          || BV_ISSET(selcols, DEM_COL_BEST))) {
     if (pplayer->score.demographics.count(demo.name()) > 0) {
       value = pplayer->score.demographics[demo.name()];
     } else {

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1157,6 +1157,20 @@ bool is_valid_demography(const char *demography, int *error)
 }
 
 /**
+ * Updates cached demographics values.
+ *
+ * All values are stored, even the ones that are not enabled. This simplifies
+ * the implementation and allows toggling demographics during the game.
+ */
+void update_demographics(struct player *pplayer)
+{
+  pplayer->score.demographics.clear();
+  for (const auto &[_, demo] : rowtable) {
+    pplayer->score.demographics[demo.name()] = demo.evaluate(pplayer);
+  }
+}
+
+/**
    Send demographics report; what gets reported depends on value of
    demographics server option.
  */

--- a/server/report.h
+++ b/server/report.h
@@ -10,7 +10,8 @@
 **************************************************************************/
 #pragma once
 
-#include "support.h" // bool type
+// common
+#include "fc_types.h"
 
 struct connection;
 struct conn_list;
@@ -36,6 +37,7 @@ void send_current_history_report(struct conn_list *dest);
 void report_wonders_of_the_world(struct conn_list *dest);
 void report_top_five_cities(struct conn_list *dest);
 bool is_valid_demography(const char *demography, int *error);
+void update_demographics(struct player *pplayer);
 void report_demographics(struct connection *pconn);
 void report_achievements(struct connection *pconn);
 void report_final_scores(struct conn_list *dest);

--- a/server/score.cpp
+++ b/server/score.cpp
@@ -18,6 +18,7 @@
 // utility
 #include "bitvector.h"
 #include "log.h"
+#include "report.h"
 #include "shared.h"
 
 // common
@@ -364,6 +365,8 @@ void calc_civ_score(struct player *pplayer)
   pplayer->score.spaceship = pplayer->spaceship.state;
 
   pplayer->score.game = get_civ_score(pplayer);
+
+  update_demographics(pplayer);
 }
 
 /**


### PR DESCRIPTION
This fixes #2114 by calculating (all) demographics at turn change and saving the values in `player->score.demographics`. They are also stored in saves so a save/load cycle doesn't lead to a recalculation.