### PR TITLE
Stop running governors on incomplete game data

### DIFF
--- a/client/governor.cpp
+++ b/client/governor.cpp
@@ -116,19 +116,16 @@ governor *governor::i()
 void governor::add_city_changed(struct city *pcity)
 {
   scity_changed.insert(pcity->id);
-  run();
 };
 
 void governor::add_city_new(struct city *pcity)
 {
   scity_changed.insert(pcity->id);
-  run();
 };
 
 void governor::add_city_remove(struct city *pcity)
 {
   scity_remove.insert(pcity->id);
-  run();
 };
 
 // run all events


### PR DESCRIPTION
We got reports that governors did not behave as expected in many cases, showing strange results and inconsistent with server-side data. This was in reliably observed when doing /take or /observe (#1834).

Governors run whenever information about a city changes, including when it is seen for the first time. There is a catch, however: the city may be sent before all game data is known. In this case its processing must be delayed. This is achieved using freeze/thaw packets sent by the server.

The governor code was incorrectly disregarding the freeze/thaw mechanism, resulting on governors being run on incomplete data. Fixing this solved the observed issues with /take and /observe. It also speeds up the initial connection by running governors less often (somehow city information gets sent multiple times).

Closes #1834.
Backport requested since this was a blocker for 3.1.