### PR TITLE
Includes Refactor: common a to c

### DIFF
--- a/common/achievements.cpp
+++ b/common/achievements.cpp
@@ -25,8 +25,11 @@
 #include "terrain.h"
 #include "tile.h"
 
+// Qt
+#include <QtLogging> // qDebug, qWarning, qCricital, etc
+
 // std
-#include <vector>
+#include <vector> // std:vector
 
 static struct achievement achievements[MAX_ACHIEVEMENT_TYPES];
 

--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
+// self
+#include "actions.h"
+
 // utility
 #include "bitvector.h"
 #include "fcintl.h"
@@ -9,7 +12,6 @@
 #include "support.h"
 
 // common
-#include "actions.h"
 #include "base.h"
 #include "city.h"
 #include "combat.h"
@@ -36,13 +38,16 @@
 #include "unittype.h"
 
 // Qt
+#include <QLatin1String>
 #include <QMessageLogger>
-#include <QtGlobal> // Q_UNUSED
+#include <QString>
+#include <QStringLiteral>
+#include <QtPreprocessorSupport> // Q_UNUSED
 
 // std
 #include <algorithm> // max, min
 #include <cmath>     // ceil, floor
-#include <cstdarg>
+#include <cstdarg>   // va_*
 
 // Custom data types for obligatory hard action requirements.
 

--- a/common/base.cpp
+++ b/common/base.cpp
@@ -19,7 +19,7 @@
 #include "unittype.h"
 
 // Qt
-#include <QtGlobal> // Q_UNUSED
+#include <QtPreprocessorSupport> // Q_UNUSED
 
 /**
    Check if base provides effect

--- a/common/calendar.cpp
+++ b/common/calendar.cpp
@@ -1,19 +1,19 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "calendar.h"
+
+// utility
+#include "fcintl.h"
+#include "log.h"
+#include "support.h"
 
 // common
+#include "effects.h"
+#include "fc_types.h"
 #include "game.h"
 #include "victory.h"
-
-#include "calendar.h"
 
 /**
    Advance the calendar in the passed game_info structure

--- a/common/calendar.h
+++ b/common/calendar.h
@@ -1,13 +1,6 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 struct packet_game_info;

--- a/common/capstr.cpp
+++ b/common/capstr.cpp
@@ -1,28 +1,20 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cstdlib> // getenv()
+// self
+#include "capstr.h"
+
+// generated
+#include <fc_version.h>
 
 // utility
 #include "support.h"
 
-// generated
-#include "fc_version.h"
-
 // common
 #include "connection.h" // MAX_LEN_CAPSTR
 
-#include "capstr.h"
+// std
+#include <cstdlib> // getenv
 
 static char our_capability_internal[MAX_LEN_CAPSTR];
 const char *const our_capability = our_capability_internal;

--- a/common/capstr.h
+++ b/common/capstr.h
@@ -1,15 +1,6 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 extern const char *const our_capability;

--- a/common/chat.h
+++ b/common/chat.h
@@ -1,20 +1,12 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 /* Definitions related to interpreting chat messages.
  * Behaviour generally can't be changed at whim because client and
- * server are assumed to agree on these details. */
+ * server are assumed to agree on these details.
+ */
 
 // Special characters in chatlines.
 

