### PR TITLE
Always render map with SmoothPixmapTransform render hint

### DIFF
--- a/client/renderer.cpp
+++ b/client/renderer.cpp
@@ -87,10 +87,7 @@ void renderer::render(QPainter &painter, const QRegion &region) const
  */
 void renderer::render(QPainter &painter, const QRect &area) const
 {
-  if (scale() != 1) {
-    painter.setRenderHint(QPainter::SmoothPixmapTransform);
-  }
-
+  painter.setRenderHint(QPainter::SmoothPixmapTransform);
   auto mapview_rect =
       QRectF(area.left() / scale(), area.top() / scale(),
              area.width() / scale(), area.height() / scale());


### PR DESCRIPTION
Since the switch to Qt6, the map was rendering with visual scaling artifacts on screens with high DPI scaling. Setting the `SmoothPixmapTransform` render hint fixes this problem.

`SmoothPixmapTransform` was already set when the map view was zoomed. This is consistent with the observation that the artifacts disappeared as soon as the map was zoomed in or out.

Closes #2588 