### PR TITLE
Fix a crash when switching players

### DIFF
--- a/client/unitselect.cpp
+++ b/client/unitselect.cpp
@@ -47,15 +47,6 @@ units_select::units_select(struct tile *ptile, QWidget *parent)
 }
 
 /**
-   Destructor for unit select
- */
-units_select::~units_select()
-{
-  m_widget->close();
-  delete m_widget;
-}
-
-/**
    Updates unit list on tile
  */
 void units_select::update_units() { m_widget->update_units(); }

--- a/client/unitselect.h
+++ b/client/unitselect.h
@@ -66,7 +66,6 @@ class units_select : public QMenu {
 
 public:
   units_select(struct tile *ptile, QWidget *parent = 0);
-  ~units_select() override;
   void update_units();
   void create_pixmap();
 


### PR DESCRIPTION
The game was crashing when switching players after opening the unit choice menu at least once.

Fix it by removing the destructor of units_select. Rely on Qt parent-child mechanics to delete the widget (this was already in place).