### PR TITLE
Fix spelling mistakes in barbarian leader names

### DIFF
--- a/data/nation/barbarian.ruleset
+++ b/data/nation/barbarian.ruleset
@@ -15,7 +15,7 @@ leaders = {
  "Theodoric",   "Male"
  "Stilicho",    "Male"
  "Attila",      "Male"
- "Boadicea",    "Female"
+ "Boudica",     "Female"
 }
 
 flag="barbarian"

--- a/data/nation/pirate.ruleset
+++ b/data/nation/pirate.ruleset
@@ -12,11 +12,11 @@ leaders = {
  "name",                        "sex"
  "Anne Bonny",                  "Female"
  "Calico Jack",                 "Male"
- "Cofresí",                     "Male"
+ "Roberto Cofresí",             "Male"
  "Blackbeard",                  "Male"
  "Henry Morgan",                "Male"
- "François l'Ollonais",         "Male"
- "Bartolomeo Portugues",        "Male"
+ "François l'Olonais",          "Male"
+ "Bartolomeu Português",        "Male"
  "Ching Shih",                  "Female"
 }
 


### PR DESCRIPTION
Some leaders of the Barbarian and Pirate nations had misspelled names (noticed this after looking up François l'Olonais). Fix them using the preferred spellings from English Wikipedia. I didn't touch Ching Shih because it didn't seem so clear.