### PR TITLE
Allow getting and setting primary tile resource in Lua

### DIFF
--- a/common/scriptcore/api_game_methods.cpp
+++ b/common/scriptcore/api_game_methods.cpp
@@ -868,6 +868,18 @@ bool api_methods_tile_has_road(lua_State *L, Tile *ptile, const char *name)
 }
 
 /**
+   Return the ruleset name of the primary resource on this tile, or nullptr.
+ */
+const char *api_methods_tile_get_resource(lua_State *L, Tile *ptile)
+{
+  LUASCRIPT_CHECK_STATE(L, nullptr);
+  LUASCRIPT_CHECK_SELF(L, ptile, nullptr);
+
+  extra_type *pextra = tile_resource(ptile);
+  return pextra ? extra_rule_name(pextra) : nullptr;
+}
+
+/**
    Is tile occupied by enemies
  */
 bool api_methods_enemy_tile(lua_State *L, Tile *ptile, Player *against)

--- a/common/scriptcore/api_game_methods.h
+++ b/common/scriptcore/api_game_methods.h
@@ -133,6 +133,7 @@ bool api_methods_tile_city_exists_within_max_city_map(lua_State *L,
 bool api_methods_tile_has_extra(lua_State *L, Tile *ptile, const char *name);
 bool api_methods_tile_has_base(lua_State *L, Tile *ptile, const char *name);
 bool api_methods_tile_has_road(lua_State *L, Tile *ptile, const char *name);
+const char *api_methods_tile_get_resource(lua_State *L, Tile *ptile);
 bool api_methods_enemy_tile(lua_State *L, Tile *ptile, Player *against);
 int api_methods_tile_num_units(lua_State *L, Tile *ptile);
 int api_methods_tile_sq_distance(lua_State *L, Tile *ptile1, Tile *ptile2);

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -307,6 +307,8 @@ module Tile {
     @ has_base(lua_State *L, Tile *self, const char *name);
   bool api_methods_tile_has_road
     @ has_road(lua_State *L, Tile *self, const char *name);
+  const char *api_methods_tile_get_resource
+    @ primary_resource_name(lua_State *L, Tile *self);
   bool api_methods_enemy_tile
     @ is_enemy(lua_State *L, Tile *self, Player *against);
   int api_methods_tile_num_units

--- a/server/scripting/api_server_edit.cpp
+++ b/server/scripting/api_server_edit.cpp
@@ -573,6 +573,28 @@ void api_edit_remove_extra(lua_State *L, Tile *ptile, const char *name)
 }
 
 /**
+   Changes the primary resource of the given tile. If name is set to nullptr,
+   the primary resource is removed.
+ */
+void api_edit_tile_primary_resource_set(lua_State *L, Tile *ptile,
+                                        const char *name)
+{
+  LUASCRIPT_CHECK_STATE(L);
+  LUASCRIPT_CHECK_ARG_NIL(L, ptile, 2, Tile);
+
+  struct extra_type *pextra = nullptr;
+  if (name != nullptr) {
+    pextra = extra_type_by_rule_name(name);
+    LUASCRIPT_CHECK_ARG(L, pextra, 3, "No such resource type");
+    LUASCRIPT_CHECK_ARG(L, pextra->data.resource, 3,
+                        "Not a resource type extra");
+  }
+
+  tile_set_resource(ptile, pextra);
+  update_tile_knowledge(ptile);
+}
+
+/**
    Set tile label text.
  */
 void api_edit_tile_set_label(lua_State *L, Tile *ptile, const char *label)

--- a/server/scripting/api_server_edit.h
+++ b/server/scripting/api_server_edit.h
@@ -64,6 +64,8 @@ void api_edit_create_base(lua_State *L, Tile *ptile, const char *name,
                           struct player *pplayer);
 void api_edit_create_road(lua_State *L, Tile *ptile, const char *name);
 void api_edit_remove_extra(lua_State *L, Tile *ptile, const char *name);
+void api_edit_tile_primary_resource_set(lua_State *L, Tile *ptile,
+                                        const char *name);
 
 void api_edit_tile_set_label(lua_State *L, Tile *ptile, const char *label);
 

--- a/server/scripting/tolua_server.pkg
+++ b/server/scripting/tolua_server.pkg
@@ -146,6 +146,8 @@ module edit {
     @ create_road (lua_State *L, Tile *ptile, const char *name);
   void api_edit_remove_extra
     @ remove_extra (lua_State *L, Tile *ptile, const char *name);
+  void api_edit_tile_primary_resource_set
+    @ tile_primary_resource_set(lua_State *L, Tile *ptile, const char *name);
   void api_edit_tile_set_label
     @ tile_set_label (lua_State *L, Tile *ptile, const char *label);
   Player *api_edit_create_player
@@ -424,6 +426,10 @@ end
 
 function Tile:change_terrain(terrain)
   edit.change_terrain(self, terrain)
+end
+
+function Tile:set_primary_resource(resource)
+  edit.tile_primary_resource_set(self, resource)
 end
 
 function Tile:unleash_barbarians()


### PR DESCRIPTION
Closes #2752

Can be tested by typing lua commands into the console: 
```
/lua cmd log.debug("%s", find.tile(0, 0):primary_resource_name())
/lua cmd find.tile(0, 0):set_primary_resource("Buffalo")
/lua cmd find.tile(0, 0):set_primary_resource(nil)
```