### PR TITLE
Update macOS build to 15 with intel support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,8 +218,8 @@ jobs:
       #  run: cmake --build build --target test
 
   os_x:
-    name: "macOS (arm64-osx)"
-    runs-on: macos-latest
+    name: "macOS (x64-osx)"
+    runs-on: macos-15-intel
     needs: clang-format
     env:
       VCPKG_BUILD_TYPE: release


### PR DESCRIPTION
No related issue. Got a notice from GitHub.

Request backport to stable.

> Notice of macOS x86_64 (Intel) architecture deprecation
Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027. You should begin migrating your workloads to arm64-based (Apple Silicon) runners as soon as possible to prepare for this eventual deprecation.