### PR TITLE
Utility Include: Re-look at utility header files

### DIFF
--- a/utility/bitvector.h
+++ b/utility/bitvector.h
@@ -6,6 +6,12 @@
 // utility
 #include "log.h"
 
+// Qt
+#include <QBitArray>
+
+// std
+#include <cstddef>
+
 // Yields TRUE iff the bit bit_no is set in val.
 #define TEST_BIT(val, bit_no)                                               \
   (((val) & (1u << (bit_no))) == (1u << (bit_no)))

--- a/utility/fciconv.h
+++ b/utility/fciconv.h
@@ -6,6 +6,10 @@
 // utility
 #include "support.h"
 
+// std
+#include <cstddef>
+#include <cstdio>
+
 [[deprecated]] char *data_to_internal_string_malloc(const char *text);
 [[deprecated]] char *internal_to_data_string_malloc(const char *text);
 [[deprecated]] char *internal_to_local_string_malloc(const char *text);

--- a/utility/fcintl.h
+++ b/utility/fcintl.h
@@ -12,10 +12,12 @@
 // dependency
 #ifdef FREECIV_ENABLE_NLS
 
-/* Include libintl.h only if nls enabled.
+/**
+ * Include libintl.h only if nls enabled.
  * It defines some wrapper macros that
- * we don't want defined when nls is disabled. */
-#include <libintl.h>
+ * we don't want defined when nls is disabled.
+ */
+#include <libintl.h> // NOLINT(misc-include-cleaner)
 
 // MSYS libintl redefines asprintf/vasprintf as macros, and this clashes with
 // QString::asprintf and QString::vasprintf.

--- a/utility/genhash.h
+++ b/utility/genhash.h
@@ -6,6 +6,9 @@
 // utility
 #include "support.h" // bool type
 
+// std
+#include <cstddef>
+
 struct genhash; // opaque
 
 // Hash value type.

--- a/utility/rand.h
+++ b/utility/rand.h
@@ -4,6 +4,7 @@
 #pragma once
 
 // std
+#include <cstdint>
 #include <random>
 
 #define fc_rand(_size) fc_rand_debug((_size), "fc_rand", __LINE__, __FILE__)

--- a/utility/section_file.h
+++ b/utility/section_file.h
@@ -7,7 +7,11 @@
 #include "registry_ini.h"
 #include "support.h"
 
+// Qt
 class QString;
+
+// std
+#include <cstddef>
 
 template <class Key, class T> class QMultiHash;
 

--- a/utility/shared.h
+++ b/utility/shared.h
@@ -13,6 +13,10 @@ class QStringList;
 
 template <typename T> class QVector;
 
+// std
+#include <cstddef>
+#include <time.h>
+
 // Changing these will break network compatability!
 #define MAX_LEN_ADDR 256 // see also MAXHOSTNAMELEN and RFC 1123 2.1
 #define MAX_LEN_PATH 4095

--- a/utility/speclist.h
+++ b/utility/speclist.h
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
+// utility
+#include "support.h"
+
 /**
  * speclists: "specific genlists", by dwp.
  * (A generalisation of previous city_list and unit_list stuff.)

--- a/utility/specpq.h
+++ b/utility/specpq.h
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
+// utility
+#include "log.h"
+#include "support.h"
+
+// std
+#include <cstdlib>
+
 /**
  * specpqs: "specific priority queues".
  *

--- a/utility/specvec.h
+++ b/utility/specvec.h
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
+// utility
+#include "log.h"
+#include "support.h"
+
+// std
+#include <cstddef>
+#include <cstdlib>
+
 /**
  * specvectors: "specific vectors".
  *

--- a/utility/support.h
+++ b/utility/support.h
@@ -7,7 +7,7 @@
 class QString;
 
 // std
-#include <cinttypes>
+#include <cstdarg>
 #include <cstdio>
 
 /* Want to use GCC's __attribute__ keyword to check variadic


### PR DESCRIPTION
As part of learning something new in #2597 taking a re-look at the `.h` files in the `utility` directory to ensure we are doing full IWYU there.

See #2464 