### PR TITLE
Use markdown to render help texts in the help browser.

### DIFF
--- a/client/fonts.cpp
+++ b/client/fonts.cpp
@@ -179,6 +179,7 @@ void configure_fonts()
                  true);
   configure_font(fonts::city_productions, sl, QFont::SansSerif,
                  default_size);
+  configure_font(fonts::help_text, sl, QFont::SansSerif, default_size);
 
   /* Monospace List */
   sl.clear();
@@ -188,7 +189,6 @@ void configure_fonts()
 
   configure_font(fonts::notify_label, sl, QFont::Monospace, default_size);
   configure_font(fonts::help_label, sl, QFont::Monospace, default_size);
-  configure_font(fonts::help_text, sl, QFont::Monospace, default_size);
   configure_font(fonts::chatline, sl, QFont::Monospace, default_size);
 
   /* Serif List */

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -39,7 +39,6 @@
 #include "fonts.h"
 #include "helpdlg.h"
 #include "tileset/tilespec.h"
-#include "views/view_map_common.h"
 
 #define MAX_HELP_TEXT_SIZE 8192
 #define REQ_LABEL_NEVER _("(Never)")

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -870,7 +870,7 @@ void help_widget::set_topic_other(const help_item *topic, const char *title)
 {
   Q_UNUSED(title)
   if (topic->text) {
-    text_browser->setPlainText(topic->text);
+    text_browser->setMarkdown(topic->text);
   } else {
     text_browser->setPlainText(
         QLatin1String("")); // Something better to do ?
@@ -893,7 +893,7 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
   if (utype) {
     helptext_unit(buffer, sizeof(buffer), client.conn.playing, topic->text,
                   utype, client_current_nation_set());
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
 
     // Create information panel
     show_info_panel();
@@ -1002,7 +1002,7 @@ void help_widget::set_topic_building(const help_item *topic,
   if (itype) {
     helptext_building(buffer, sizeof(buffer), client.conn.playing,
                       topic->text, itype, client_current_nation_set());
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
     show_info_panel();
     auto spr = get_building_sprite(tileset, itype);
     if (spr) {
@@ -1169,7 +1169,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
       info_panel_done();
       helptext_advance(buffer, sizeof(buffer), client.conn.playing,
                        topic->text, n, client_current_nation_set());
-      text_browser->setPlainText(buffer);
+      text_browser->setMarkdown(buffer);
     }
   } else {
     set_topic_other(topic, title);
@@ -1296,7 +1296,7 @@ void help_widget::set_topic_terrain(const help_item *topic,
 
     helptext_terrain(buffer, sizeof(buffer), client.conn.playing,
                      topic->text, pterrain);
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
 
     // Create information panel
     show_info_panel();
@@ -1446,7 +1446,7 @@ void help_widget::set_topic_extra(const help_item *topic, const char *title)
   if (pextra) {
     helptext_extra(buffer, sizeof(buffer), client.conn.playing, topic->text,
                    pextra);
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
   } else {
     set_topic_other(topic, title);
   }
@@ -1463,7 +1463,7 @@ void help_widget::set_topic_specialist(const help_item *topic,
   if (pspec) {
     helptext_specialist(buffer, sizeof(buffer), client.conn.playing,
                         topic->text, pspec);
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
   } else {
     set_topic_other(topic, title);
   }
@@ -1480,7 +1480,7 @@ void help_widget::set_topic_government(const help_item *topic,
   if (pgov) {
     helptext_government(buffer, sizeof(buffer), client.conn.playing,
                         topic->text, pgov);
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
   } else {
     set_topic_other(topic, title);
   }
@@ -1495,7 +1495,7 @@ void help_widget::set_topic_nation(const help_item *topic, const char *title)
   struct nation_type *pnation = nation_by_translated_plural(title);
   if (pnation) {
     helptext_nation(buffer, sizeof(buffer), pnation, topic->text);
-    text_browser->setPlainText(buffer);
+    text_browser->setMarkdown(buffer);
   } else {
     set_topic_other(topic, title);
   }
@@ -1511,7 +1511,7 @@ void help_widget::set_topic_goods(const help_item *topic, const char *title)
   if (pgood) {
     helptext_goods(buffer, sizeof(buffer), client.conn.playing, topic->text,
                    pgood);
-    text_browser->setText(buffer);
+    text_browser->setMarkdown(buffer);
   } else {
     set_topic_other(topic, title);
   }

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -528,6 +528,7 @@ void help_widget::setup_ui()
 
   text_browser = new QTextBrowser(this);
   text_browser->setProperty(fonts::help_text, "true");
+  text_browser->setOpenExternalLinks(true);
   layout->addWidget(text_browser);
   main_widget = text_browser;
 

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -136,22 +136,15 @@ static bool insert_veteran_help(char *outbuf, size_t outlen,
       CATLSTR(outbuf, outlen, "\n\n");
     }
     // TODO: Report raise_chance and work_raise_chance
-    CATLSTR(
-        outbuf, outlen,
-        /* TRANS: Header for fixed-width veteran level table.
-         * TRANS: Translators cannot change column widths :(
-         * TRANS: "Level name" left-justified, other two right-justified */
-        _("Veteran level      Power factor   Move bonus\n"));
+    cat_snprintf(outbuf, outlen, "| %s | %s | %s |\n", _("Veteran level"),
+                 _("Power factor"), _("Move bonus"));
     CATLSTR(outbuf, outlen,
             // TRANS: Part of header for veteran level table.
-            _("--------------------------------------------"));
+            _("| :-- | --: | --: |"));
     for (i = 0; i < veteran->levels; i++) {
       const struct veteran_level *level = &veteran->definitions[i];
       const char *name = name_translation_get(&level->name);
-      /* Use get_internal_string_length() for correct alignment with
-       * multibyte character encodings */
-      cat_snprintf(outbuf, outlen, "\n%s%*s %4d%% %12s", name,
-                   MAX(0, 25 - (int) get_internal_string_length(name)), "",
+      cat_snprintf(outbuf, outlen, "\n| %s | %4d%% | %s |", name,
                    level->power_fact,
                    /* e.g. "-    ", "+ 1/3", "+ 1    ", "+ 2 2/3" */
                    qUtf8Printable(move_points_text_full(
@@ -195,15 +188,9 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
         pillage_time = -1;
     bool terrain_independent_extras = false;
 
-    CATLSTR(outbuf, outlen,
-            /* TRANS: Header for fixed-width terrain alteration table.
-             * TRANS: Translators cannot change column widths :( */
-            _("Terrain           Cultivate        Plant            "
-              "Transform\n"));
-    CATLSTR(
-        outbuf, outlen,
-        "-------------------------------------------------------------------"
-        "-\n");
+    cat_snprintf(outbuf, outlen, "| %s | %s | %s |%s |\n", _("Terrain"),
+                 _("Cultivate"), _("Plant"), _("Transform"));
+    CATLSTR(outbuf, outlen, "| :-- | :-- | :-- | :-- |\n");
     terrain_type_iterate(pterrain)
     {
       if (0 != qstrlen(terrain_rule_name(pterrain))) {
@@ -221,15 +208,8 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
 
         auto terrain = terrain_name_translation(pterrain);
 
-        /* Use get_internal_string_length() for correct alignment with
-         * multibyte character encodings */
-        cat_snprintf(
-            outbuf, outlen, "%s%*s %s%*s %s%*s %s\n", terrain,
-            MAX(0, 16 - (int) get_internal_string_length(terrain)), "",
-            cultivate,
-            MAX(0, 16 - (int) get_internal_string_length(cultivate)), "",
-            plant, MAX(0, 16 - (int) get_internal_string_length(plant)), "",
-            transform);
+        cat_snprintf(outbuf, outlen, "| %s | %s | %s | %s |\n", terrain,
+                     cultivate, plant, transform);
 
         if (clean_pollution_time != 0
             && pterrain->clean_pollution_time != 0) {
@@ -423,21 +403,19 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
               _("Time taken for the following activities is independent of "
                 "terrain:\n"));
       CATLSTR(outbuf, outlen, "\n");
-      CATLSTR(outbuf, outlen,
-              /* TRANS: Header for fixed-width terrain alteration table.
-               * TRANS: Translators cannot change column widths :( */
-              _("Activity            Time\n"));
-      CATLSTR(outbuf, outlen, "---------------------------");
+      cat_snprintf(outbuf, outlen, "| %s | %s |\n", _("Activity"),
+                   _("Time"));
+      CATLSTR(outbuf, outlen, "| :-- | --: |");
       if (clean_pollution_time > 0) {
-        cat_snprintf(outbuf, outlen, _("\nClean pollution    %3d"),
+        cat_snprintf(outbuf, outlen, "\n| %s | %d |", _("Clean pollution"),
                      clean_pollution_time);
       }
       if (clean_fallout_time > 0) {
-        cat_snprintf(outbuf, outlen, _("\nClean fallout      %3d"),
+        cat_snprintf(outbuf, outlen, "\n| %s | %d |", _("Clean fallout"),
                      clean_fallout_time);
       }
       if (pillage_time > 0) {
-        cat_snprintf(outbuf, outlen, _("\nPillage            %3d"),
+        cat_snprintf(outbuf, outlen, "\n| %s | %d |", _("Pillage"),
                      pillage_time);
       }
       extra_type_by_cause_iterate(EC_ROAD, pextra)
@@ -445,9 +423,8 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
         if (pextra->buildable && pextra->build_time > 0) {
           const char *rname = extra_name_translation(pextra);
 
-          cat_snprintf(outbuf, outlen, "\n%s%*s %3d", rname,
-                       MAX(0, 18 - (int) get_internal_string_length(rname)),
-                       "", pextra->build_time);
+          cat_snprintf(outbuf, outlen, "\n| %s | %d |", rname,
+                       pextra->build_time);
         }
       }
       extra_type_by_cause_iterate_end;
@@ -456,9 +433,8 @@ static bool insert_generated_text(char *outbuf, size_t outlen,
         if (pextra->buildable && pextra->build_time > 0) {
           const char *bname = extra_name_translation(pextra);
 
-          cat_snprintf(outbuf, outlen, "\n%s%*s %3d", bname,
-                       MAX(0, 18 - (int) get_internal_string_length(bname)),
-                       "", pextra->build_time);
+          cat_snprintf(outbuf, outlen, "\n| %s | %d |", bname,
+                       pextra->build_time);
         }
       }
       extra_type_by_cause_iterate_end;
@@ -3804,28 +3780,20 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
         CATLSTR(
             buf, bufsz,
             _("\nTime to build and output bonus depends on terrain:\n\n"));
-        CATLSTR(buf, bufsz,
-                /* TRANS: Header for fixed-width road properties table.
-                 * TRANS: Translators cannot change column widths :( */
-                _("Terrain       Time     Bonus F/P/T\n"
-                  "----------------------------------\n"));
+        cat_snprintf(buf, bufsz, "| %s | %s | %s |\n", _("Terrain"),
+                     _("Time"), _("Bonus F/P/T"));
+        CATLSTR(buf, bufsz, "| :-- | --: | :-- |\n");
       } else if (do_time) {
         CATLSTR(buf, bufsz, _("\nTime to build depends on terrain:\n\n"));
-        CATLSTR(buf, bufsz,
-                /* TRANS: Header for fixed-width extra properties table.
-                 * TRANS: Translators cannot change column widths :( */
-                _("Terrain       Time\n"
-                  "------------------\n"));
+        cat_snprintf(buf, bufsz, "| %s | %s |\n", _("Terrain"), _("Time"));
+        CATLSTR(buf, bufsz, "| :-- | --: |\n");
       } else {
         fc_assert(do_bonus);
         CATLSTR(buf, bufsz,
-                /* TRANS: Header for fixed-width road properties table.
-                 * TRANS: Translators cannot change column widths :( */
                 _("\nYields an output bonus with some terrains:\n\n"));
-        CATLSTR(buf, bufsz,
-                _("Terrain       Bonus F/P/T\n"
-                  "-------------------------\n"));
-        ;
+        cat_snprintf(buf, bufsz, "| %s | %s |\n", _("Terrain"),
+                     _("Bonus F/P/T"));
+        CATLSTR(buf, bufsz, "| :-- | :-- |\n");
       }
       terrain_type_iterate(t)
       {
@@ -3837,21 +3805,20 @@ void helptext_extra(char *buf, size_t bufsz, struct player *pplayer,
         if (turns > 0 || bonus_text) {
           const char *terrain = terrain_name_translation(t);
 
-          cat_snprintf(
-              buf, bufsz, "%s%*s ", terrain,
-              MAX(0, 12 - (int) get_internal_string_length(terrain)), "");
+          cat_snprintf(buf, bufsz, "| %s ", terrain);
+
           if (do_time) {
             if (turns > 0) {
-              cat_snprintf(buf, bufsz, "%3d      ", turns);
+              cat_snprintf(buf, bufsz, "| %d ", turns);
             } else {
-              CATLSTR(buf, bufsz, "  -      ");
+              CATLSTR(buf, bufsz, "| - ");
             }
           }
           if (do_bonus) {
             fc_assert(proad != nullptr);
-            cat_snprintf(buf, bufsz, " %s", bonus_text ? bonus_text : "-");
+            cat_snprintf(buf, bufsz, "| %s ", bonus_text ? bonus_text : "-");
           }
-          CATLSTR(buf, bufsz, "\n");
+          CATLSTR(buf, bufsz, "|\n");
         }
       }
       terrain_type_iterate_end;

--- a/common/networking/connection.cpp
+++ b/common/networking/connection.cpp
@@ -583,7 +583,8 @@ void connection_common_close(struct connection *pconn)
   if (!pconn->used) {
     qCritical("WARNING: Trying to close already closed connection");
   } else {
-    pconn->sock->deleteLater();
+    if (pconn->sock)
+      pconn->sock->deleteLater();
     pconn->sock = nullptr;
     pconn->used = false;
     pconn->established = false;

--- a/docs/Manuals/Program/freeciv21-manual.rst
+++ b/docs/Manuals/Program/freeciv21-manual.rst
@@ -7,8 +7,7 @@ freeciv21-manual
 SYNOPSIS
 ========
 
-``freeciv21-manual`` [ -l|--log `<FILE>` ] [ -r|--ruleset `<RULESET>` ] [ -w|--wiki ] [ -h|--help ]
-[ -v|--version ]
+``freeciv21-manual`` [ -l|--log `<FILE>` ] [ -r|--ruleset `<RULESET>` ] [ -h|--help ] [ -v|--version ]
 
 DESCRIPTION
 ===========
@@ -38,9 +37,6 @@ each option separately, such as, ``freevic21-manual -r civ2civ3 -w``.
 
 ``-r, --ruleset <RULESET>``
     Make manual for RULESET.
-
-``-w, --wiki``
-    Write manual in wiki format.
 
 ``-h, --help``
     Display help on command line options.

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -31,16 +31,13 @@
 // common
 #include "capstr.h"
 #include "connection.h"
-#include "events.h"
 #include "fc_interface.h"
 #include "fc_types.h" // LINE_BREAK
 #include "game.h"
 #include "government.h"
 #include "helpdata.h"
 #include "improvement.h"
-#include "map.h"
 #include "movement.h"
-#include "player.h"
 #include "tech.h"
 #include "version.h"
 

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -18,6 +18,7 @@
 // Qt
 #include <QCommandLineParser>
 #include <QCoreApplication>
+#include <QTextDocumentFragment>
 
 // utility
 #include "astring.h"
@@ -117,6 +118,20 @@ struct tag_types html_tags = {
     "</body></html>"};
 
 static QString ruleset;
+
+static QString markdown_to_html(QString(markdown))
+{
+  QTextDocumentFragment fragment =
+      QTextDocumentFragment::fromMarkdown(markdown);
+  QString html = fragment.toHtml();
+
+  // QTextDocumentFragment insists on providing complete HTML
+  // documents. Cut away the HTML boilerplate.
+  html = html.left(html.indexOf("</body>"));
+  html = html.right(html.length() - html.indexOf("<body>") - 6);
+
+  return html;
+}
 
 /**
    Write a server manual, then quit.
@@ -477,7 +492,8 @@ static bool manual_command(struct tag_types *tag_info)
         fprintf(doc, "<em>%s</em></td>\n",
                 obs_tech != nullptr ? advance_name_translation(obs_tech)
                                     : Q_("?tech:None"));
-        fprintf(doc, "<td>%s</td>\n</tr>\n\n", buf);
+        fprintf(doc, "<td>%s</td>\n</tr>\n\n",
+                qUtf8Printable(markdown_to_html(buf)));
       }
       improvement_iterate_end;
       fprintf(doc, "</table>");
@@ -499,7 +515,7 @@ static bool manual_command(struct tag_types *tag_info)
                 tag_info->sect_title_end);
         fprintf(doc, tag_info->subitem_begin, "helptext");
         helptext_government(buf, sizeof(buf), nullptr, nullptr, &pgov);
-        fprintf(doc, "%s\n\n", buf);
+        fprintf(doc, "%s\n\n", qUtf8Printable(markdown_to_html(buf)));
         fprintf(doc, "%s", tag_info->subitem_end);
         fprintf(doc, "%s", tag_info->item_end);
       };
@@ -557,7 +573,7 @@ static bool manual_command(struct tag_types *tag_info)
         fprintf(doc, "%s", tag_info->subitem_end);
         fprintf(doc, tag_info->subitem_begin, "helptext");
         helptext_unit(buf, sizeof(buf), nullptr, "", putype, nullptr);
-        fprintf(doc, "%s", buf);
+        fprintf(doc, "%s", qUtf8Printable(markdown_to_html(buf)));
         fprintf(doc, "%s", tag_info->subitem_end);
         fprintf(doc, "%s", tag_info->item_end);
       }
@@ -582,7 +598,7 @@ static bool manual_command(struct tag_types *tag_info)
           fprintf(doc, tag_info->subitem_begin, "helptext");
           helptext_advance(buf, sizeof(buf), nullptr, "", ptech->item_number,
                            nullptr);
-          fprintf(doc, "%s", buf);
+          fprintf(doc, "%s", qUtf8Printable(markdown_to_html(buf)));
           fprintf(doc, "%s", tag_info->subitem_end);
 
           fprintf(doc, "%s", tag_info->item_end);

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -17,7 +17,7 @@
 
 // Qt
 #include <QCommandLineParser>
-#include <QCoreApplication>
+#include <QGuiApplication>
 #include <QTextDocumentFragment>
 
 // utility
@@ -629,8 +629,8 @@ int main(int argc, char **argv)
   int retval = EXIT_SUCCESS;
   struct tag_types *tag_info = &html_tags;
 
-  QCoreApplication app(argc, argv);
-  QCoreApplication::setApplicationVersion(freeciv21_version());
+  QGuiApplication app(argc, argv);
+  QGuiApplication::setApplicationVersion(freeciv21_version());
 
   init_nls();
 

--- a/tools/civmanual.cpp
+++ b/tools/civmanual.cpp
@@ -116,40 +116,6 @@ struct tag_types html_tags = {
     // tail
     "</body></html>"};
 
-struct tag_types wiki_tags = {
-    // file extension
-    "mediawiki",
-
-    // header
-    " ",
-
-    // title begin
-    "=",
-
-    // title end
-    "=",
-
-    // section title begin
-    "===",
-
-    // section title end
-    "===",
-
-    // item begin
-    "----\n<!-- %s %d -->\n",
-
-    // item end
-    "\n",
-
-    // subitem begin
-    "<!-- %s -->\n",
-
-    // subitem end
-    "\n",
-
-    // tail
-    " "};
-
 static QString ruleset;
 
 /**
@@ -672,7 +638,6 @@ int main(int argc, char **argv)
        _("Make manual for RULESET."),
        // TRANS: Command-line argument
        _("RULESET")},
-      {{"w", "wiki"}, _("Write manual in wiki format.")},
   });
   if (!ok) {
     qFatal("Adding command line arguments failed.");
@@ -697,9 +662,6 @@ int main(int argc, char **argv)
   }
   if (parser.isSet(QStringLiteral("log"))) {
     srvarg.log_filename = parser.value(QStringLiteral("log"));
-  }
-  if (parser.isSet(QStringLiteral("wiki"))) {
-    tag_info = &wiki_tags;
   }
 
   init_our_capability();


### PR DESCRIPTION
This is a work in progress to render help texts in the help browser as markdown. Code generating help texts has been changed accordingly (this mainly concerns the generation of tables).

Although the help renders correctly for the most part, the contents of `data/helpdata.txt` needs to be reviewed and adapted to markdown. This is not in scope for this PR though and will be handled in seperate issues/PRs.

Closes #4 