### PR TITLE
Add support for loading civ2 saves

### DIFF
--- a/docs/Manuals/Advanced/civ2.rst
+++ b/docs/Manuals/Advanced/civ2.rst
@@ -59,6 +59,13 @@ While the format of the above files is well documented and could easily be
 parsed, doing so will require some rethinking of the way Freeciv21 handles game
 rules (in particular regarding saves).
 
+Another important issue is that Freeciv21 does not load scenario sprites.
+The map may look strange as a result.
+For now, we suggest creating a modified version of the ``isotrident`` tileset
+for each scenario.
+``Isotrident`` has the same geometry as the original civ2 sprites and terrain
+sprites follow a similar layout.
+
 Other known limitations include:
 
 * The game rules in civ2 depend on the difficulty level, in particular regarding

--- a/docs/Manuals/Advanced/civ2.rst
+++ b/docs/Manuals/Advanced/civ2.rst
@@ -1,0 +1,26 @@
+.. SPDX-License-Identifier: GPL-3.0-or-later
+.. SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+.. include:: /global-include.rst
+
+Loading Civilization 2 Files
+****************************
+
+Freeciv21 has **limited** and **experimental** support for loading scenario
+files designed for the PC game Civilization 2 (hereafter civ2).
+This works by reading information from the binary file format used to save
+games and scenarios.
+The format is not fully understood and only a limited subset the saves can be
+loaded.
+This is currently not sufficient to play the loaded scenarios, but enables using
+them as a base for creating Freeciv21 games.
+
+Civilization 2 scenarios and saves come with one of two extensions: ``.sav`` or
+``.scn``.
+The underlying format is identical and Freeciv21 can load both.
+This is done with the usual :ref:`load command <server-command-load>` or by
+selecting the file :ref:`from the user interface <game-manual-load>`.
+
+Currently, Freeciv21 can only load files produced by the Multiplayer Gold
+Edition (MGE) of civ2.
+Trying to load a file produced by any other version will result in an error.

--- a/docs/Manuals/Advanced/civ2.rst
+++ b/docs/Manuals/Advanced/civ2.rst
@@ -15,6 +15,12 @@ loaded.
 This is currently not sufficient to play the loaded scenarios, but enables using
 them as a base for creating Freeciv21 games.
 
+.. warning::
+  Experimental support means that the game may misbehave (or outright crash)
+  when encountering an unexpected feature.
+  When reporting such cases, please always include the file you were trying to
+  load.
+
 Civilization 2 scenarios and saves come with one of two extensions: ``.sav`` or
 ``.scn``.
 The underlying format is identical and Freeciv21 can load both.
@@ -24,3 +30,56 @@ selecting the file :ref:`from the user interface <game-manual-load>`.
 Currently, Freeciv21 can only load files produced by the Multiplayer Gold
 Edition (MGE) of civ2.
 Trying to load a file produced by any other version will result in an error.
