### PR TITLE
Include Refactor: common o to s

### DIFF
--- a/common/path.cpp
+++ b/common/path.cpp
@@ -1,11 +1,23 @@
-// SPDX-FileCopyrightText: 2022 Louis Moureaux
 // SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+// self
 #include "path.h"
 
-#include "path_finder.h"
+// utility
+#include "log.h"
 
-#include <algorithm>
+// common
+#include "path_finder.h"
+#include "unit.h"
+
+// Qt
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <algorithm> // std::sort, std::unique
+#include <vector>    // std::vector
 
 namespace freeciv {
 

--- a/common/path.h
+++ b/common/path.h
@@ -1,11 +1,14 @@
-// SPDX-FileCopyrightText: 2022 Louis Moureaux
 // SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 #pragma once
 
+// common
 #include "unit.h"
 
-#include <vector>
+// std
+#include <vector> // std::vector
 
 struct tile;
 

--- a/common/path_finder.cpp
+++ b/common/path_finder.cpp
@@ -1,21 +1,42 @@
-// SPDX-FileCopyrightText: 2022 Louis Moureaux
 // SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
+// self
 #include "path_finder.h"
 
+// utility
+#include "log.h"
+
+// common
 #include "actions.h"
+#include "city.h"
+#include "fc_types.h"
 #include "game.h"
 #include "map.h"
 #include "movement.h"
 #include "path.h"
+#include "player.h"
 #include "tile.h"
 #include "unit.h"
 #include "unit_utils.h"
+#include "unitlist.h"
+#include "unittype.h"
 #include "world_object.h"
 
-#include <map>
-#include <queue>
-#include <set>
+// Qt
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <algorithm> // std:min, std::find_if
+#include <cstddef>   // size_t
+#include <map>       // std::multimap
+#include <memory>    // std::make_unique
+#include <optional>  // std::optional, std::nullopt
+#include <queue>     // std::priority_queue
+#include <tuple>     // std:tie
+#include <utility>   // std:move
+#include <vector>    // std:vector
 
 namespace freeciv {
 

--- a/common/path_finder.h
+++ b/common/path_finder.h
@@ -1,17 +1,27 @@
-// SPDX-FileCopyrightText: 2022 Louis Moureaux
 // SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
 
 #pragma once
 
+// utility
+#include "log.h"
+
+// common
+#include "fc_types.h"
 #include "path.h"
+#include "player.h"
 #include "unit.h"
 
-#include <map>
-#include <memory>
-#include <optional>
-#include <queue>
-#include <set>
-#include <utility>
+// std
+#include <cstddef>    // size_t
+#include <functional> // std::greater
+#include <map>        // std::multimap
+#include <memory>     // std::unique_ptr
+#include <optional>   // std::optional
+#include <queue>      // std::priority_queue
+#include <utility>    // std::move
+#include <vector>     // std::vector
 
 struct tile;
 

--- a/common/player.cpp
+++ b/common/player.cpp
@@ -1,20 +1,11 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
-#include <QBitArray>
-#include <QString>
+// self
+#include "player.h"
 
 // utility
+#include "bitvector.h"
 #include "fcintl.h"
 #include "log.h"
 #include "shared.h"
@@ -23,22 +14,42 @@
 // common
 #include "ai.h"
 #include "city.h"
+#include "effects.h"
+#include "extras.h"
 #include "fc_interface.h"
-#include "featured_text.h"
+#include "fc_types.h"
 #include "game.h"
-#include "government.h"
 #include "idex.h"
 #include "improvement.h"
 #include "map.h"
 #include "multipliers.h"
 #include "nation.h"
+#include "requirements.h"
 #include "research.h"
 #include "rgbcolor.h"
+#include "spaceship.h"
+#include "team.h"
+#include "tech.h"
+#include "tile.h"
+#include "traderoutes.h"
 #include "unit.h"
 #include "unitlist.h"
+#include "unittype.h"
 #include "vision.h"
 
-#include "player.h"
+// common/networking
+#include "connection.h"
+
+// Qt
+#include <QBitArray>
+#include <QString>
+#include <QStringLiteral>
+#include <Qt>        // Qt::*
+#include <QtLogging> // qDebug, qWarning, qCricital, etc
+
+// std
+#include <cstring> // str*, mem*
+#include <vector>  // std:vector
 
 struct player_slot {
   struct player *player;

--- a/common/player.h
+++ b/common/player.h
@@ -1,27 +1,35 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
+
+// utility
+#include "bitvector.h"
+#include "fcintl.h"
+#include "shared.h"
 
 // common
 #include "city.h"
 #include "effects.h"
+#include "fc_types.h"
+#include "improvement.h"
+#include "requirements.h"
+#include "rgbcolor.h"
 #include "spaceship.h"
 #include "tech.h"
+#include "tile.h"
 #include "traits.h"
+#include "unit.h"
+
+// Qt
+#include <QBitArray>
+#include <QByteArray>
+#include <QtPreprocessorSupport> // Q_UNUSED
 
 // std
-#include <map>
-#include <string>
+#include <map>    // std::map
+#include <string> // std:string
+#include <vector> // std:vector
 
 #define PLAYER_DEFAULT_TAX_RATE 0
 #define PLAYER_DEFAULT_SCIENCE_RATE 100

--- a/common/reqtext.cpp
+++ b/common/reqtext.cpp
@@ -1,34 +1,45 @@
-/*
-Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "reqtext.h"
 
 // utility
 #include "astring.h"
 #include "fcintl.h"
+#include "log.h"
+#include "support.h"
 
 // common
 #include "achievements.h"
 #include "actions.h"
+#include "base.h"
 #include "calendar.h"
+#include "city.h"
 #include "extras.h"
+#include "fc_types.h"
 #include "government.h"
-#include "map.h"
+#include "improvement.h"
 #include "movement.h"
 #include "nation.h"
 #include "player.h"
 #include "requirements.h"
+#include "road.h"
 #include "server_settings.h"
 #include "specialist.h"
 #include "style.h"
+#include "tech.h"
+#include "terrain.h"
+#include "traderoutes.h"
+#include "unittype.h"
 
-#include "reqtext.h"
+// Qt
+#include <QString>
+#include <QtContainerFwd> // QVector<QString>
+#include <QtLogging>      // qDebug, qWarning, qCricital, etc
+
+// std
+#include <cstddef> // size_t
 
 /**
    Append text for the requirement. Something like

--- a/common/reqtext.h
+++ b/common/reqtext.h
@@ -1,16 +1,10 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
+
+// std
+#include <cstddef> // size_t
 
 enum rt_verbosity { VERB_DEFAULT, VERB_ACTUAL };
 

--- a/common/requirements.cpp
+++ b/common/requirements.cpp
@@ -1,23 +1,26 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "requirements.h"
+
 // utility
+#include "bitvector.h"
 #include "fcintl.h"
 #include "log.h"
+#include "shared.h"
 #include "support.h"
 
 // common
 #include "achievements.h"
+#include "actions.h"
+#include "base.h"
 #include "calendar.h"
 #include "citizens.h"
+#include "city.h"
 #include "culture.h"
+#include "extras.h"
+#include "fc_types.h"
 #include "game.h"
 #include "government.h"
 #include "improvement.h"
@@ -30,8 +33,24 @@
 #include "server_settings.h"
 #include "specialist.h"
 #include "style.h"
+#include "tech.h"
+#include "terrain.h"
+#include "tile.h"
+#include "traderoutes.h"
+#include "unit.h"
+#include "unitlist.h"
+#include "unittype.h"
 
-#include "requirements.h"
+// Qt
+#include <QString>
+#include <QStringLiteral>
+#include <QtLogging>             // qDebug, qWarning, qCricital, etc
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <cstdarg> // va_*
+#include <cstddef> // size_t
+#include <cstdlib> // atoi
 
 /**
   Container for req_item_found functions

--- a/common/requirements.h
+++ b/common/requirements.h
@@ -1,18 +1,19 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
 #pragma once
 
+// utility
+#include "fcintl.h"
+
 // common
 #include "fc_types.h"
+
+// Qt
+#include <QString>
+
+// std
+#include <cstddef> // size_t
 
 /* Range of requirements.
  * Used in the network protocol.

--- a/common/research.cpp
+++ b/common/research.cpp
@@ -1,14 +1,11 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "research.h"
+
 // utility
+#include "bitvector.h"
 #include "fcintl.h"
 #include "iterator.h"
 #include "log.h"
@@ -16,15 +13,28 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 #include "support.h"
 
 // common
+#include "city.h"
+#include "effects.h"
 #include "fc_types.h"
 #include "game.h"
 #include "name_translation.h"
 #include "nation.h"
 #include "player.h"
+#include "requirements.h"
 #include "team.h"
 #include "tech.h"
 
-#include "research.h"
+// Qt
+#include <QByteArray>
+#include <QByteArrayAlgorithms> // qstrlen, qstrdup, qstrncpy
+#include <QGlobalStatic>        // Q_GLOBAL_STATIC
+#include <QString>
+#include <QtContainerFwd> // QVector<QString>
+
+// std
+#include <cstddef> // size_t
+#include <vector>  // std:vector
+
 // FIXME: Dont use extern, move inside some game running class eventually
 std::vector<research> research_array(MAX_NUM_PLAYER_SLOTS);
 

--- a/common/research.h
+++ b/common/research.h
@@ -1,13 +1,6 @@
-/***********************************************************************
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
 
 // utility
@@ -17,6 +10,10 @@ _   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
 // common
 #include "fc_types.h"
 #include "tech.h"
+
+// std
+#include <cstddef> // size_t
+#include <vector>  // std:vector
 
 /* TECH_KNOWN is self-explanatory, TECH_PREREQS_KNOWN are those for which all
  * requirements are fulfilled; all others (including those which can never

--- a/common/rgbcolor.cpp
+++ b/common/rgbcolor.cpp
@@ -1,23 +1,19 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
-#include <cstdarg>
+// self
+#include "rgbcolor.h"
 
 // utility
 #include "log.h"
-#include "registry.h"
 #include "registry_ini.h"
+#include "support.h"
 
-// common
-#include "rgbcolor.h"
+// std
+#include <cstdarg> // va_*
+#include <cstddef> // size_t
+#include <cstdio>  // sscanf
+#include <cstring> // str*, mem*
 
 /**
    Allocate new rgbcolor structure.

--- a/common/rgbcolor.h
+++ b/common/rgbcolor.h
@@ -1,17 +1,17 @@
-/**************************************************************************
- Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
-                   part of Freeciv21. Freeciv21 is free software: you can
-    ^oo^      redistribute it and/or modify it under the terms of the GNU
-    (..)        General Public License  as published by the Free Software
-   ()  ()       Foundation, either version 3 of the License,  or (at your
-   ()__()             option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
 
 // utility
 #include "shared.h"
+#include "support.h"
+
+// Qt
+#include <QtLogging> // qDebug, qWarning, qCricital, etc
+
+// std
+#include <cstddef> // size_t
 
 struct section_file;
 

--- a/common/road.cpp
+++ b/common/road.cpp
@@ -1,21 +1,25 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "road.h"
+
+// utility
+#include "bitvector.h"
+#include "log.h"
 
 // common
 #include "extras.h"
 #include "fc_types.h"
 #include "game.h"
 #include "map.h"
+#include "requirements.h"
+#include "tile.h"
+#include "unit.h"
+#include "unittype.h"
 
-#include "road.h"
+// std
+#include <algorithm> // std::max
 
 /**
    Return the road id.

--- a/common/road.h
+++ b/common/road.h
@@ -1,16 +1,14 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
+
+// utility
+#include "fcintl.h"
+
+// common
+#include "fc_types.h"
+#include "requirements.h"
 
 // Used in the network protocol.
 #define SPECENUM_NAME road_flag_id

--- a/common/server_settings.cpp
+++ b/common/server_settings.cpp
@@ -1,18 +1,19 @@
-/*
-_   ._       Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors.
- \  |    This file is part of Freeciv21. Freeciv21 is free software: you
-  \_|        can redistribute it and/or modify it under the terms of the
- .' '.              GNU General Public License  as published by the Free
- :O O:             Software Foundation, either version 3 of the License,
- '/ \'           or (at your option) any later version. You should have
-  :X:      received a copy of the GNU General Public License along with
-  :X:              Freeciv21. If not, see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "server_settings.h"
+
+// utility
+#include "fcintl.h"
+#include "log.h"
 
 // common
 #include "fc_interface.h"
+#include "fc_types.h"
 
-#include "server_settings.h"
+// Qt
+#include <QString>
 
 /**
    Returns the server setting with the specified name.

--- a/common/server_settings.h
+++ b/common/server_settings.h
@@ -1,18 +1,13 @@
-/***********************************************************************
-Copyright (c) 1996-2021 Freeciv21 and Freeciv contributors. This file is
- /\/\             part of Freeciv21. Freeciv21 is free software: you can
-   \_\  _..._    redistribute it and/or modify it under the terms of the
-   (" )(_..._)      GNU General Public License  as published by the Free
-    ^^  // \\      Software Foundation, either version 3 of the License,
-                  or (at your option) any later version. You should have
-received a copy of the GNU General Public License along with Freeciv21.
-                              If not, see https://www.gnu.org/licenses/.
-***********************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
 #pragma once
 
 // common
 #include "fc_types.h"
+
+// Qt
+#include <QString>
 
 // Special value to signal the absence of a server setting.
 #define SERVER_SETTING_NONE ((server_setting_id) -1)

--- a/common/spaceship.cpp
+++ b/common/spaceship.cpp
@@ -1,19 +1,18 @@
-/*__            ___                 ***************************************
-/   \          /   \          Copyright (c) 1996-2020 Freeciv21 and Freeciv
-\_   \        /  __/          contributors. This file is part of Freeciv21.
- _\   \      /  /__     Freeciv21 is free software: you can redistribute it
- \___  \____/   __/    and/or modify it under the terms of the GNU  General
-     \_       _/          Public License  as published by the Free Software
-       | @ @  \_               Foundation, either version 3 of the  License,
-       |                              or (at your option) any later version.
-     _/     /\                  You should have received  a copy of the GNU
-    /o)  (o/\ \_                General Public License along with Freeciv21.
-    \_____/ /                     If not, see https://www.gnu.org/licenses/.
-      \____/        ********************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
-#include "shared.h" // TRUE, FALSE
-
+// self
 #include "spaceship.h"
+
+// utility
+#include "bitvector.h"
+#include "log.h"
+
+// common
+#include "fc_types.h"
+
+// Qt
+#include <QtPreprocessorSupport> // Q_UNUSED
 
 const struct sship_part_info structurals_info[NUM_SS_STRUCTURALS] = {
     {19, 13, -1}, // -1 means none required

--- a/common/spaceship.h
+++ b/common/spaceship.h
@@ -1,18 +1,10 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
 #pragma once
 
 // utility
 #include "bitvector.h"
-#include "support.h" // bool type
 
 // common
 #include "fc_types.h"

--- a/common/specialist.cpp
+++ b/common/specialist.cpp
@@ -1,25 +1,25 @@
-/*
-    Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
-                         is part of Freeciv21. Freeciv21 is free software:
-|\_/|,,_____,~~`        you can redistribute it and/or modify it under the
-(.".)~~     )`~}}    terms of the GNU General Public License  as published
- \o/\ /---~\\ ~}}     by the Free Software Foundation, either version 3 of
-   _//    _// ~}       the License, or (at your option) any later version.
-                        You should have received a copy of the GNU General
-                          Public License along with Freeciv21. If not, see
-                                            https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "specialist.h"
 
 // utility
 #include "fcintl.h"
 #include "log.h"
+#include "shared.h"
+#include "support.h"
 
 // common
 #include "city.h"
 #include "effects.h"
+#include "fc_types.h"
 #include "game.h"
+#include "name_translation.h"
+#include "requirements.h"
 
-#include "specialist.h"
+// std
+#include <cstring> // str*, mem*
 
 struct specialist specialists[SP_MAX];
 int default_specialist;

--- a/common/specialist.h
+++ b/common/specialist.h
@@ -1,24 +1,18 @@
-/**************************************************************************
-    Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
-                         is part of Freeciv21. Freeciv21 is free software:
-|\_/|,,_____,~~`        you can redistribute it and/or modify it under the
-(.".)~~     )`~}}    terms of the GNU General Public License  as published
- \o/\ /---~\\ ~}}     by the Free Software Foundation, either version 3 of
-   _//    _// ~}       the License, or (at your option) any later version.
-                        You should have received a copy of the GNU General
-                          Public License along with Freeciv21. If not, see
-                                            https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
 #pragma once
 
 // utility
-#include "shared.h"
+#include "fcintl.h"
 
 // common
 #include "fc_types.h"
 #include "name_translation.h"
 #include "requirements.h"
+
+// Qt
+#include <QtContainerFwd> // QVector<QString>
 
 struct specialist {
   int item_number;

--- a/common/style.cpp
+++ b/common/style.cpp
@@ -1,24 +1,22 @@
-/*
-    Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
-                         is part of Freeciv21. Freeciv21 is free software:
-|\_/|,,_____,~~`        you can redistribute it and/or modify it under the
-(.".)~~     )`~}}    terms of the GNU General Public License  as published
- \o/\ /---~\\ ~}}     by the Free Software Foundation, either version 3 of
-   _//    _// ~}       the License, or (at your option) any later version.
-                        You should have received a copy of the GNU General
-                          Public License along with Freeciv21. If not, see
-                                            https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
+
+// self
+#include "style.h"
 
 // utility
 #include "fcintl.h"
+#include "log.h"
+#include "shared.h"
+#include "support.h"
 
 // common
+#include "city.h"
 #include "fc_types.h"
 #include "game.h"
 #include "name_translation.h"
-
-#include "style.h"
+#include "player.h"
+#include "requirements.h"
 
 static struct nation_style *styles = nullptr;
 

--- a/common/style.h
+++ b/common/style.h
@@ -1,19 +1,16 @@
-/**************************************************************************
-    Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
-                         is part of Freeciv21. Freeciv21 is free software:
-|\_/|,,_____,~~`        you can redistribute it and/or modify it under the
-(.".)~~     )`~}}    terms of the GNU General Public License  as published
- \o/\ /---~\\ ~}}     by the Free Software Foundation, either version 3 of
-   _//    _// ~}       the License, or (at your option) any later version.
-                        You should have received a copy of the GNU General
-                          Public License along with Freeciv21. If not, see
-                                            https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv and Freeciv21 Contributors
 
 #pragma once
 
+// common
+#include "city.h"
 #include "name_translation.h"
+#include "player.h"
 #include "requirements.h"
+
+// Qt
+#include <QString>
 
 struct nation_style {
   int id;


### PR DESCRIPTION
IWYU refactor of `common/o*` to `common/s*`. Note: There is no `common/o*`, or `common/q*`.

Another win, no FIXME's in this PR!

Part of #2464