### PR TITLE
Fix garbage unit names for foreign units

### DIFF
--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -308,8 +308,10 @@ unpackage_short_unit(const struct packet_unit_short_info *packet)
   punit->veteran = packet->veteran;
   punit->hp = packet->hp;
   punit->activity = static_cast<unit_activity>(packet->activity);
-  punit->name =
-      QString::fromUtf8(QByteArray(packet->name, ARRAY_SIZE(packet->name)));
+
+  // Use QByteArrayView to prevent an unbounded read
+  auto name = QByteArrayView(packet->name, ARRAY_SIZE(packet->name));
+  punit->name = QString::fromUtf8(name.left(name.indexOf('\0')));
 
   if (packet->activity_tgt == EXTRA_NONE) {
     punit->activity_target = nullptr;


### PR DESCRIPTION
Apply the fix from a458a80 to the foreign units.