### PR TITLE
Fix one more -Wmaybe-uninitialized false positive

### DIFF
--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -1228,7 +1228,7 @@ QVector<QString> *get_init_script_choices()
 static void write_init_script(char *script_filename)
 {
   char buf[256];
-  FILE *script_file;
+  FILE *script_file = nullptr;
 
   const auto real_filename = interpret_tilde(script_filename);
 


### PR DESCRIPTION
GCC 13.3.0 with -Og complains that script_file may be used uninitialized. This is a lie, but initializing the variable is good practice anyway.

After this PR, we compile fine in -Og mode.