### PR TITLE
Includes Refactor: common m to n

### DIFF
--- a/common/map.cpp
+++ b/common/map.cpp
@@ -1,37 +1,41 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <QSet>
-#include <cstring> // qstrlen
-#include <stdexcept>
+// self
+#include "map.h"
 
 // utility
+#include "bitvector.h"
 #include "log.h"
 #include "rand.h"
 #include "shared.h"
-#include "support.h"
 
 // common
 #include "ai.h"
 #include "city.h"
+#include "extras.h"
+#include "fc_types.h"
 #include "game.h"
+#include "map_types.h"
 #include "movement.h"
 #include "nation.h"
-#include "packets.h"
+#include "player.h"
+#include "requirements.h"
 #include "road.h"
+#include "terrain.h"
+#include "tile.h"
 #include "unit.h"
+#include "unitlist.h"
+#include "unittype.h"
 
-#include "map.h"
+// Qt
+#include <QHash>
+#include <QSet>
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <cstdlib> // abs
+#include <utility> // std:move, std::as_const
 
 static struct startpos *startpos_new(struct tile *ptile);
 static void startpos_destroy(struct startpos *psp);

--- a/common/map.h
+++ b/common/map.h
@@ -1,27 +1,25 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cmath> // sqrt
+#pragma once
 
 // utility
 #include "bitvector.h"
-#include "iterator.h"
-#include "log.h" // fc_assert
+#include "iterator.h" // IWYU pragma: keep (FIXME)
+#include "log.h"
+#include "shared.h"
 
 // common
+#include "fc_types.h"
 #include "game.h"
 #include "map_types.h"
+#include "tile.h"
+#include "unit.h"
+#include "unittype.h"
+
+// Qt
+#include <QSet>
+#include <QtPreprocessorSupport> // Q_UNUSED
 
 // Parameters for terrain counting functions.
 static const bool C_ADJACENT = false;

--- a/common/map_types.h
+++ b/common/map_types.h
@@ -1,21 +1,14 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <QHash>
+#pragma once
 
 // common
 #include "fc_types.h"
+
+// Qt
+#include <QHash>
+#include <QSet>
 
 /****************************************************************
   Miscellaneous terrain information

--- a/common/mapimg.cpp
+++ b/common/mapimg.cpp
@@ -1,20 +1,15 @@
-/*
-Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cstdarg>
+// self
+#include "mapimg.h"
 
 // utility
 #include "bitvector.h"
 #include "fcintl.h"
 #include "log.h"
+#include "shared.h"
+#include "support.h"
 #include "timing.h"
 
 // common
@@ -27,12 +22,28 @@ received a copy of the GNU General Public License along with Freeciv21.
 #include "terrain.h"
 #include "tile.h"
 
-#include "mapimg.h"
-
 // Qt
+#include <QByteArray>
+#include <QByteArrayAlgorithms> // qstrlen, qstrdup, qstrncpy
+#include <QColor>
+#include <QFileInfo>
 #include <QImage>
 #include <QImageWriter>
+#include <QLatin1String>
 #include <QPainter>
+#include <QString>
+#include <QStringLiteral>
+#include <Qt>                    // Qt::*
+#include <QtContainerFwd>        // QStringList = QList<QString>
+#include <QtLogging>             // qDebug, qWarning, qCricital, etc
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <cstdarg> // va_*
+#include <cstddef> // size_t
+#include <cstdio>  // sscanf
+#include <cstring> // str*, mem*
+#include <utility> // std::as_const
 
 // == image colors ==
 enum img_special {

--- a/common/mapimg.h
+++ b/common/mapimg.h
@@ -1,13 +1,5 @@
-/***********************************************************************
-Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 /****************************************************************************
   Map images:
@@ -48,7 +40,14 @@ received a copy of the GNU General Public License along with Freeciv21.
 
 #pragma once
 
+// common
+#include "player.h"
+#include "terrain.h"
 #include "tile.h"
+
+// std
+#include <cstddef> // size_t
+
 #define MAX_LEN_MAPDEF 256
 
 // map image layers
@@ -70,7 +69,8 @@ received a copy of the GNU General Public License along with Freeciv21.
 // used a possible dummy value
 #define SPECENUM_COUNT MAPIMG_LAYER_COUNT
 #define SPECENUM_COUNTNAME "-"
-#include "specenum_gen.h"
+#include "specenum_gen.h" // IWYU pragma: keep (FIXME)
+
 /* If you change this enum, the default values for the client have to be
  * adapted (see options.c). */
 

--- a/common/metaknowledge.cpp
+++ b/common/metaknowledge.cpp
@@ -1,22 +1,27 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "metaknowledge.h"
+
+// utility
+#include "log.h"
+#include "shared.h"
 
 // common
+#include "city.h"
 #include "diptreaty.h"
+#include "fc_types.h"
 #include "game.h"
+#include "improvement.h"
 #include "map.h"
+#include "player.h"
+#include "requirements.h"
+#include "specialist.h"
 #include "tile.h"
 #include "traderoutes.h"
