### PR TITLE
vcpkg updates for kf6archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@
 #   server and other components
 cmake_minimum_required(VERSION 3.21...3.22 FATAL_ERROR)
 
+# Suppress policy warnings due to normalized install directories
+if(POLICY CMP0177)
+  cmake_policy(SET CMP0177 OLD)
+endif()
+
 # Set vcpkg if exists. Used by MacOS and Visual Studio
 if(DEFINED ENV{VCPKG_ROOT} AND FREECIV_USE_VCPKG)
   message(STATUS "Microsoft VCPKG enabled, setting toolset specific settings.")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "freeciv21",
-  "version-string": "3.0.0",
-  "builtin-baseline": "23ceb9cbf9b6d32f485cf039547b70102a6ef9d8",
+  "version-string": "3.2.0",  
   "dependencies": [
     "qtbase",
     "qtmultimedia",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "freeciv21",
-  "version-string": "3.2.0",  
+  "version-string": "3.2.0",
+  "builtin-baseline": "e9bb3f9e7ae3bf82a861a818e8a0f1187db399c0",
   "dependencies": [
     "qtbase",
     "qtmultimedia",


### PR DESCRIPTION
Part of #2612

We need to have MSFT approve my [PR](https://github.com/microsoft/vcpkg/pull/46399) for this to fully work. Once that happens, then we can enable the CI for Windows Visual Studio and macOS.

The main piece of this PR is to remove the baseline commit id. We can update to a new baseline when kf6archive is stable in vcpkg.