### PR TITLE
Fix unit selection placement behavior

### DIFF
--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -424,12 +424,9 @@ void toggle_unit_sel_widget(struct tile *ptile)
   if (unit_sel != nullptr) {
     unit_sel->close();
     delete unit_sel;
-    unit_sel = new units_select(ptile, queen()->mapview_wdg);
-    unit_sel->show();
-  } else {
-    unit_sel = new units_select(ptile, queen()->mapview_wdg);
-    unit_sel->show();
   }
+
+  unit_sel = new units_select(ptile, queen()->mapview_wdg);
 }
 
 /**

--- a/client/unitselect.h
+++ b/client/unitselect.h
@@ -22,12 +22,12 @@ class QFont;
 
 struct unit;
 
-/***************************************************************************
- Transparent widget for selecting units
-***************************************************************************/
-class units_select : public QMenu {
+/**
+ Transparent widget for selecting units.
+ */
+class units_select_widget : public QWidget {
   Q_OBJECT
-  Q_DISABLE_COPY(units_select);
+  Q_DISABLE_COPY(units_select_widget);
   QPixmap *pix;
   QPixmap *h_pix;                /** pixmap for highlighting */
   QSize item_size;               /** size of each pixmap of unit */
@@ -37,8 +37,8 @@ class units_select : public QMenu {
   int column_count, row_count;
 
 public:
-  units_select(struct tile *ptile, QWidget *parent = 0);
-  ~units_select() override;
+  units_select_widget(struct tile *ptile, QWidget *parent = 0);
+  ~units_select_widget() override;
   void update_units();
   void create_pixmap();
   tile *utile;
@@ -49,13 +49,32 @@ protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void wheelEvent(QWheelEvent *event) override;
-  void closeEvent(QCloseEvent *event) override;
 
 private:
   bool more;
   int show_line;
   int highligh_num;
   int unit_count;
+};
+
+/**
+ Popup for selecting units, uses units_select_widget internally.
+ */
+class units_select : public QMenu {
+  Q_OBJECT
+  Q_DISABLE_COPY(units_select);
+
+public:
+  units_select(struct tile *ptile, QWidget *parent = 0);
+  ~units_select() override;
+  void update_units();
+  void create_pixmap();
+
+protected:
+  void closeEvent(QCloseEvent *event) override;
+
+private:
+  units_select_widget *m_widget;
 };
 
 void toggle_unit_sel_widget(struct tile *ptile);


### PR DESCRIPTION
On Qt 6.8.3 the popup was always placed at the origin of the map view. This is caused by missing `QAction`s in the `QMenu`. Adding a `QWidgetAction` fixes this issue.

Minor additional fixes:
- Remove superfluous call to show() on units_select
- Reduce minor code duplication.

Closes #2604 