### PR TITLE
Fix memory leak in move_points_text_full

### DIFF
--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -150,12 +150,12 @@ static bool insert_veteran_help(char *outbuf, size_t outlen,
       const char *name = name_translation_get(&level->name);
       /* Use get_internal_string_length() for correct alignment with
        * multibyte character encodings */
-      cat_snprintf(
-          outbuf, outlen, "\n%s%*s %4d%% %12s", name,
-          MAX(0, 25 - (int) get_internal_string_length(name)), "",
-          level->power_fact,
-          /* e.g. "-    ", "+ 1/3", "+ 1    ", "+ 2 2/3" */
-          move_points_text_full(level->move_bonus, true, "+ ", "-", true));
+      cat_snprintf(outbuf, outlen, "\n%s%*s %4d%% %12s", name,
+                   MAX(0, 25 - (int) get_internal_string_length(name)), "",
+                   level->power_fact,
+                   /* e.g. "-    ", "+ 1/3", "+ 1    ", "+ 2 2/3" */
+                   qUtf8Printable(move_points_text_full(
+                       level->move_bonus, true, "+ ", "-", true)));
     }
     return true;
   }
@@ -2140,12 +2140,13 @@ char *helptext_unit(char *buf, size_t bufsz, struct player *pplayer,
             _("* Gets double firepower when attacking cities.\n"));
   }
   if (utype_has_flag(utype, UTYF_IGTER)) {
-    cat_snprintf(buf, bufsz,
-                 /* TRANS: "MP" = movement points. %s may have a
-                  * fractional part. */
-                 _("* Ignores terrain effects (moving costs at most %s MP "
-                   "per tile).\n"),
-                 move_points_text(terrain_control.igter_cost, true));
+    cat_snprintf(
+        buf, bufsz,
+        /* TRANS: "MP" = movement points. %s may have a
+         * fractional part. */
+        _("* Ignores terrain effects (moving costs at most %s MP "
+          "per tile).\n"),
+        qUtf8Printable(move_points_text(terrain_control.igter_cost, true)));
   }
   if (utype_has_flag(utype, UTYF_NOZOC)) {
     CATLSTR(buf, bufsz, _("* Never imposes a zone of control.\n"));
@@ -3730,7 +3731,7 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
                     * fractional part. */
                    _("* Movement cost along %s is %s MP.\n"),
                    extra_name_translation(pextra),
-                   move_points_text(proad->move_cost, true));
+                   qUtf8Printable(move_points_text(proad->move_cost, true)));
     }
   }
 

--- a/common/movement.cpp
+++ b/common/movement.cpp
@@ -798,8 +798,8 @@ void init_move_fragments()
      padding spaces will be included to make all such strings line up when
      right-aligned.
  */
-const char *move_points_text_full(int mp, bool reduce, const char *prefix,
-                                  const char *none, bool align)
+QString move_points_text_full(int mp, bool reduce, const char *prefix,
+                              const char *none, bool align)
 {
   QString str;
 
@@ -850,14 +850,14 @@ const char *move_points_text_full(int mp, bool reduce, const char *prefix,
                       QString::number(SINGLE_MOVE / cancel));
     }
   }
-  return qstrdup(qUtf8Printable(str));
+  return str;
 }
 
 /**
    Simple version of move_points_text_full() -- render positive movement
    points as text without any prefix or alignment.
  */
-const char *move_points_text(int mp, bool reduce)
+QString move_points_text(int mp, bool reduce)
 {
   return move_points_text_full(mp, reduce, nullptr, nullptr, false);
 }

--- a/common/movement.h
+++ b/common/movement.h
@@ -114,6 +114,6 @@ bool is_airunit_refuel_point(const struct tile *ptile,
                              const struct unit *punit);
 
 void init_move_fragments();
-const char *move_points_text_full(int mp, bool reduce, const char *prefix,
-                                  const char *none, bool align);
-const char *move_points_text(int mp, bool reduce);
+QString move_points_text_full(int mp, bool reduce, const char *prefix,
+                              const char *none, bool align);
+QString move_points_text(int mp, bool reduce);

--- a/common/reqtext.cpp
+++ b/common/reqtext.cpp
@@ -1603,13 +1603,15 @@ bool req_text_insert(char *buf, size_t bufsz, struct player *pplayer,
                      /* %s is numeric move points; it may have a
                       * fractional part ("1 1/3 MP"). */
                      _("Requires that the unit has at least %s MP left."),
-                     move_points_text(preq->source.value.minmoves, true));
+                     qUtf8Printable(move_points_text(
+                         preq->source.value.minmoves, true)));
       } else {
         cat_snprintf(buf, bufsz,
                      /* %s is numeric move points; it may have a
                       * fractional part ("1 1/3 MP"). */
                      _("Requires that the unit has less than %s MP left."),
-                     move_points_text(preq->source.value.minmoves, true));
+                     qUtf8Printable(move_points_text(
+                         preq->source.value.minmoves, true)));
       }
       return true;
     case REQ_RANGE_CADJACENT:

--- a/common/requirements.cpp
+++ b/common/requirements.cpp
@@ -4309,8 +4309,9 @@ const char *universal_name_translation(const struct universal *psource,
   case VUT_MINMOVES:
     /* TRANS: Minimum unit movement points left for requirement to be met
      * (%s is a string like "1" or "2 1/3") */
-    cat_snprintf(buf, bufsz, _("%s MP"),
-                 move_points_text(psource->value.minmoves, true));
+    cat_snprintf(
+        buf, bufsz, _("%s MP"),
+        qUtf8Printable(move_points_text(psource->value.minmoves, true)));
     return buf;
   case VUT_MINHP:
     // TRANS: HP = hit points

--- a/common/unittype.cpp
+++ b/common/unittype.cpp
@@ -1307,7 +1307,7 @@ const char *utype_values_string(const struct unit_type *punittype)
   // Print in two parts as move_points_text() returns a static buffer
   fc_snprintf(buffer, sizeof(buffer), "%d/%d/%s", punittype->attack_strength,
               punittype->defense_strength,
-              move_points_text(punittype->move_rate, true));
+              qUtf8Printable(move_points_text(punittype->move_rate, true)));
   if (utype_fuel(punittype)) {
     cat_snprintf(buffer, sizeof(buffer), "(%d)", utype_fuel(punittype));
   }

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -2528,7 +2528,7 @@ static bool illegal_action_pay_price(
                    * fractions. */
                   _("Your %s lost %s MP for attempting an illegal action."),
                   unit_name_translation(act_unit),
-                  move_points_text(punishment_mp, true));
+                  qUtf8Printable(move_points_text(punishment_mp, true)));
   }
 
   return punishment_mp != 0 || punishment_hp != 0;

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -565,7 +565,7 @@ static bool manual_command(struct tag_types *tag_info)
         fprintf(doc, "%s", tag_info->subitem_end);
         fprintf(doc, tag_info->subitem_begin, "moves");
         fprintf(doc, _("Moves: %s"),
-                move_points_text(putype->move_rate, true));
+                qUtf8Printable(move_points_text(putype->move_rate, true)));
         fprintf(doc, "%s", tag_info->subitem_end);
         fprintf(doc, tag_info->subitem_begin, "vision");
         fprintf(doc, _("Vision: %d"),


### PR DESCRIPTION
The function was allocating memory using qstrdup, but none of its callers was freeing it. Force them to pay attention by returning a QString instead of const char *.

Found by ASan.