### PR TITLE
Allow overriding connection names from the console

### DIFF
--- a/client/editor/map_editor.cpp
+++ b/client/editor/map_editor.cpp
@@ -145,9 +145,6 @@ void map_editor::close()
 void map_editor::update_players()
 {
   if (!players_done) {
-    // While updating players, ensure we can take all possible nations
-    send_chat_printf("/set allowtake hHaAoObd");
-
     players_iterate(pplayer)
     {
       if (!is_barbarian(pplayer)) {

--- a/docs/Manuals/Server/options.rst
+++ b/docs/Manuals/Server/options.rst
@@ -70,7 +70,9 @@ To place a setting value on any of these settings use the ``/set <option-name> <
   * 1 = Controller allowed, observers allowed, cannot displace connections.
   * 2 = Controller allowed, no observers allowed, can displace connections.
   * 3 = Controller allowed, no observers allowed, cannot displace connections.
-  * 4 = No controller allowed, observers allowed
+  * 4 = No controller allowed, observers allowed.
+
+  The limits do not affect clients with HACK access level.
 
 ``alltemperate``
   :strong:`Default Value`: disabled

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -2654,7 +2654,8 @@ static struct setting settings[] = {
            "connections;\n"
            "     3 = Controller allowed, no observers allowed, can't "
            "displace connections;\n"
-           "     4 = No controller allowed, observers allowed"),
+           "     4 = No controller allowed, observers allowed.\n"
+           "The limits do not affect clients with HACK access level."),
         allowtake_callback, nullptr, GAME_DEFAULT_ALLOW_TAKE),
 
     GEN_BOOL("autotoggle", game.server.auto_ai_toggle, SSET_META,

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -3531,6 +3531,12 @@ static bool take_command(struct connection *caller, char *str, bool check)
 
   if (arg.count() == 2) {
     sz_strlcpy(username, qUtf8Printable(arg.at(i)));
+    if (!is_valid_username(username)) {
+      cmd_reply(CMD_TAKE, caller, C_FAIL,
+                _("\"%s\" is not a valid username."), username);
+      return res;
+    }
+
     pconn = conn_by_user_prefix(qUtf8Printable(arg.at(i)), &match_result);
     i++; // found a conn, now reference the second argument
 


### PR DESCRIPTION
There was no way for server administrators to set the connection username before a player connected for the first time. This forced players to /take themselves when connecting to a Longturn server for the first time (#1599).

A slightly unrelated issue was that the `allowtake` setting was applied even to local games (#2552). This allowed users to shoot themselves in the foot. Those players could always modify `allowtake`, but it wasn't immediately obvious.

This patch solves the first issue by allowing the console or HACK connections to issue `/take <username> <player>` even if there is no existing connection called `<username>`.

Since the fcdb API exposes the connection object and not merely the username, it could not be called without an active connection. Instead of changing the API, I decided to simply bypass it when the command is issued from a HACK context. Someone with HACK access already controls the server, so they could disable authentication if they wanted to. For consistency and given #2552, HACK connections now also bypass `allowtake`.

This also allows removing the `set allowtake` call in the editor.

The first and second commit should be backported. The third touches new code in 3.2.

Closes #1599.
Closes #2552.