### PR TITLE
Limit the number of unused warnings shown

### DIFF
--- a/utility/registry_ini.h
+++ b/utility/registry_ini.h
@@ -57,7 +57,8 @@ struct section_file *secfile_from_stream(QIODevice *stream,
                                          bool allow_duplicates);
 
 bool secfile_save(const struct section_file *secfile, QString filename);
-void secfile_check_unused(const struct section_file *secfile);
+void secfile_check_unused(const struct section_file *secfile,
+                          int max_warnings = 10);
 const char *secfile_name(const struct section_file *secfile);
 
 enum entry_special_type { EST_NORMAL, EST_INCLUDE, EST_COMMENT };


### PR DESCRIPTION
When failing to load savegames, a long list of "unused" entries from the save was displayed, quickly filling up the terminal buffer.

Limit the number of displayed unused entries to 10, and list the total count when there are more.