### PR TITLE
Use Azure Ubuntu mirrors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,15 +29,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup mirror
+        run: |
+          sed -i 's/archive\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
       - name: Install GCC
         if: ${{ matrix.compiler == 'gcc' }}
         run: |
-          apt-get update
           apt-get install -y g++
       - name: Install clang
         if: ${{ matrix.compiler == 'clang' }}
         run: |
-          apt-get update
           apt-get install -y clang
           export CC=$(which clang)
           export CXX=$(which clang++)
@@ -101,9 +103,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup mirror
+        run: |
+          sed -i 's/archive\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
       - name: Install GCC
         run: |
-          apt-get update
           apt-get install -y g++
       - name: Install dependencies
         run: |
@@ -409,9 +414,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup mirror
+        run: |
+          sed -i 's/archive\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
       - name: Install dependencies
         run: |
-          apt-get update
           apt-get install -y \
             git \
             cmake \

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -26,9 +26,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
+      - name: Setup mirror
+        run: |
+          sed -i 's/archive\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
+
       - name: Install Dependencies
         run: |
-          apt-get update
           apt-get install -y \
             clang \
             cmake \

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -15,9 +15,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup mirror
+        run: |
+          sed -i 's/archive\.ubuntu\.com/azure.archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
       - name: Install dependencies
         run: |
-          apt-get update
           apt-get install -y \
             cmake \
             ninja-build \


### PR DESCRIPTION
Ubuntu is (rightfully) unhappy about actions pulling packages out of their main repositories, so they start returning 403 errors. This fails the workflows.

Switch all actions running in containers to the Microsoft mirror configured by default on action workers.