### PR TITLE
Fix exiting pregame when the server disconnects

### DIFF
--- a/client/fc_client.cpp
+++ b/client/fc_client.cpp
@@ -325,8 +325,8 @@ void fc_client::slot_disconnect()
 {
   if (client.conn.used) {
     disconnect_from_server();
-    switch_page(PAGE_MAIN);
   }
+  switch_page(PAGE_MAIN);
 }
 
 /**


### PR DESCRIPTION
The "Disconnect" button on the pregame page would stop working When the server was stopped, because its whole action was tied to having a running server. Make the switch to PAGE_MAIN unconditional.

Suggesting to backport.

## Test plan

* Start the client
* Start new game
* Type `/quit` in the chat
* Try to come back to the main page