-
-#include "metaknowledge.h"
+#include "unit.h"
+#include "unittype.h"
 
 /**
    Returns TRUE iff the target_tile it self and all tiles cardinally

--- a/common/metaknowledge.h
+++ b/common/metaknowledge.h
@@ -1,17 +1,14 @@
-/***********************************************************************
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 #pragma once
 
+// utility
+#include "shared.h"
+
 // common
+#include "fc_types.h"
+#include "player.h"
 #include "requirements.h"
 
 enum fc_tristate mke_eval_req(

--- a/common/movement.cpp
+++ b/common/movement.cpp
@@ -1,32 +1,37 @@
-/*
-Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <QBitArray>
+// self
+#include "movement.h"
 
 // utility
 #include "bitvector.h"
 #include "log.h"
 #include "shared.h"
 #include "support.h"
+
 // common
+#include "actions.h"
+#include "city.h"
+#include "effects.h"
+#include "extras.h"
 #include "fc_types.h"
 #include "game.h"
 #include "map.h"
+#include "map_types.h"
+#include "player.h"
 #include "road.h"
 #include "terrain.h"
+#include "tile.h"
 #include "unit.h"
 #include "unitlist.h"
 #include "unittype.h"
 
-#include "movement.h"
+// Qt
+#include <QBitArray>
+#include <QByteArrayAlgorithms> // qstrlen, qstrdup, qstrncpy
+#include <QString>
+#include <QStringLiteral>
 
 /**
    This function calculates the move rate of the unit, taking into account

--- a/common/movement.h
+++ b/common/movement.h
@@ -1,18 +1,18 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-#include "map.h"
+// common
+#include "fc_types.h"
+#include "map.h" // IWYU pragma: keep (FIXME)
+#include "map_types.h"
+#include "path_finder.h"
+#include "player.h"
+#include "terrain.h"
+#include "tile.h"
+#include "unit.h"
+#include "unittype.h"
 
 #define SINGLE_MOVE (terrain_control.move_fragments)
 #define MOVE_COST_IGTER (terrain_control.igter_cost)

--- a/common/multipliers.cpp
+++ b/common/multipliers.cpp
@@ -1,21 +1,21 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "multipliers.h"
 
 // utility
 #include "fcintl.h"
+#include "log.h"
+#include "shared.h"
+#include "support.h"
 
 // common
+#include "fc_types.h"
 #include "game.h"
-
-#include "multipliers.h"
+#include "name_translation.h"
+#include "player.h"
+#include "requirements.h"
 
 static struct multiplier multipliers[MAX_NUM_MULTIPLIERS];
 

--- a/common/multipliers.h
+++ b/common/multipliers.h
@@ -1,15 +1,16 @@
-/***********************************************************************
-Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 #pragma once
+
+// common
+#include "fc_types.h"
+#include "name_translation.h"
+#include "requirements.h"
+
+// Qt
+#include <QString>
+#include <QtContainerFwd> // QVector<QString>
 
 struct multiplier {
   Multiplier_type_id id;

--- a/common/name_translation.h
+++ b/common/name_translation.h
@@ -1,14 +1,10 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 #pragma once
+
+// utiltiy
+#include "fcintl.h"
+#include "shared.h"
 
 // common
 #include "fc_types.h" // MAX_LEN_NAME

--- a/common/nation.cpp
+++ b/common/nation.cpp
@@ -1,33 +1,42 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 /**
-   Functions for handling the nations.
+ * \file
+ * Functions for handling the nations.
  */
+
+// self
+#include "nation.h"
 
 // utility
 #include "fcintl.h"
-#include "name_translation.h"
+#include "iterator.h"
+#include "log.h"
+#include "shared.h"
 #include "support.h"
 
 // common
+#include "city.h"
 #include "connection.h"
+#include "fc_types.h"
 #include "game.h"
 #include "government.h"
+#include "name_translation.h"
+#include "packets.h"
 #include "player.h"
+#include "rgbcolor.h"
+#include "terrain.h"
 #include "traits.h"
+#include "unit.h"
 
-#include "nation.h"
+// Qt
+#include <QtLogging> // qDebug, qWarning, qCricital, etc
+
+// std
+#include <cstddef> // size_t
+#include <cstring> // str*, mem*
+#include <vector>  // std:vector
 
 // Nation set structure.
 struct nation_set {

--- a/common/nation.h
+++ b/common/nation.h
@@ -1,22 +1,24 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-#include <array>
-
-#include "name_translation.h"
 // utility
 #include "iterator.h"
 
+// common
+#include "city.h"
+#include "fc_types.h"
+#include "name_translation.h"
+#include "player.h"
 #include "rgbcolor.h"
+#include "traits.h"
+#include "unit.h"
+
+// std
+#include <array>   // std::array
+#include <cstddef> // size_t
+#include <vector>  // std:vector
 
 #define NO_NATION_SELECTED (nullptr)
 


### PR DESCRIPTION
IWYU refactor of `common/m*` to `common/n*`. Note: There is no `common/j*`, `common/k*`, or `common/l*`. As with the other refactors, I'll come back and work on the `FIXME` later.

Part of #2464