### PR TITLE
Enable visual studio CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,26 +194,32 @@ jobs:
           name: Windows-exe
           path: build/Windows-x86_64/Freeciv21-*.exe
 
-#  windows_clang_msvc:
-#    name: "Windows Clang"
-#    runs-on: windows-latest
-#    needs: clang-format
-#    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-#    env:
-#      VCPKG_ROOT: ${{github.workspace}}/vcpkg
-#      VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg/bincache
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#      - uses: lukka/run-vcpkg@v11
-#        name: Install dependencies
-#        with:
-#          vcpkgGitCommitId: b322364f06308bdd24823f9d8f03fe0cc86fd46f
-#      - name: Configure
-#        run: cmake -S . -B build --preset "windows-debug"
-#      - name: Building
-#        run: cmake --build build --config Debug
+  windows_clang_msvc:
+    name: "Windows Clang"
+    runs-on: windows-latest
+    needs: clang-format
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    env:
+      VCPKG_ROOT: ${{github.workspace}}/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg/bincache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Dependencies
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: dd3097e305afa53f7b4312371f62058d2e665320
+      - name: Configure
+        run: |
+          cmake -S . --preset "windows-debug"
+      - name: Build
+        run: |
+          cmake --build build-vs --config Debug
+      - name: Test Install
+        run: |
+          cmake --build build-vs --target install
       #- name: Test
       #  run: cmake --build build --target test
 
@@ -247,7 +253,7 @@ jobs:
 #      - uses: lukka/run-vcpkg@v11
 #        name: Install dependencies
 #        with:
-#          vcpkgGitCommitId: b322364f06308bdd24823f9d8f03fe0cc86fd46f
+#          vcpkgGitCommitId: dd3097e305afa53f7b4312371f62058d2e665320
 #      - name: Build
 #        uses: lukka/run-cmake@v10
 #        with:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "freeciv21",
   "version-string": "3.2.0",
-  "builtin-baseline": "e9bb3f9e7ae3bf82a861a818e8a0f1187db399c0",
   "dependencies": [
+    "qtbase",
     "qtmultimedia",
     "qtsvg",
     "openssl",
@@ -17,12 +17,6 @@
     {
       "name": "readline",
       "platform": "windows"
-    }
-  ],
-  "overrides": [
-    {
-      "name": "qtbase",
-      "version-string": "6.8.3"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,6 @@
   "version-string": "3.2.0",
   "builtin-baseline": "e9bb3f9e7ae3bf82a861a818e8a0f1187db399c0",
   "dependencies": [
-    "qtbase",
     "qtmultimedia",
     "qtsvg",
     "openssl",
@@ -18,6 +17,12 @@
     {
       "name": "readline",
       "platform": "windows"
+    }
+  ],
+  "overrides": [
+    {
+      "name": "qtbase",
+      "version-string": "6.8.3"
     }
   ]
 }


### PR DESCRIPTION
Now that `kf6archve` is in vcpkg, enable the visual studio build CI. The macOS build CI will come with another PR as I work through some updates on my macOS VM.

No related issue.