### PR TITLE
macOS: Create App Bundle at Install

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -264,23 +264,9 @@ jobs:
           BRANCH: ${{github.ref_name}}
         id: split
         run: echo "fragment=${BRANCH##*/}" >> $GITHUB_OUTPUT
-      - name: Create App Bundle
+      - name: Create DMG package
         run: |
           cd build
-          mkdir -pv Freeciv21.app/Contents/MacOS Freeciv21.app/Contents/Resources/doc Freeciv21.app/Contents/Resources/locale
-          cp -v dist/Info.plist Freeciv21.app/Contents
-          cp -rv install/share/doc/freeciv21/* Freeciv21.app/Contents/Resources/doc
-          cp -rv install/share/freeciv21/* Freeciv21.app/Contents/Resources
-          cp -rv install/share/locale/* Freeciv21.app/Contents/Resources/locale
-          cp -v install/bin/freeciv21-* Freeciv21.app/Contents/MacOS
-          mkdir client.iconset
-          cp -v ../data/icons/16x16/freeciv21-client.png client.iconset/icon_16x16.png
-          cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_16x16@2x.png
-          cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_32x32.png
-          cp -v ../data/icons/64x64/freeciv21-client.png client.iconset/icon_32x32@2x.png
-          cp -v ../data/icons/128x128/freeciv21-client.png client.iconset/icon_128x128.png
-          iconutil -c icns client.iconset
-          cp -v client.icns Freeciv21.app/Contents/Resources
           create-dmg \
             --hdiutil-verbose \
             --volname "Freeciv21 Game Installer" \

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -65,14 +65,14 @@ if(MSYS OR MINGW)
     set(CMAKE_GET_RUNTIME_DEPENDENCIES_TOOL objdump)
 
     # We need the CLANG_PATH variable that isn't available in a install(CODE ) block.
-	# So we find the llvm-objdump.exe and use its path to set
+    # So we find the llvm-objdump.exe and use its path to set
     string(REGEX REPLACE "llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
 
     # Function to analyze the third party dll files linked to the exe's
     # Uses the repurposed variable from above to tell the function where
     # the dll files are located. Ignores dll's that come with Windows.
     file(GLOB exes "${CMAKE_INSTALL_PREFIX}/freeciv21-*.exe")
-	  file(GET_RUNTIME_DEPENDENCIES
+    file(GET_RUNTIME_DEPENDENCIES
       RESOLVED_DEPENDENCIES_VAR r_deps
       UNRESOLVED_DEPENDENCIES_VAR u_deps
       DIRECTORIES ${CLANG_PATH}
@@ -92,11 +92,11 @@ if(MSYS OR MINGW)
     string(REGEX REPLACE "llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
 
     # Run Qt's windeployqt6.exe to find the required DLLs for the GUI apps.
-	# It also copies the files we need to where we need them.
+    # It also copies the files we need to where we need them.
     message(STATUS "Installing Qt library dependencies for freeciv21 GUI executables...")
     execute_process(
       COMMAND ${CLANG_PATH}/windeployqt6.exe --no-translations --verbose 0 --libdir ${CMAKE_INSTALL_PREFIX} 
-	  --plugindir ${CMAKE_INSTALL_PREFIX} --list mapping ${CMAKE_INSTALL_PREFIX}
+    --plugindir ${CMAKE_INSTALL_PREFIX} --list mapping ${CMAKE_INSTALL_PREFIX}
     )
     ]] COMPONENT freeciv21)
 
@@ -255,16 +255,6 @@ if(UNIX AND NOT APPLE)
   endif(FREECIV_ENABLE_RULEDIT)
 endif(UNIX AND NOT APPLE)
 
-if(APPLE)
-  # Use Auto Revision variables to convert some templates to real files at build
-  # time. Avoid overwriting if the version didn't change.
-  configure_file("dist/Info.plist.in" dist/Info.plist.new
-                @ONLY NEWLINE_STYLE UNIX)
-  file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist.new"
-                "${CMAKE_BINARY_DIR}/dist/Info.plist"
-      ONLY_IF_DIFFERENT)
-endif(APPLE)
-
 # We grab the Libertinus Font package online for the client
 if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
   message(STATUS "Downloading Libertinus Font Package")
@@ -291,7 +281,7 @@ if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
       FILES_MATCHING PATTERN *.otf PATTERN *.txt
     )
   else()
-      install(
+    install(
       DIRECTORY ${CMAKE_BINARY_DIR}/src/Libertinus
       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/freeciv21/fonts
       COMPONENT freeciv21
@@ -300,3 +290,66 @@ if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
   endif(MSYS OR WIN32)
 endif()
 
+if(APPLE)
+  # Use Auto Revision variables to convert some templates to real files at build
+  # time. Avoid overwriting if the version didn't change.
+  configure_file("dist/Info.plist.in" dist/Info.plist.new
+                @ONLY NEWLINE_STYLE UNIX)
+  file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist.new"
+                "${CMAKE_BINARY_DIR}/dist/Info.plist"
+      ONLY_IF_DIFFERENT)
+
+   install(CODE [[
+    message(STATUS "Creating Freeciv21 App Bundle for macOS...")
+    # Check to see if the app bundle was already created in a previous run
+    if(EXISTS "${CMAKE_BINARY_DIR}/Freeciv21.app")
+      message(STATUS "App Bundle exists, removing...")
+      file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/Freeciv21.app")
+      file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/client.iconset")
+      file(REMOVE "${CMAKE_BINARY_DIR}/client.icns")
+      file(GLOB DMG_FILES "${CMAKE_BINARY_DIR}/Freeciv21*.dmg*")
+      file(REMOVE ${DMG_FILES})
+    endif()
+    # Create app bundle
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/MacOS")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/doc")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/locale")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist"
+                   "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Info.plist")
+    file(COPY "${CMAKE_BINARY_DIR}/install/bin/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/MacOS/"
+      FILES_MATCHING PATTERN "Freeciv21-*"
+    )
+    file(COPY "${CMAKE_BINARY_DIR}/install/share/freeciv21/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/"
+      FILES_MATCHING PATTERN "*"
+    )
+    file(COPY "${CMAKE_BINARY_DIR}/install/share/doc/freeciv21/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/doc/"
+      FILES_MATCHING PATTERN "*"
+    )
+    file(COPY "${CMAKE_BINARY_DIR}/install/share/locale/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/locale/"
+      FILES_MATCHING PATTERN "*"
+    )
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/client.iconset")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/16x16/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16.png")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/32x32/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16@2x.png")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/32x32/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32.png")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/64x64/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32@2x.png")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/128x128/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_128x128.png")
+    execute_process(
+      COMMAND iconutil --convert icns "${CMAKE_BINARY_DIR}/client.iconset")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/client.icns"
+                   "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/client.icns")
+    message(STATUS "Freeciv21 App Bundle successfully created. Open from '${CMAKE_BINARY_DIR}' to play.")
+    ]] COMPONENT freeciv21)
+endif(APPLE)

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -336,15 +336,15 @@ if(APPLE)
       FILES_MATCHING PATTERN "*"
     )
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/client.iconset")
-    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/16x16/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/16x16/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16.png")
-    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/32x32/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/32x32/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16@2x.png")
-    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/32x32/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/32x32/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32.png")
-    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/64x64/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/64x64/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32@2x.png")
-    file(COPY_FILE "${CMAKE_BINARY_DIR}/../data/icons/128x128/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_128x128.png")
     execute_process(
       COMMAND iconutil --convert icns "${CMAKE_BINARY_DIR}/client.iconset")

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -301,6 +301,7 @@ if(APPLE)
 
    install(CODE [[
     message(STATUS "Creating Freeciv21 App Bundle for macOS...")
+
     # Check to see if the app bundle was already created in a previous run
     if(EXISTS "${CMAKE_BINARY_DIR}/Freeciv21.app")
       message(STATUS "App Bundle exists, removing...")
@@ -310,6 +311,7 @@ if(APPLE)
       file(GLOB DMG_FILES "${CMAKE_BINARY_DIR}/Freeciv21*.dmg*")
       file(REMOVE ${DMG_FILES})
     endif()
+
     # Create app bundle
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app")
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents")
@@ -319,32 +321,33 @@ if(APPLE)
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/locale")
     file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist"
                    "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Info.plist")
-    file(COPY "${CMAKE_BINARY_DIR}/install/bin/"
+    file(COPY "${CMAKE_INSTALL_PREFIX}/bin/"
       DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/MacOS/"
       FILES_MATCHING PATTERN "Freeciv21-*"
     )
-    file(COPY "${CMAKE_BINARY_DIR}/install/share/freeciv21/"
+    file(COPY "${CMAKE_INSTALL_PREFIX}/share/freeciv21/"
       DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/"
       FILES_MATCHING PATTERN "*"
     )
-    file(COPY "${CMAKE_BINARY_DIR}/install/share/doc/freeciv21/"
+    file(COPY "${CMAKE_INSTALL_PREFIX}/share/doc/freeciv21/"
       DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/doc/"
       FILES_MATCHING PATTERN "*"
     )
-    file(COPY "${CMAKE_BINARY_DIR}/install/share/locale/"
+    file(COPY "${CMAKE_INSTALL_PREFIX}/share/locale/"
       DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/locale/"
       FILES_MATCHING PATTERN "*"
     )
+
     file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/client.iconset")
-    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/16x16/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/16x16/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16.png")
-    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/32x32/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/32x32/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16@2x.png")
-    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/32x32/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/32x32/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32.png")
-    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/64x64/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/64x64/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32@2x.png")
-    file(COPY_FILE "${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-client.png"
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/128x128/freeciv21-client.png"
                    "${CMAKE_BINARY_DIR}/client.iconset/icon_128x128.png")
     execute_process(
       COMMAND iconutil --convert icns "${CMAKE_BINARY_DIR}/client.iconset")

--- a/docs/Contributing/macos.rst
+++ b/docs/Contributing/macos.rst
@@ -103,28 +103,8 @@ On macOS, you need to use a preset that is defined in the :file:`CMakePresets.js
   Freeciv21 directory and reused for subsequent builds.
 
 
-Create App Bundle and DMG Installer
-===================================
-
-Follow these steps to build an app bundle for Freeciv21:
-
-.. code-block:: sh
-
-  % cd build
-  % mkdir -pv Freeciv21.app/Contents/MacOS Freeciv21.app/Contents/Resources/doc
-  % cp -v dist/Info.plist Freeciv21.app/Contents/
-  % cp -rv install/share/doc/freeciv21/* Freeciv21.app/Contents/Resources/doc
-  % cp -rv install/share/freeciv21/* Freeciv21.app/Contents/Resources
-  % cp -v install/bin/freeciv21-* Freeciv21.app/Contents/MacOS
-  % mkdir client.iconset
-  % cp -v ../data/icons/16x16/freeciv21-client.png client.iconset/icon_16x16.png
-  % cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_16x16@2x.png
-  % cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_32x32.png
-  % cp -v ../data/icons/64x64/freeciv21-client.png client.iconset/icon_32x32@2x.png
-  % cp -v ../data/icons/128x128/freeciv21-client.png client.iconset/icon_128x128.png
-  % iconutil -c icns client.iconset
-  % cp -v client.icns Freeciv21.app/Contents/Resources
-
+Create DMG Installer
+====================
 
 Follow this steps to create the DMG:
 


### PR DESCRIPTION
No related issue. Adding more support for macOS to our build infrastructure. This PR creates a usable app bundle in the configured build directory. I also found some tab marks in the cmake file so removed those and replaced with spaces.