### PR TITLE
Emit warning if the Qt audio plugin does not support Ogg Vorbis

### DIFF
--- a/client/audio/audio_qt.cpp
+++ b/client/audio/audio_qt.cpp
@@ -13,6 +13,7 @@
 // Qt
 #include <QAudio>
 #include <QAudioOutput>
+#include <QMediaFormat>
 #include <QMediaPlayer>
 #include <QSoundEffect>
 
@@ -163,6 +164,14 @@ static bool qt_audio_init()
                        break;
                      }
                    });
+
+  auto fmt = QMediaFormat(QMediaFormat::Ogg);
+  fmt.setAudioCodec(QMediaFormat::AudioCodec::Vorbis);
+  if (!fmt.isSupported(QMediaFormat::Decode)) {
+    qWarning("Qt Multimedia does not support OGG Vorbis on your system. "
+             "Additional runtime libraries or environment variables "
+             "(QT_MEDIA_BACKEND) may be needed to play in-game music.");
+  }
 
   return true;
 }


### PR DESCRIPTION
Commit #2648 added a check that emits a configure warning if the backend of the Qt audio plugin does not support Ogg Vorbis. This commit adds an identical check to the Qt audio plugin itself and emits a warning when the plugin is loaded at runtime.