### PR TITLE
Map Editor: Complete Step 1

### DIFF
--- a/client/editor/map_editor.cpp
+++ b/client/editor/map_editor.cpp
@@ -178,6 +178,9 @@ void map_editor::player_changed(int index)
     }
   }
   players_iterate_end;
+  if (ett_wdg_active) {
+    ett_wdg->set_default_values();
+  }
 }
 
 /**

--- a/client/editor/tool_tile.cpp
+++ b/client/editor/tool_tile.cpp
@@ -154,12 +154,11 @@ void editor_tool_tile::update_ett(struct tile *ptile)
     if (client_has_player()
         && tile_get_known(ptile, client_player()) == TILE_UNKNOWN) {
       set_default_values();
-      ui.value_terrain->setText(Q_("?terrain:Not Visible"));
-      ui.value_vision->setText(Q_("?vision:Unknown"));
+      ui.value_terrain->setText(Q_("?terrain:Unknown"));
+      ui.value_vision->setText(Q_("?vision:Not Visible"));
     } else {
       ui.value_terrain->setText(create_help_link(
-          qUtf8Printable(terrain_name_translation(tile_terrain(ptile))),
-          HELP_TERRAIN));
+          terrain_name_translation(tile_terrain(ptile)), HELP_TERRAIN));
 
       QPixmap pm = get_tile_sprites(ptile);
       ui.pixmap_terrain->setPixmap(pm);
@@ -170,12 +169,12 @@ void editor_tool_tile::update_ett(struct tile *ptile)
       // tile owner
       struct player *owner = tile_owner(ptile);
       if (owner != nullptr) {
-        ui.value_owner->setText(create_help_link(
-            qUtf8Printable(nation_adjective_for_player(owner)),
-            HELP_NATIONS));
+        ui.value_owner->setText(
+            create_help_link(nation_plural_for_player(owner), HELP_NATIONS));
       } else {
         ui.value_owner->setText(Q_("?owner:None"));
       }
+
       // tile visibility to the current player
       if (tile_get_known(ptile, client_player()) == TILE_KNOWN_SEEN) {
         ui.value_vision->setText(Q_("?vision:Known and Visble"));
@@ -190,33 +189,27 @@ void editor_tool_tile::update_ett(struct tile *ptile)
       ui.value_nat_y->setNum(index_to_native_pos_y(ptile->index));
 
       // tile resource
-      auto text = create_help_link(
-          qUtf8Printable(get_tile_extra_text(ptile, {EC_RESOURCE})),
-          HELP_GOODS);
+      auto text = get_tile_extra_text(ptile, {EC_RESOURCE});
       ui.value_resource->setText(text.isEmpty() ? Q_("?resource:None")
                                                 : text);
       // tile road (highest level)
-      text = create_help_link(
-          qUtf8Printable(get_tile_extra_text(ptile, {EC_ROAD})), HELP_EXTRA);
+      text = get_tile_extra_text(ptile, {EC_ROAD});
       ui.value_road->setText(text.isEmpty() ? Q_("?road:None") : text);
+
       // tile infrastructure
-      text = create_help_link(qUtf8Printable(get_tile_extra_text(
-                                  ptile, {EC_IRRIGATION, EC_MINE})),
-                              HELP_EXTRA);
+      text = get_tile_extra_text(ptile, {EC_IRRIGATION, EC_MINE});
       ui.value_infra->setText(text.isEmpty() ? Q_("?infrastructure:None")
                                              : text);
       // tile base
-      text = create_help_link(
-          qUtf8Printable(get_tile_extra_text(ptile, {EC_BASE})), HELP_EXTRA);
+      text = get_tile_extra_text(ptile, {EC_BASE});
       ui.value_base->setText(text.isEmpty() ? Q_("?base:None") : text);
+
       // tile hut
-      text = create_help_link(
-          qUtf8Printable(get_tile_extra_text(ptile, {EC_HUT})), HELP_EXTRA);
+      text = get_tile_extra_text(ptile, {EC_HUT});
       ui.value_hut->setText(text.isEmpty() ? Q_("?hut:None") : text);
+
       // tile nuisance (pollution, fallout)
-      text = create_help_link(qUtf8Printable(get_tile_extra_text(
-                                  ptile, {EC_POLLUTION, EC_FALLOUT})),
-                              HELP_EXTRA);
+      text = get_tile_extra_text(ptile, {EC_POLLUTION, EC_FALLOUT});
       ui.value_nuisance->setText(text.isEmpty() ? Q_("?nuisance:None")
                                                 : text);
       // tile label
@@ -240,7 +233,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_ROAD, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -249,7 +243,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_IRRIGATION, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -258,7 +253,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_MINE, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -267,7 +263,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_POLLUTION, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -276,7 +273,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_FALLOUT, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -285,7 +283,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_HUT, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -294,7 +293,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_BASE, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -303,7 +303,8 @@ QString editor_tool_tile::get_tile_extra_text(
       extra_type_by_cause_iterate(EC_RESOURCE, pextra)
       {
         if (tile_has_extra(ptile, pextra)) {
-          names.push_back(extra_name_translation(pextra));
+          names.push_back(
+              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
         }
       }
       extra_type_by_cause_iterate_end;
@@ -344,7 +345,7 @@ QPixmap editor_tool_tile::get_tile_sprites(const struct tile *ptile) const
 
   // Add any resource on the tile
   // FIXME: fill_basic_extra_sprite_array() does not work with all EC_* cause
-  // codes.
+  // codes. Refer to issue #2622.
   if (tile_terrain(ptile)->resources) {
     struct extra_type *tres = nullptr;
     extra_type_by_cause_iterate(EC_RESOURCE, pextra)

--- a/client/editor/tool_tile.cpp
+++ b/client/editor/tool_tile.cpp
@@ -234,8 +234,8 @@ QString editor_tool_tile::get_tile_extra_text(
         names.push_back(
             create_help_link(extra_name_translation(pextra), HELP_EXTRA));
       }
-      }
-      extra_type_by_cause_iterate_end;
+    }
+    extra_type_by_cause_iterate_end;
   }
   if (names.isEmpty()) {
     return QString();

--- a/client/editor/tool_tile.cpp
+++ b/client/editor/tool_tile.cpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: James Robertson <jwrober@gmail.com>
 
 // self
-#include "editor/tool_tile.h"
+#include "tool_tile.h"
 
 // utility
 #include "astring.h"
@@ -228,91 +228,14 @@ QString editor_tool_tile::get_tile_extra_text(
 {
   QVector<QString> names;
   for (auto cause : causes) {
-    switch (cause) {
-    case EC_ROAD:
-      extra_type_by_cause_iterate(EC_ROAD, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
+    extra_type_by_cause_iterate(cause, pextra)
+    {
+      if (tile_has_extra(ptile, pextra)) {
+        names.push_back(
+            create_help_link(extra_name_translation(pextra), HELP_EXTRA));
+      }
       }
       extra_type_by_cause_iterate_end;
-      break;
-    case EC_IRRIGATION:
-      extra_type_by_cause_iterate(EC_IRRIGATION, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_MINE:
-      extra_type_by_cause_iterate(EC_MINE, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_POLLUTION:
-      extra_type_by_cause_iterate(EC_POLLUTION, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_FALLOUT:
-      extra_type_by_cause_iterate(EC_FALLOUT, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_HUT:
-      extra_type_by_cause_iterate(EC_HUT, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_BASE:
-      extra_type_by_cause_iterate(EC_BASE, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_RESOURCE:
-      extra_type_by_cause_iterate(EC_RESOURCE, pextra)
-      {
-        if (tile_has_extra(ptile, pextra)) {
-          names.push_back(
-              create_help_link(extra_name_translation(pextra), HELP_EXTRA));
-        }
-      }
-      extra_type_by_cause_iterate_end;
-      break;
-    case EC_APPEARANCE:
-    case EC_COUNT:
-      break;
-    }
   }
   if (names.isEmpty()) {
     return QString();

--- a/client/editor/tool_tile.h
+++ b/client/editor/tool_tile.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// generated
+#include <packets_gen.h>
+
 // Qt
 class QWidget;
 class QString;
@@ -21,11 +24,8 @@ private:
   void select_tile();
   void set_default_values();
 
-  QString get_tile_road_name(const struct tile *ptile) const;
-  QString get_tile_infra_name(const struct tile *ptile) const;
-  QString get_tile_nuisance_name(const struct tile *ptile) const;
-  QString get_tile_hut_name(const struct tile *ptile) const;
-  QString get_tile_base_name(const struct tile *ptile) const;
+  QString get_tile_extra_text(const tile *ptile,
+                              const std::vector<extra_cause> &causes) const;
   QPixmap get_tile_sprites(const struct tile *ptile) const;
 
 public:

--- a/client/editor/tool_tile.h
+++ b/client/editor/tool_tile.h
@@ -22,8 +22,6 @@ private:
   Ui::FormToolTile ui;
 
   void select_tile();
-  void set_default_values();
-
   QString get_tile_extra_text(const tile *ptile,
                               const std::vector<extra_cause> &causes) const;
   QPixmap get_tile_sprites(const struct tile *ptile) const;
@@ -33,6 +31,7 @@ public:
   ~editor_tool_tile() override;
 
   void close_tool();
+  void set_default_values();
   void update_ett(struct tile *ptile);
 };
 

--- a/client/editor/tool_tile.h
+++ b/client/editor/tool_tile.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-// generated
-#include <packets_gen.h>
+// common
+#include "packets.h"
 
 // Qt
 class QWidget;

--- a/client/editor/tool_tile.ui
+++ b/client/editor/tool_tile.ui
@@ -228,6 +228,9 @@
       <property name="text">
        <string>value_road</string>
       </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="9" column="1">
@@ -270,6 +273,9 @@
       <property name="text">
        <string>value_infra</string>
       </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="12" column="0">
@@ -309,6 +315,9 @@
      <widget class="QLabel" name="value_tile_label">
       <property name="text">
        <string>value_label</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/client/editor/tool_tile.ui
+++ b/client/editor/tool_tile.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>260</width>
-    <height>500</height>
+    <height>550</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+   <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,7 +19,7 @@
   <property name="maximumSize">
    <size>
     <width>260</width>
-    <height>500</height>
+    <height>550</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -31,10 +31,13 @@
      <x>0</x>
      <y>10</y>
      <width>260</width>
-     <height>500</height>
+     <height>541</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
+    <property name="sizeConstraint">
+     <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
+    </property>
     <property name="leftMargin">
      <number>8</number>
     </property>
@@ -47,30 +50,84 @@
     <property name="bottomMargin">
      <number>2</number>
     </property>
-    <item row="8" column="0">
-     <widget class="QLabel" name="label_nat_y">
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_continent">
       <property name="text">
-       <string>Native Y: </string>
+       <string>Continent: </string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
+    <item row="13" column="0">
+     <widget class="QLabel" name="label_base">
+      <property name="text">
+       <string>Base:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="0">
      <widget class="QLabel" name="label_y">
       <property name="text">
        <string>Tile Y: </string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="15" column="0">
+    <item row="3" column="1">
+     <widget class="QLabel" name="value_continent">
+      <property name="text">
+       <string>value_continent</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_terrain">
+      <property name="text">
+       <string>Base Terrain: </string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::AutoText</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="13" column="1">
+     <widget class="QLabel" name="value_base">
+      <property name="text">
+       <string>value_base</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLabel" name="value_owner">
+      <property name="text">
+       <string>value_owner</string>
+      </property>
+     </widget>
+    </item>
+    <item row="14" column="0">
+     <widget class="QLabel" name="label_hut">
+      <property name="text">
+       <string>Hut:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="17" column="0">
      <spacer name="verticalSpacer">
       <property name="orientation">
-       <enum>Qt::Vertical</enum>
+       <enum>Qt::Orientation::Vertical</enum>
       </property>
       <property name="sizeHint" stdset="0">
        <size>
@@ -80,37 +137,23 @@
       </property>
      </spacer>
     </item>
-    <item row="4" column="0">
-     <widget class="QLabel" name="label_owner">
+    <item row="6" column="0">
+     <widget class="QLabel" name="label_x">
       <property name="text">
-       <string>Owner:</string>
+       <string>Tile X: </string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="11" column="0">
-     <widget class="QLabel" name="label_infra">
+    <item row="9" column="0">
+     <widget class="QLabel" name="label_nat_y">
       <property name="text">
-       <string>Infrastructure:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="10" column="0">
-     <widget class="QLabel" name="label_road">
-      <property name="text">
-       <string>Road:</string>
+       <string>Native Y: </string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="14" column="1">
-     <widget class="QLabel" name="value_nuisance">
-      <property name="text">
-       <string>value_nuisance</string>
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
      </widget>
     </item>
@@ -123,17 +166,88 @@
        </size>
       </property>
       <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
+       <enum>Qt::LayoutDirection::RightToLeft</enum>
       </property>
       <property name="text">
        <string>edit</string>
       </property>
      </widget>
     </item>
-    <item row="7" column="1">
-     <widget class="QLabel" name="value_nat_x">
+    <item row="16" column="0">
+     <widget class="QLabel" name="label_tile_label">
       <property name="text">
-       <string>value_nat_x</string>
+       <string>Tile Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="0">
+     <widget class="QLabel" name="label_nat_x">
+      <property name="text">
+       <string>Native X: </string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="15" column="0">
+     <widget class="QLabel" name="label_nuisance">
+      <property name="text">
+       <string>Nuisance:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="0">
+     <widget class="QLabel" name="label_resource">
+      <property name="text">
+       <string>Resource:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="0">
+     <widget class="QLabel" name="label_road">
+      <property name="text">
+       <string>Road:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="1">
+     <widget class="QLabel" name="value_road">
+      <property name="text">
+       <string>value_road</string>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="1">
+     <widget class="QLabel" name="value_nat_y">
+      <property name="text">
+       <string>value_nat_y</string>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="1">
+     <widget class="QLabel" name="value_y">
+      <property name="text">
+       <string>value_y</string>
+      </property>
+     </widget>
+    </item>
+    <item row="14" column="1">
+     <widget class="QLabel" name="value_hut">
+      <property name="text">
+       <string>value_hut</string>
       </property>
      </widget>
     </item>
@@ -144,139 +258,71 @@
       </property>
      </widget>
     </item>
-    <item row="7" column="0">
-     <widget class="QLabel" name="label_nat_x">
+    <item row="15" column="1">
+     <widget class="QLabel" name="value_nuisance">
       <property name="text">
-       <string>Native X: </string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="QLabel" name="value_x">
-      <property name="text">
-       <string>value_x</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="1">
-     <widget class="QLabel" name="value_resource">
-      <property name="text">
-       <string>value_terrain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="10" column="1">
-     <widget class="QLabel" name="value_road">
-      <property name="text">
-       <string>value_road</string>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="1">
-     <widget class="QLabel" name="value_nat_y">
-      <property name="text">
-       <string>value_nat_y</string>
+       <string>value_nuisance</string>
       </property>
      </widget>
     </item>
     <item row="12" column="1">
-     <widget class="QLabel" name="value_base">
-      <property name="text">
-       <string>value_base</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <widget class="QLabel" name="value_y">
-      <property name="text">
-       <string>value_y</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="label_x">
-      <property name="text">
-       <string>Tile X: </string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QLabel" name="value_owner">
-      <property name="text">
-       <string>value_owner</string>
-      </property>
-     </widget>
-    </item>
-    <item row="11" column="1">
      <widget class="QLabel" name="value_infra">
       <property name="text">
        <string>value_infra</string>
       </property>
      </widget>
     </item>
-    <item row="3" column="1">
-     <widget class="QLabel" name="value_continent">
+    <item row="12" column="0">
+     <widget class="QLabel" name="label_infra">
       <property name="text">
-       <string>value_continent</string>
+       <string>Infrastructure:</string>
       </property>
      </widget>
     </item>
-    <item row="14" column="0">
-     <widget class="QLabel" name="label_nuisance">
+    <item row="4" column="0">
+     <widget class="QLabel" name="label_owner">
       <property name="text">
-       <string>Nuisance:</string>
+       <string>Owner:</string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="9" column="0">
-     <widget class="QLabel" name="label_resource">
+    <item row="10" column="1">
+     <widget class="QLabel" name="value_resource">
       <property name="text">
-       <string>Resource:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_terrain">
-      <property name="text">
-       <string>Base Terrain: </string>
+       <string>value_resource</string>
       </property>
       <property name="textFormat">
-       <enum>Qt::AutoText</enum>
+       <enum>Qt::TextFormat::RichText</enum>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
-     </widget>
-    </item>
-    <item row="12" column="0">
-     <widget class="QLabel" name="label_base">
-      <property name="text">
-       <string>Base:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
       </property>
      </widget>
     </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_continent">
+    <item row="16" column="1">
+     <widget class="QLabel" name="value_tile_label">
       <property name="text">
-       <string>Continent: </string>
+       <string>value_label</string>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <widget class="QLabel" name="value_x">
+      <property name="text">
+       <string>value_x</string>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="1">
+     <widget class="QLabel" name="value_nat_x">
+      <property name="text">
+       <string>value_nat_x</string>
       </property>
      </widget>
     </item>
@@ -285,22 +331,34 @@
       <property name="text">
        <string>value_terrain</string>
       </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::RichText</enum>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+      </property>
      </widget>
     </item>
-    <item row="13" column="0">
-     <widget class="QLabel" name="label_hut">
+    <item row="5" column="0">
+     <widget class="QLabel" name="label_owner_vision">
       <property name="text">
-       <string>Hut:</string>
+       <string>Owner Vision:</string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
       </property>
      </widget>
     </item>
-    <item row="13" column="1">
-     <widget class="QLabel" name="value_hut">
+    <item row="5" column="1">
+     <widget class="QLabel" name="value_vision">
       <property name="text">
-       <string>value_hut</string>
+       <string>value_vision</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -119,7 +119,7 @@ QString create_help_link(const char *name, const char *entry,
         QString::fromUtf8(QString(entry).toUtf8().toPercentEncoding());
     return "<a href=" + QString::number(hpt) + "," + a + ">" + d + "</a>";
   } else {
-    return nullptr;
+    return QStringLiteral();
   }
 }
 

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -112,10 +112,15 @@ QString create_help_link(const char *name, help_page_type hpt)
 QString create_help_link(const char *name, const char *entry,
                          help_page_type hpt)
 {
-  QString d = QString(name).toHtmlEscaped().replace(
-      QStringLiteral(" "), QStringLiteral("&nbsp;"));
-  QString a = QString::fromUtf8(QString(entry).toUtf8().toPercentEncoding());
-  return "<a href=" + QString::number(hpt) + "," + a + ">" + d + "</a>";
+  if (!QString(name).isEmpty()) {
+    QString d = QString(name).toHtmlEscaped().replace(
+        QStringLiteral(" "), QStringLiteral("&nbsp;"));
+    QString a =
+        QString::fromUtf8(QString(entry).toUtf8().toPercentEncoding());
+    return "<a href=" + QString::number(hpt) + "," + a + ">" + d + "</a>";
+  } else {
+    return nullptr;
+  }
 }
 
 /**


### PR DESCRIPTION
This patch completes population all properties of a tile from the editor. This PR also implements two suggestions from #2595 - merge repeated functions into a single one and add help text links for tiles.

Closes #2547 
Closes #2626
