### PR TITLE
Fix tile info popup behavior

### DIFF
--- a/client/views/view_map.cpp
+++ b/client/views/view_map.cpp
@@ -677,6 +677,7 @@ void popup_tile_info(struct tile *ptile)
 
       // Try to avoid covering the tile. This assumes that the menu is shown
       // below the location passed to popeup().
+      auto tile_height = tileset_tile_height(tileset) * mapview->scale();
       if (y + tile_height + info->sizeHint().height() < mapview->height()) {
         y += tile_height;
       } else {


### PR DESCRIPTION
On Qt 6.8.3, it was not possible to open the tile info popup. Adding a `QWidgetAction`, containing the layout that was directly added to the `QMenu` before, fixes the behavior.

While here: Scale tile_height according to the current map setting

Closes #2603 