### PR TITLE
Add button to reconnect when losing the connection

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -156,6 +156,7 @@ target_sources(
   views/view_research_reqtree.cpp
   views/view_units.cpp
 
+  widgets/conn_loss_widget.cpp
   widgets/decorations.cpp
   widgets/city/city_icon_widget.cpp
   widgets/city/governor_widget.cpp

--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -29,7 +29,6 @@
 
 // common
 #include "packets.h"
-#include "tile.h"
 
 // client
 #include "attribute.h"
@@ -41,7 +40,9 @@
 #include "governor.h"
 #include "options.h"
 #include "packhand.h"
+#include "page_game.h"
 #include "qtg_cxxside.h"
+#include "widgets/conn_loss_widget.h"
 
 // In autoconnect mode, try to connect to once a second
 #define AUTOCONNECT_INTERVAL 500
@@ -94,6 +95,9 @@ static void error_on_socket()
     log_debug("%s", qUtf8Printable(client.conn.sock->errorString()));
     output_window_append(ftc_client,
                          qUtf8Printable(client.conn.sock->errorString()));
+    if (queen()) {
+      queen()->conn_loss->show();
+    }
   }
   client.conn.used = false;
 }

--- a/client/page_game.cpp
+++ b/client/page_game.cpp
@@ -27,7 +27,6 @@
 #include "cityrep_g.h"
 #include "effects.h"
 #include "government.h"
-#include "repodlgs_g.h"
 
 // client
 #include "chatline.h"
@@ -43,13 +42,14 @@
 #include "minimap.h"
 #include "minimap_panel.h"
 #include "ratesdlg.h"
+#include "repodlgs_common.h"
 #include "text.h"
 #include "tileset/tilespec.h"
 #include "top_bar.h"
 #include "views/view_map.h"
 #include "views/view_map_common.h"
 #include "views/view_nations.h"
-#include "views/view_units.h"
+#include "widgets/conn_loss_widget.h"
 
 #include "voteinfo_bar.h"
 
@@ -77,6 +77,9 @@ pageGame::pageGame(QWidget *parent)
   mapview_wdg = new map_view();
   mapview_wdg->setFocusPolicy(Qt::WheelFocus);
   top_bar_wdg = new top_bar();
+  conn_loss = new freeciv::conn_loss_widget;
+  conn_loss->hide();
+
   sw_map = new top_bar_widget(Q_("?noun:View"), QStringLiteral("MAP"),
                               top_bar_show_map);
 
@@ -225,6 +228,8 @@ pageGame::pageGame(QWidget *parent)
   auto page_game_layout = new QVBoxLayout;
   page_game_layout->addWidget(top_bar_wdg);
   page_game_layout->setStretchFactor(top_bar_wdg, 0);
+  page_game_layout->addWidget(conn_loss);
+  page_game_layout->setStretchFactor(conn_loss, 0);
   page_game_layout->addWidget(game_tab_widget);
   page_game_layout->setStretchFactor(game_tab_widget, 1);
   page_game_layout->setContentsMargins(0, 0, 0, 0);

--- a/client/page_game.h
+++ b/client/page_game.h
@@ -35,6 +35,10 @@ class units_select;
 class xvote;
 class map_editor;
 
+namespace freeciv {
+class conn_loss_widget;
+} // namespace freeciv
+
 /****************************************************************************
   Widget holding all game tabs
 ****************************************************************************/
@@ -72,6 +76,7 @@ public:
   QWidget *game_main_widget;
   fc_game_tab_widget *game_tab_widget;
   top_bar *top_bar_wdg;
+  freeciv::conn_loss_widget *conn_loss;
   goto_dialog *gtd;
   units_select *unit_selector;
   hud_battle_log *battlelog_wdg;

