### PR TITLE
[stable] Update vcpkg to 2025.04.09 to fix macOS builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,7 +197,7 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies
         with:
-          vcpkgGitCommitId: b322364f06308bdd24823f9d8f03fe0cc86fd46f
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
       - name: Configure
         run: cmake -S . -B build --preset "windows-debug"
       - name: Building
@@ -234,7 +234,7 @@ jobs:
       - uses: lukka/run-vcpkg@v11
         name: Install dependencies
         with:
-          vcpkgGitCommitId: b322364f06308bdd24823f9d8f03fe0cc86fd46f
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
       - name: Build
         uses: lukka/run-cmake@v10
         with:


### PR DESCRIPTION
This fixes the build but now we get an ARM-only dmg. I haven't been able to change it to x86 or to create a universal binary. It seems vcpkg doesn't support the latter.

Binaries for x86 Mac is a release blocker. Older macs cannot execute ARM code, while newer macs can execute x86.