### PR TITLE
Fix Windows MSYS2 install and package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,14 +145,12 @@ jobs:
           install: |
             git
             mingw-w64-clang-x86_64-cmake
-            mingw-w64-clang-x86_64-ninja
             mingw-w64-clang-x86_64-nsis
             mingw-w64-clang-x86_64-clang
-            mingw-w64-clang-x86_64-libunwind
             mingw-w64-clang-x86_64-readline
             mingw-w64-clang-x86_64-lua
             mingw-w64-clang-x86_64-SDL2_mixer
-            mingw-w64-clang-x86_64-qt6
+            mingw-w64-clang-x86_64-qt6-base
             mingw-w64-clang-x86_64-qt6-svg
             mingw-w64-clang-x86_64-karchive
       - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,13 +61,13 @@ endif()
 project(freeciv21 VERSION ${FREECIV21_VERSION} LANGUAGES C CXX)
 
 # Gather all the tailored settings we need for Windows builds early.
-if(WIN32 OR MSYS OR MINGW)
+if(WIN32 OR MSYS)
   # We need to alter the out of box values of these variables for Win32 et al builds
   set(CMAKE_INSTALL_DATAROOTDIR ".")
   set(CMAKE_INSTALL_BINDIR ".")
   set(PROJECT_NAME "data")
   set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/")
-  get_filename_component(MINGW_PATH ${CMAKE_CXX_COMPILER} PATH)
+  get_filename_component(CLANG_PATH ${CMAKE_CXX_COMPILER} PATH)
 endif()
 
 add_compile_definitions(PUBLIC $<$<CONFIG:Debug>:FREECIV_DEBUG>)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -15,7 +15,7 @@ set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set(CPACK_PACKAGE_CHECKSUM "SHA256")
 
-if(WIN32 OR MSYS OR MINGW)
+if(WIN32 OR MSYS)
 
   # Use the NSIS Package for Windows
   set(CPACK_GENERATOR "NSIS")
@@ -23,11 +23,7 @@ if(WIN32 OR MSYS OR MINGW)
 
   # Establish some variables to place the package where we want it
   if(NOT CPACK_SYSTEM_NAME)
-    if("$ENV{MSYSTEM}" STREQUAL "MINGW32")
-      set(CPACK_CPU_ARCH "i686")
-    else()
-      set(CPACK_CPU_ARCH $ENV{MSYSTEM_CARCH})
-    endif()
+    set(CPACK_CPU_ARCH $ENV{MSYSTEM_CARCH})
     set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CPACK_CPU_ARCH}")
   endif()
 

--- a/cmake/FreecivBackward.cmake
+++ b/cmake/FreecivBackward.cmake
@@ -9,7 +9,7 @@ include(CheckSymbolExists)
 #   - native API on MSVC (MSYS and MINGW aren't ABI-compatible with it)
 #   - libunwind if available
 #   - backtrace() if everything else fails.
-if (MSVC OR MINGW OR MSYS)
+if (MSVC OR MSYS)
   message(STATUS "Using the Windows native API for stack unwinding. "
                  "This is the preferred option.")
   set(CAN_UNWIND_STACK TRUE)
@@ -62,7 +62,7 @@ if (CAN_UNWIND_STACK) # If we can't unwind, everything below is useless
     message(STATUS "Using the Windows native API to retrieve stack symbols. "
                    "This is the preferred option.")
     set(CAN_RETRIEVE_SYMBOLS TRUE)
-  elseif (WIN32 AND (MINGW OR MSYS))
+  elseif (WIN32 AND MSYS)
     message(STATUS "Using the Windows native API to retrieve stack symbols. "
                    "You'll need to convert DWARF debug information to PDB.")
     set(CAN_RETRIEVE_SYMBOLS TRUE)

--- a/cmake/FreecivDependencies.cmake
+++ b/cmake/FreecivDependencies.cmake
@@ -45,7 +45,7 @@ if(FREECIV_ENABLE_NLS)
   set(ENABLE_NLS TRUE)
   if(UNIX)
     set(LOCALEDIR "${CMAKE_INSTALL_FULL_LOCALEDIR}")
-  elseif(WIN32 OR MSYS OR MINGW)
+  elseif(WIN32 OR MSYS)
     set(LOCALEDIR "${CMAKE_INSTALL_LOCALEDIR}")
   endif()
   include(GettextTranslate)
@@ -129,13 +129,13 @@ if (EMSCRIPTEN)
 endif()
 
 # Networking library
-if (WIN32 OR MINGW OR MSYS)
+if (WIN32 OR MSYS)
   set(FREECIV_MSWINDOWS TRUE)
 endif()
 
 # Define the GUI type for Win32 Qt programs
 # Removes the console window that pops up with the GUI app
-if (WIN32 OR MINGW OR MSYS)
+if (WIN32 OR MSYS)
   set(GUI_TYPE WIN32)
 else()
   set(GUI_TYPE "")


### PR DESCRIPTION
Closes #2609 

I also took the opportunity to remove some 32-bit checks. Since we don't support 32-bits any longer we don't need it now.

With the move to `clang` as part of going to Qt6 we don't also need to check for `MINGW` for most of the checks, so I removed those as well.