### PR TITLE
Bump CI to Ubuntu 25.10 (questing)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install clang
         if: ${{ matrix.compiler == 'clang' }}
         run: |
-          apt-get install -y clang
+          apt-get install -y clang libstdc++-15-dev
           export CC=$(which clang)
           export CXX=$(which clang++)
       - name: Install dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     needs: clang-format
     strategy:
       matrix:
-        os: [ubuntu:24.10]
+        os: [ubuntu:25.10]
         compiler: [gcc, clang]
         build_type: ["", Release, Debug, RelWithDebInfo]
         exclude:
@@ -98,7 +98,7 @@ jobs:
     needs: clang-format
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.10
+      image: ubuntu:25.10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions: {} # Security: run cmake from a fully unprivileged context
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.10
+      image: ubuntu:25.10
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -10,7 +10,7 @@ jobs:
   latest:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.10
+      image: ubuntu:25.10
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We were using 24.10, which has reached EOL and has been removed from the Azure mirror.