### PR TITLE
Prevent a crash on Windows

### DIFF
--- a/client/views/view_map_common.cpp
+++ b/client/views/view_map_common.cpp
@@ -90,12 +90,17 @@ Q_GLOBAL_STATIC(QElapsedTimer, anim_timer);
 
 void anim_delay(int milliseconds)
 {
+#ifdef QT_OS_WIN
+  // Workaround for #2567
+  QThread::msleep(milliseconds);
+#else
   QEventLoop loop;
   QTimer t;
   t.connect(&t, &QTimer::timeout, &loop, &QEventLoop::quit);
   t.start(milliseconds);
   QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
   loop.exec();
+#endif
 }
 
 /**


### PR DESCRIPTION
The game was crashing on Windows when attacking units on a local server. This was caused by network input being processed in the middle of the animation and units being deleted. This was caused by anim_delay() processing events. Strangely enough, this doesn't happen with TCP sockets.

This patch reintroduces a blocking sleep in anim_delay() on Windows. It blocks the window and might lead to it being unresponsive, but this is better than an almost guaranteed crash.

A proper fix would include a better framework for animations, which cannot be done in time for 3.1.

**Note that this patch is for the `stable` branch only.** I do not consider it an appropriate fix for master.