### PR TITLE
[stable] macOS CI: Use macos-13 for intel (x64-osx)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -207,7 +207,7 @@ jobs:
 
   os_x:
     name: "macOS"
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: clang-format
     env:
       VCPKG_BUILD_TYPE: release


### PR DESCRIPTION
The github actions runner images for `macos-latest` (`macos-14+`) are based on the `arm64` architecture. Those images have an `intel` architecture option only for paying customers.  Solution is to use the `macos-13` image as it is still on `intel`.

See https://github.com/actions/runner-images/discussions/10810

Attempts to use varying `CMAKE_TRIPLET...` environment variables effectively creates a cross-compile environment and our build system isn't setup to do that it seems.

Part of #2647

Not closing the issue as this is effectively a work around and not a perm fix. It allows us to release 3.1, but we need to figure it out for further 3.2 series packages too.