--- a/common/citizens.cpp
+++ b/common/citizens.cpp
@@ -1,13 +1,8 @@
-/*
-Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "citizens.h"
 
 // utility
 #include "log.h"
@@ -15,10 +10,12 @@ received a copy of the GNU General Public License along with Freeciv21.
 
 // common
 #include "city.h"
+#include "fc_types.h"
 #include "game.h"
 #include "player.h"
 
-#include "citizens.h"
+// std
+#include <cstring> // memset
 
 /**
    Initialise citizens data.

--- a/common/citizens.h
+++ b/common/citizens.h
@@ -1,13 +1,6 @@
-/**************************************************************************
- Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
-                   part of Freeciv21. Freeciv21 is free software: you can
-    ^oo^      redistribute it and/or modify it under the terms of the GNU
-    (..)        General Public License  as published by the Free Software
-   ()  ()       Foundation, either version 3 of the License,  or (at your
-   ()__()             option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 // common

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -1,49 +1,54 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <array>
-#include <cmath> // pow, sqrt, exp
-#include <cstdlib>
-#include <cstring>
-#include <vector>
+// self
+#include "city.h"
 
 // utility
+#include "bitvector.h"
 #include "distribute.h"
 #include "fcintl.h"
 #include "log.h"
 #include "player.h"
+#include "shared.h"
 #include "support.h"
 
 // common
+#include "actions.h"
 #include "ai.h"
 #include "citizens.h"
 #include "effects.h"
+#include "fc_types.h"
 #include "game.h"
 #include "government.h"
 #include "improvement.h"
 #include "map.h"
 #include "movement.h"
-#include "packets.h"
+#include "name_translation.h"
 #include "requirements.h"
 #include "specialist.h"
+#include "terrain.h"
+#include "tile.h"
 #include "traderoutes.h"
 #include "unit.h"
+#include "unitlist.h"
+#include "unittype.h"
 #include "workertask.h"
+#include "worklist.h"
 
-// aicore
+// common/aicore
 #include "cm.h"
 
-#include "city.h"
+// Qt
+#include <QtLogging> // QtMsgType
+
+// std
+#include <array>   // std::array
+#include <cmath>   // pow, sqrt, exp
+#include <cstdlib> // free
+#include <cstring> // memset
+#include <ctime>   // time
+#include <vector>  // std::vector
 
 // Define this to add in extra (very slow) assertions for the city code.
 #undef CITY_DEBUGGING

--- a/common/city.h
+++ b/common/city.h
@@ -1,20 +1,28 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
+// generated
+#include <fc_config.h>
+
+// utility
+#include "log.h"
+
 // common
+#include "fc_types.h"
 #include "improvement.h"
+#include "name_translation.h"
+#include "requirements.h"
 #include "worklist.h"
+
+// Qt
+#include <QtLogging> // QtMsgType
+
+// std
+#include <array>  // std:array
+#include <ctime>  // time_t
+#include <vector> // std:vector
 
 enum production_class_type {
   PCT_UNIT,

--- a/common/clientutils.cpp
+++ b/common/clientutils.cpp
@@ -1,23 +1,28 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "clientutils.h"
+
+// utility
+#include "fcintl.h"
+#include "log.h"
 
 // common
 #include "extras.h"
 #include "fc_types.h"
 #include "game.h" // FIXME it's extra_type_iterate that needs this really
 #include "tile.h"
+#include "unit.h"
+#include "unitlist.h"
 
-#include "clientutils.h"
+// Qt
+#include <QLatin1String>
+#include <QString>
+#include <QStringLiteral>
+
+// std
+#include <cstring> // str*, mem*
 
 /* This module contains functions that would belong to the client,
  * except that in case of freeciv-web, server does handle these

--- a/common/clientutils.h
+++ b/common/clientutils.h
@@ -1,16 +1,9 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-#include <QString>
+class QString;
 
 struct extra_type;
 struct tile;

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -1,34 +1,32 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cmath>
+// self
+#include "combat.h"
 
 // utility
 #include "bitvector.h"
 #include "log.h"
 #include "rand.h"
+#include "shared.h"
 
 // common
-#include "base.h"
+#include "actions.h"
+#include "city.h"
+#include "effects.h"
+#include "extras.h"
+#include "fc_types.h"
 #include "game.h"
 #include "map.h"
 #include "movement.h"
-#include "packets.h"
+#include "player.h"
+#include "tile.h"
 #include "unit.h"
 #include "unitlist.h"
 #include "unittype.h"
 
-#include "combat.h"
+// std
+#include <cmath>
 
 /**
    Checks if player is restricted diplomatically from attacking the tile.

--- a/common/combat.h
+++ b/common/combat.h
@@ -1,17 +1,13 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
+// common
+#include "city.h"
+#include "player.h"
+#include "tile.h"
+#include "unit.h"
 #include "unittype.h"
 
 /*

--- a/common/culture.cpp
+++ b/common/culture.cpp
@@ -1,21 +1,14 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "culture.h"
 
 // common
 #include "city.h"
 #include "effects.h"
 #include "game.h"
 #include "player.h"
-
-#include "culture.h"
 
 /**
    Return current culture score of the city.

--- a/common/culture.h
+++ b/common/culture.h
@@ -1,13 +1,6 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 struct city;


### PR DESCRIPTION
IWYU refactor of `common/a*` to `common/c*`. The file `common/clientutils.cpp` has an include for `game.h` that needs to stay there right now. I'm expecting to come back and clean that up as I move through the rest of the common directory.

Part of #2464