+Freeciv21 also cannot parse civ2 map files (``.mp``).
+
+Supported Features
+------------------
+
+Currently, Freeciv21 mainly loads ruleset-independent features:
+
+* The username, color, and gender of all alive players.
+* AI status. AI level is assigned based on the civ2 difficulty level.
+* Treasury and tax rates.
+* Diplomatic relations between players (except for the *None* diplomatic status,
+  which is translated to *War*, and *Vendetta* which is ignored).
+* Embassies.
+* The map: terrain, rivers, improvements and player knowledge thereof.
+* Cities and citizen assignment on the map.
+
+Known Limitations
+-----------------
+
+The main limitation is that Freeciv21 cannot understand changes to the civ2
+rules.
+The games are loaded with an unmodified ``civ2`` ruleset.
+Information from ``RULES.TXT`` and ``EVENTS.TXT`` is disregarded.
+This means that terrains may have the wrong yields and also prevents a
+meaningful loading of nations, units, buildings, techs, or specialists.
+While the format of the above files is well documented and could easily be
+parsed, doing so will require some rethinking of the way Freeciv21 handles game
+rules (in particular regarding saves).
+
+Other known limitations include:
+
+* The game rules in civ2 depend on the difficulty level, in particular regarding
+  unhappiness. Freeciv21 always targets the deity (hardest) setting.
+* If the map has an odd number of rows, the last row is skipped. This is
+  required because Freeciv21 only supports an even number of rows.
+* Tile special resources are generated again the Freeciv21 way. The information
+  stored by civ2 is not sufficient to restore them faithfully. Freeciv21 ignores
+  the "no resources" flag.
+* Base ownership is not assigned.
+* Map wrapping is not restored.
+* Trade routes are missing. Commodities are not supported by Freeciv21's
+  ``civ2`` ruleset.
+* Cities' food, shields, improvements, and original owners are not restored.
+* Freeciv21 supports more than 255 cities. This may affect scenarios that rely
+  on this limit to prevent the creating of new cities.
+* The name of the Barbarian nation appears incorrectly. It is not stored in the
+  save.
+* All players start in Despotism.
+* Some cities may generate warnings. This is caused by civ2 saving what appears
+  to be inconsistent data about citizen assignment to tiles around the cities,
+  and is harmless (but you may want to check the cities).
+* Many game settings that could be mapped to Freeciv21 server settings are not.
+  Example of this are victory settings and the Barbarian activity modifier.

--- a/docs/Manuals/Advanced/index.rst
+++ b/docs/Manuals/Advanced/index.rst
@@ -14,4 +14,5 @@ looking for more general  or generic gameplay information, it would be best to s
   players.rst
   fc21-uri.rst
   map-generator
+  civ2
   :maxdepth: 2

--- a/docs/Manuals/Game/start-screen.rst
+++ b/docs/Manuals/Game/start-screen.rst
@@ -278,6 +278,7 @@ join the server. Pretty much all Longturn online multiplayer games are connected
   may be prompted to confirm the password a second time in the :guilabel:`Confirm Password` box before being
   allowed to connect.
 
+.. _game-manual-load:
 
 Load Saved Game
 ===============

--- a/docs/Manuals/Server/commands.rst
+++ b/docs/Manuals/Server/commands.rst
@@ -407,6 +407,8 @@ server's own command-line. This server command-line is separate from the OS term
   with the command-line argument: ``--file <filename>`` or ``-f <filename>`` and use the ``/start`` command
   once players have reconnected.
 
+.. _server-command-load:
+
 ``/load <file-name>``
   Load a game from ``<file-name>``. Any current data including players, rulesets and server options are lost.
 