--- a/client/widgets/conn_loss_widget.cpp
+++ b/client/widgets/conn_loss_widget.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#include "conn_loss_widget.h"
+
+// utility
+#include "fcintl.h"
+
+// common
+#include "featured_text.h"
+
+// client
+#include "chatline_common.h"
+#include "client_main.h"
+#include "clinet.h"
+
+namespace freeciv {
+
+/**
+ * Constructor.
+ */
+conn_loss_widget::conn_loss_widget(QWidget *parent) : QFrame(parent)
+{
+  ui.setupUi(this);
+  ui.label->setText(_("Connection to server lost"));
+  ui.action->setText(_("Reconnect"));
+
+  connect(ui.action, &QPushButton::pressed, [this] {
+    disconnect_from_server();
+
+    // client_url() already contains the password.
+    char errbuf[512];
+    if (connect_to_server(client_url(), errbuf, sizeof(errbuf)) >= 0) {
+      // Success!
+      setVisible(false);
+    } else {
+      output_window_append(ftc_client, errbuf);
+    }
+  });
+}
+
+} // namespace freeciv

--- a/client/widgets/conn_loss_widget.h
+++ b/client/widgets/conn_loss_widget.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPLv3-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#pragma once
+
+#include <QFrame>
+
+#include "widgets/ui_conn_loss_widget.h"
+
+namespace freeciv {
+
+class conn_loss_widget : public QFrame { // QFrame base for styling
+  Q_OBJECT
+
+public:
+  explicit conn_loss_widget(QWidget *parent = nullptr);
+  virtual ~conn_loss_widget() = default; ///< Destructor.
+
+private:
+  Ui::conn_loss_widget ui;
+};
+
+} // namespace freeciv

--- a/client/widgets/conn_loss_widget.ui
+++ b/client/widgets/conn_loss_widget.ui
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>conn_loss_widget</class>
+ <widget class="QWidget" name="conn_loss_widget">
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>300</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="action"/>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/data/themes/Classic/resource.qss
+++ b/data/themes/Classic/resource.qss
@@ -876,3 +876,7 @@ hud_unit_combat {
   selection-background-color: rgb(0, 0, 75);
   alternate-background-color: #ffecba;
 }
+
+freeciv--conn_loss_widget {
+  background-color: #ffaa00;
+}

--- a/data/themes/NightStalker/resource.qss
+++ b/data/themes/NightStalker/resource.qss
@@ -985,3 +985,7 @@ message_dlg QTableWidget {
   background-color: #525d6e;
   alternate-background-color: #4b5565;
 }
+
+freeciv--conn_loss_widget {
+  background-color: #4500ce;
+}


### PR DESCRIPTION
We keep getting reports of the server "stopping to work" when instead the connection was lost to the network timeout. Make this case more obvious by adding a large banner at the top of the client.

Also provide a button to reconnect automatically. It cannot ask for a password, so it will not work if the user's password has changed in the meantime. I do not consider this a critical issue.

Closes #2126.

### Test plan

I suggest compiling a server with the following changes to facilitate testing:
```diff
diff --git i/common/game.h w/common/game.h
index 6e8f2a3832..2e25837c35 100644
--- i/common/game.h
+++ w/common/game.h
@@ -595,12 +595,12 @@ extern struct world wld;
 #define GAME_MIN_NETWAIT 0
 #define GAME_MAX_NETWAIT 20
 
-#define GAME_DEFAULT_PINGTIME 20
+#define GAME_DEFAULT_PINGTIME 1
 #define GAME_MIN_PINGTIME 1
 #define GAME_MAX_PINGTIME 1800
 
-#define GAME_DEFAULT_PINGTIMEOUT 60
-#define GAME_MIN_PINGTIMEOUT 60
+#define GAME_DEFAULT_PINGTIMEOUT 5
+#define GAME_MIN_PINGTIMEOUT 5
 #define GAME_MAX_PINGTIMEOUT 1800
 
 #define GAME_DEFAULT_NOTRADESIZE 0
```

* Start a server
* Start a client with `-H` (else it won't timeout)
* Stop the client with Ctrl+Z in the terminal (or send SIGSTOP)
* Wait `pingtimeout` seconds (5 if you applied the patch from above, 60 otherwise)
* Release the client with `fg` (or send SIGCONT)
* A banner appears suggesting to reconnect
* Click "Reconnect"
* You are back in the game