### PR TITLE
Fix one more -Wmaybe-uninitialized

### DIFF
--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -4594,7 +4594,7 @@ static bool load_ruleset_nations(struct section_file *file,
   const char **vec;
   const char *name, *bad_leader;
   const char *sval;
-  int default_set;
+  int default_set = -1;
   const char *filename = secfile_name(file);
   struct section_list *sec = nullptr;
   enum trait tr;


### PR DESCRIPTION
Compiling stable in debug mode was failing with another -Wmaybe-uninitialized false positive. Ensure the compiler knows the value is initialized.

Backport requested.