--- a/server/savegame/CMakeLists.txt
+++ b/server/savegame/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(savegame INTERFACE)
 target_sources(
   savegame
   INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/civ2.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/savecompat.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/savegame2.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/savegame3.cpp

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -243,7 +243,7 @@ bool read_player(QDataStream &bytes, tribe_info &ti)
   bytes.skipRawData(8);
   // NOTE: The format of tax and science is unclear in "Everything about Hex
   // Editing". What's below is a guess.
-  bytes >> ti.tax >> ti.science >> ti.govermnent;
+  bytes >> ti.science >> ti.tax >> ti.govermnent;
   bytes.skipRawData(14);
   bytes.readRawData(reinterpret_cast<char *>(ti.treaties.data()),
                     4 * (NUM_PLAYERS - 1));

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -5,6 +5,36 @@
 
 #include <QFile>
 #include <QString>
+#include <QtDebug>
+
+#include <cstdint>
+
+/**
+ * \file civ2.cpp Loads civ2 saves.
+ *
+ * Useful resources:
+ * * https://apolyton.net/forum/civilization-series/civilization-i-and-civilization-ii/130935-civilization-ii-sav-scn-file-format
+ * * http://civgaming.net/mercator/reference/mapstruct.html in the Wayback
+ *   machine
+ * * https://github.com/evyscr/civ2mp2fc/tree/master
+ */
+
+namespace /* anonymous */ {
+const static auto MAGIC = QByteArrayLiteral("CIVILIZE\0\x1A");
+
+/**
+ * Internal Civliization II version numbers.
+ */
+enum civ2_version {
+  CIV2_CLASSIC = 39,         ///< Classic, Conflicts in Civilization
+  CIV2_FANTASTIC = 40,       ///< Fantastic Worlds
+  CIV2_MULTIPLAYER = 44,     ///< Multiplayer v1.3
+  CIV2_TEST_OF_TIME_10 = 49, ///< Test of Time v1.0
+  CIV2_TEST_OF_TIME_11 = 50, ///< Test of Time v1.1
+};
+/// The highest supported version (from above)
+const static auto MAX_VERSION = CIV2_MULTIPLAYER;
+} // namespace
 
 /**
  * Checks if the file at path looks like a civ2 save.
@@ -16,8 +46,7 @@ bool is_civ2_save(const QString &path)
     return false;
   }
 
-  const auto magic = QByteArrayLiteral("CIVILIZE");
-  return input.read(magic.size()) == magic;
+  return input.read(MAGIC.size()) == MAGIC;
 }
 
 /**
@@ -25,6 +54,25 @@ bool is_civ2_save(const QString &path)
  */
 bool load_civ2_save(const QString &path)
 {
+  // Open the file
+  auto file = QFile(path);
+  file.open(QIODevice::ReadOnly);
+  QDataStream bytes(&file);
+  bytes.setByteOrder(QDataStream::LittleEndian);
+
+  // Header
+  bytes.skipRawData(MAGIC.size()); // CIVILIZE 0x00 0x1A
+
+  std::int16_t version;
+  bytes >> version;
+
+  qDebug() << "Loading civ2 file with version" << version;
+  if (version > MAX_VERSION) {
+    qCritical("Unsupported civ2 file version: %d",
+              static_cast<int>(version));
+    return false;
+  }
+
   // Unsupported!
   qCritical("Cannot read civ2 saves!");
   return false;

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -656,6 +656,10 @@ bool setup_players(const civ2::game &g, load_data &data)
 
     // Set some government. 0 is Anarchy so use 1.
     pplayer->government = government_by_number(1);
+    pplayer->economic.tax = 10 * g.tribe_infos[i].tax;
+    pplayer->economic.science = 10 * g.tribe_infos[i].science;
+    pplayer->economic.luxury =
+        100 - pplayer->economic.tax - pplayer->economic.science;
 
     // Add it to a team.
     team_add_player(pplayer, team_new(nullptr));

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -1070,6 +1070,9 @@ bool load_civ2_save(const QString &path)
     return false;
   }
 
+  // Get a random state.
+  init_game_seed();
+
   auto data = load_data();
   if (!setup_ruleset(g, data)) {
     return false;

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -379,9 +379,9 @@ struct unit {
 
   std::uint16_t x; ///< x coordinate of tile.
   std::uint16_t y; ///< y coordinate of tile.
-  std::uint16_t _padding1 : 6;
+  std::uint8_t _padding1 : 6;
   bool moved : 1; ///< Has the unit moved this turn?
-  std::uint16_t _padding1_1 : 6;
+  std::uint8_t _padding1_1 : 6;
   bool veteran : 1; ///< Whether the unit is veteran.
   bool _padding2 : 1;
   bool star : 1;           ///< Display a small star on top of the flag.
@@ -407,6 +407,9 @@ struct unit {
   std::uint32_t _unknown;  ///< Always 0?
 };
 // static_assert(sizeof(unit) == 26); // CiC
+static_assert(offsetof(unit, type) == 7);
+static_assert(offsetof(unit, home_city) == 17);
+static_assert(offsetof(unit, goto_x) == 18);
 static_assert(sizeof(unit) == 32); // MGE+
 
 /**

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -108,16 +108,16 @@ const static auto SUPPORTED_VERSION = CIV2_MULTIPLAYER;
  * The civ2 file header.
  */
 struct header {
-  std::int16_t version;    ///< Save format version number
-  std::int16_t turn;       ///< Current turn
-  std::int16_t year;       ///< Current year
-  std::uint8_t difficulty; ///< Difficulty (0 to 5).
-  std::uint8_t barbarians; ///< Barbarian activity.
+  std::int16_t version;       ///< Save format version number
+  std::int16_t turn;          ///< Current turn
+  std::int16_t year;          ///< Current year
+  std::uint8_t difficulty;    ///< Difficulty (0 to 5).
+  std::uint8_t barbarians;    ///< Barbarian activity.
   std::uint8_t players_alive; ///< Bitfield: who is alive?
   std::uint8_t players_human; ///< Bitfield: which players are humans?
-  int num_techs;           ///< Number of techs in the current version
-  std::int16_t unit_count; ///< Number of unit slots in the current game.
-  std::int16_t city_count; ///< Number of city slots in the current game.
+  int num_techs;              ///< Number of techs in the current version
+  std::int16_t unit_count;    ///< Number of unit slots in the current game.
+  std::int16_t city_count;    ///< Number of city slots in the current game.
   /// First nation that discovered each tech
   std::array<char, NUM_TECHS> first_to_discover;
   /// Which nations have discoved which techs (bitfield)
@@ -444,10 +444,10 @@ struct city {
   std::byte _padding1[10];
   /// Specialists in the city.
   std::array<std::uint8_t, 4> specialists;
-  std::int16_t foodbox;             ///< Food in food box (0xff = famine)
-  std::int16_t shieldbox;           ///< Number of shields in shields box.
-  std::int16_t base_trade;          ///< Trade without trade routes.
-  std::array<char, 16> name;        ///< City name.
+  std::int16_t foodbox;                ///< Food in food box (0xff = famine)
+  std::int16_t shieldbox;              ///< Number of shields in shields box.
+  std::int16_t base_trade;             ///< Trade without trade routes.
+  std::array<char, 16> name;           ///< City name.
   std::array<std::uint8_t, 3> workers; ///< Citizen placement.
   std::uint8_t _padding2 : 2;
   std::uint8_t specialists_count : 6;    ///< Number of specialists.
@@ -464,8 +464,8 @@ struct city {
   std::int8_t total_food;   ///< Total food production.
   std::int8_t total_shield; ///< Total shield production.
   std::byte _padding3[6];
-  std::uint8_t happy;       ///< Happy citizens.
-  std::uint8_t unhappy;     ///< Unhappy citizens, angry count double.
+  std::uint8_t happy;   ///< Happy citizens.
+  std::uint8_t unhappy; ///< Unhappy citizens, angry count double.
 };
 static_assert(offsetof(city, name) == 32);
 static_assert(sizeof(city) == 88);
@@ -500,8 +500,7 @@ std::vector<city> read_cities(QDataStream &bytes, int count)
 /**
  * Groups all the data present in a civ2 save.
  */
-struct game
-{
+struct game {
   /// Game header data.
   header head;
   /// Which nation is connected to which player slot (including barbarians).
@@ -665,8 +664,8 @@ bool setup_players(const civ2::game &g, load_data &data)
 
     // Pick a random nation.
     // TODO use info from the save.
-    player_set_nation(
-        pplayer, pick_a_nation(nullptr, false, true, NOT_A_BARBARIAN));
+    player_set_nation(pplayer,
+                      pick_a_nation(nullptr, false, true, NOT_A_BARBARIAN));
     ai_traits_init(pplayer);
     pplayer->style = style_of_nation(pplayer->nation);
 
@@ -756,17 +755,16 @@ bool setup_diplomacy(const civ2::game &g, load_data &data)
 /**
  * Converts civ2-style bit fields to Freeciv21 extras.
  */
-struct extra_data
-{
+struct extra_data {
   // Freeciv21 extra IDs
-  int irrigation = -1, farmland = -1, mine = -1,
-      river = -1, road = -1, rails = -1, fort = -1,
-      airbase = -1, pollution = -1;
+  int irrigation = -1, farmland = -1, mine = -1, river = -1, road = -1,
+      rails = -1, fort = -1, airbase = -1, pollution = -1;
 
   /**
    * Detect extra numbers from the ruleset. This is based on heuristics.
    */
-  extra_data() {
+  extra_data()
+  {
     extra_type_iterate(pextra)
     {
       if (is_extra_caused_by(pextra, EC_IRRIGATION)) {

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -655,6 +655,8 @@ bool setup_players(const civ2::game &g, load_data &data)
     pplayer->ranked_username[0] = '\0';
     player_delegation_set(pplayer, nullptr);
 
+    pplayer->is_male = g.tribe_infos[i].gender == 0;
+
     // Index 0 is for barbarians.
     if (i == 0) {
       pplayer->ai_common.barbarian_type = LAND_AND_SEA_BARBARIAN;

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -17,10 +17,25 @@
  * * http://civgaming.net/mercator/reference/mapstruct.html in the Wayback
  *   machine
  * * https://github.com/evyscr/civ2mp2fc/tree/master
+ * * https://ia800304.us.archive.org/11/items/civ2-hex-editing/Hex%20Editing.pdf
  */
 
 namespace /* anonymous */ {
+/// Magic string found at the beginning of a save.
 const static auto MAGIC = QByteArrayLiteral("CIVILIZE\0\x1A");
+
+/// Number of techs for Conflicts in Civliization
+const static auto NUM_TECHS_CIC = 93;
+/// Number of techs for most versions
+const static auto NUM_TECHS = 100;
+/// Number of Great Wonder slots
+const static auto NUM_WONDERS = 56;
+/// Number of civilizations (including barbarians)
+const static auto NUM_CIVS = 8;
+/// Constant for wonders that haven't been built.
+const static auto WONDER_NOT_BUILT = -1;
+/// Constant for wonders that have been destroyed.
+const static auto WONDER_DESTROYED = -2;
 
 /**
  * Internal Civliization II version numbers.
@@ -34,7 +49,23 @@ enum civ2_version {
 };
 /// The highest supported version (from above)
 const static auto MAX_VERSION = CIV2_MULTIPLAYER;
-} // namespace
+
+/**
+ * The civ2 file header.
+ */
+struct header {
+  std::int16_t version; ///< Save format version number
+  std::int16_t turn;    ///< Current turn
+  std::int16_t year;    ///< Current year
+  int num_techs;        ///< Number of techs in the current version
+  /// First nation that discovered each tech
+  std::array<char, NUM_TECHS> first_to_discover;
+  /// Which nations have discoved which techs (bitfield)
+  std::array<char, NUM_TECHS> discovered_by;
+  /// City ID for Great Wonders
+  std::array<std::int16_t, NUM_WONDERS> wonder_locations;
+};
+} // anonymous namespace
 
 /**
  * Checks if the file at path looks like a civ2 save.
@@ -61,16 +92,31 @@ bool load_civ2_save(const QString &path)
   bytes.setByteOrder(QDataStream::LittleEndian);
 
   // Header
+  auto head = header();
+
   bytes.skipRawData(MAGIC.size()); // CIVILIZE 0x00 0x1A
+  bytes >> head.version;
 
-  std::int16_t version;
-  bytes >> version;
-
-  qDebug() << "Loading civ2 file with version" << version;
-  if (version > MAX_VERSION) {
+  qDebug() << "Loading civ2 file with version" << head.version;
+  if (head.version > MAX_VERSION) {
     qCritical("Unsupported civ2 file version: %d",
-              static_cast<int>(version));
+              static_cast<int>(head.version));
     return false;
+  }
+
+  if (head.version >= CIV2_TEST_OF_TIME_10) {
+    bytes.skipRawData(640); // Unknown use
+  }
+  bytes.skipRawData(16); // Menu settings
+
+  bytes >> head.turn >> head.year;
+  bytes.skipRawData(34); // More game settings, unknown use
+
+  head.num_techs = head.version > CIV2_CLASSIC ? NUM_TECHS :NUM_TECHS_CIC;
+  bytes.readRawData(head.first_to_discover.data(), head.num_techs);
+  bytes.readRawData(head.discovered_by.data(), head.num_techs);
+  for (auto& location: head.wonder_locations) {
+    bytes >> location;
   }
 
   // Unsupported!

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -555,6 +555,14 @@ bool setup_players(const civ2::game &g)
     pplayer->ranked_username[0] = '\0';
     player_delegation_set(pplayer, nullptr);
 
+    // Pick a random nation.
+    // TODO use info from the save.
+    player_set_nation(
+        pplayer, pick_a_nation(nullptr, false, true, NOT_A_BARBARIAN));
+
+    // Set some government. 0 is Anarchy so use 1.
+    pplayer->government = government_by_number(1);
+
     // Add it to a team.
     team_add_player(pplayer, team_new(nullptr));
 

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#include "civ2.h"
+
+#include <QFile>
+#include <QString>
+
+/**
+ * Checks if the file at path looks like a civ2 save.
+ */
+bool is_civ2_save(const QString &path)
+{
+  QFile input(path);
+  if (!input.open(QIODevice::ReadOnly)) {
+    return false;
+  }
+
+  const auto magic = QByteArrayLiteral("CIVILIZE");
+  return input.read(magic.size()) == magic;
+}
+
+/**
+ * Loads a civ2 save.
+ */
+bool load_civ2_save(const QString &path)
+{
+  // Unsupported!
+  qCritical("Cannot read civ2 saves!");
+  return false;
+}

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -656,6 +656,7 @@ bool setup_players(const civ2::game &g, load_data &data)
 
     // Set some government. 0 is Anarchy so use 1.
     pplayer->government = government_by_number(1);
+    pplayer->economic.gold = g.tribe_infos[i].money;
     pplayer->economic.tax = 10 * g.tribe_infos[i].tax;
     pplayer->economic.science = 10 * g.tribe_infos[i].science;
     pplayer->economic.luxury =

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -725,7 +725,8 @@ bool setup_map(const civ2::game &g, load_data &data)
         // TODO: Second condition is a Freeciv21 limitation.
         BV_SET(ptile->extras, mine_index);
       }
-      if ((civ2tile.improvements & civ2::ROAD) == civ2::ROAD) {
+      if ((civ2tile.improvements & civ2::ROAD) == civ2::ROAD
+          || (civ2tile.improvements & civ2::CITY) == civ2::CITY) {
         BV_SET(ptile->extras, road_index);
       }
       if ((civ2tile.improvements & civ2::RAILROAD) == civ2::RAILROAD) {

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -544,9 +544,7 @@ bool setup_players(const civ2::game &g, load_data &data)
                          : AI_LEVEL_CHEATING;
 
   int slot = 0; // Freeciv21 player slot.
-  // Index 0 is for barbarians.
-  // TODO Set up barbarians if needed.
-  for (int i = 1; i < g.tribes.size(); ++i) {
+  for (int i = 0; i < g.tribes.size(); ++i) {
     if (!(g.head.players_alive & (1 << i))) {
       // Don't create dead players. They most often don't play any role in
       // scenarios.
@@ -573,6 +571,12 @@ bool setup_players(const civ2::game &g, load_data &data)
     pplayer->server.orig_username[0] = '\0';
     pplayer->ranked_username[0] = '\0';
     player_delegation_set(pplayer, nullptr);
+
+    // Index 0 is for barbarians.
+    if (i == 0) {
+      pplayer->ai_common.barbarian_type = LAND_AND_SEA_BARBARIAN;
+      server.nbarbarians = 1;
+    }
 
     // Pick a random nation.
     // TODO use info from the save.

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -938,7 +938,7 @@ bool setup_map(const civ2::game &g, load_data &data)
         plrt->terrain = ptile->terrain; // Always visible in civ2.
 
         if (civ2tile.river) {
-          BV_SET(ptile->extras, extras.river); // Always visible in civ2.
+          BV_SET(plrt->extras, extras.river); // Always visible in civ2.
         }
 
         auto impr = g.map.visible_improvements[i][x + y * g.map.width];

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -463,9 +463,9 @@ struct city {
   std::int16_t trade;       ///< Total trade incl. trade routes.
   std::int8_t total_food;   ///< Total food production.
   std::int8_t total_shield; ///< Total shield production.
-  std::int8_t happy;        ///< Happy citizens.
-  std::int8_t unhappy;      ///< Unhappy citizens, angry count double.
   std::byte _padding3[6];
+  std::uint8_t happy;       ///< Happy citizens.
+  std::uint8_t unhappy;     ///< Unhappy citizens, angry count double.
 };
 static_assert(offsetof(city, name) == 32);
 static_assert(sizeof(city) == 88);

--- a/server/savegame/civ2.h
+++ b/server/savegame/civ2.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#pragma once
+
+class QString;
+
+bool is_civ2_save(const QString &path);
+bool load_civ2_save(const QString &path);

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -71,6 +71,7 @@
 #include "voting.h"
 
 /* server/savegame */
+#include "civ2.h"
 #include "savemain.h"
 
 /* server/scripting */
@@ -3859,12 +3860,14 @@ bool load_command(struct connection *caller, const char *filename,
 
     if (!found) {
       for (const auto &path : paths) {
-        const auto exts = {
-            QStringLiteral("sav"),     QStringLiteral("gz"),
-            QStringLiteral("bz2"),     QStringLiteral("xz"),
-            QStringLiteral("zst"),     QStringLiteral("sav.gz"),
-            QStringLiteral("sav.bz2"), QStringLiteral("sav.xz"),
-            QStringLiteral("sav.zst")};
+        const auto exts = {QStringLiteral("sav"), QStringLiteral("gz"),
+                           QStringLiteral("bz2"), QStringLiteral("xz"),
+                           QStringLiteral("zst"), QStringLiteral("sav.gz"),
+                           QStringLiteral("sav.bz2"),
+                           QStringLiteral("sav.xz"),
+                           QStringLiteral("sav.zst"),
+                           // .scn = civ2 scenarios
+                           QStringLiteral("scn")};
         for (const auto &ext : exts) {
           QString name = filename + QStringLiteral(".") + ext;
           auto file = fileinfoname(path, qUtf8Printable(name));


### PR DESCRIPTION
The goal of this PR is to support minimal loading of civ2 saves and scenario files (`.sav`/`.scn`). The format of map files (`.mp`) is also known, but is different enough that a separate code path would be needed. Saves are loaded with the usual `/load` command.

Current status:
* Most game structures are defined and can be read from civ2's binary save format
* Only MGE saves are supported (other civ2 versions have minor layout variations)
* Terrains, tile improvements, and cities are converted to fc21 data structures
* Vision and diplomatic states should be imported properly
* The game doesn't crash immediately

This is what a loaded game might look like with minimal tileset conversion:

<img width="1294" height="664" alt="image" src="https://github.com/user-attachments/assets/f6cb6386-fe07-4e89-87ed-597fee7be245" />

civ2 modders frequently reassigned terrains so things will look strange with default tilesets.

What's missing:
* Reading civ data (~~gold~~, techs...)
* Reading events (ToT only)
* Reading modified rules. civ2 loads rule changes from the scenario directory (if available), we probably want to do the same.
* The bottom row of the map cannot be loaded if the vertical size of the map is odd (Freeciv21 insists that it must be even)
* Conversion to Freeciv21 structures is incomplete:
  * Research, taxes, etc are missing
  * Cities import is very basic, only the name and size are correct
  * Diplomatic states cannot be matched 1:1
  * Units are missing

I used the first scenario from [this page](https://civfanatics.com/civ2/downloads/scenarios/modern1/) as my test case. Other "MGE" or "Civ2 Gold" scenarios should also work. "FW" files cannot be loaded at this time.
Loads of civ2 mods are available in the [civ2 mod preservation project thread](https://forums.civfanatics.com/threads/civ2-mge-tot-scenario-mod-preservation-project-log-392-processed-9-super-collections.671035/).