### PR TITLE
Move more packet formatting code to dataio

### DIFF
--- a/client/attribute.cpp
+++ b/client/attribute.cpp
@@ -220,11 +220,8 @@ static enum attribute_serial unserialize_hash(attributeHash *hash,
       return A_SERIAL_FAIL;
     }
 
-    QByteArray pvalue(value_length, Qt::Initialization::Uninitialized);
-    dio_put<std::uint32_t>(pvalue, value_length);
-    if (!dio_get(din, pvalue.data() + 4, value_length)) {
-      qDebug("attribute.cpp unserialize_hash() "
-             "memory dio_input_too_short");
+    if (din.size() != value_length) {
+      qDebug("attribute.cpp unserialize_hash() inconsistent size");
       return A_SERIAL_FAIL;
     }
 
@@ -238,7 +235,7 @@ static enum attribute_serial unserialize_hash(attributeHash *hash,
       return A_SERIAL_FAIL;
     }
 
-    hash->insert(key, pvalue);
+    hash->insert(key, QByteArray(din));
   }
 
   if (!din.empty()) {

--- a/client/goto.cpp
+++ b/client/goto.cpp
@@ -575,8 +575,8 @@ static void send_path_orders(struct unit *punit, const PFPath &path,
   qCDebug(goto_category, "  Repeat: %d. Vigilant: %d.", p.repeat,
           p.vigilant);
 
-  make_path_orders(punit, path, orders, final_order, p.orders, &p.length,
-                   &p.dest_tile);
+  make_path_orders(punit, path, orders, final_order, p.orders.data(),
+                   &p.length, &p.dest_tile);
 
   request_unit_ssa_set(punit, SSA_NONE);
   send_packet_unit_orders(&client.conn, &p);
@@ -599,8 +599,8 @@ static void send_rally_path_orders(struct city *pcity, struct unit *punit,
   qCDebug(goto_category, "Rally orders for city %d:", pcity->id);
   qCDebug(goto_category, "  Vigilant: %d.", p.vigilant);
 
-  make_path_orders(punit, path, orders, final_order, p.orders, &p.length,
-                   nullptr);
+  make_path_orders(punit, path, orders, final_order, p.orders.data(),
+                   &p.length, nullptr);
 
   send_packet_city_rally_point(&client.conn, &p);
 }

--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -267,7 +267,7 @@ static struct unit *unpackage_unit(const struct packet_unit_info *packet)
     }
 
     punit->orders.list = new unit_order[punit->orders.length]();
-    memcpy(punit->orders.list, packet->orders,
+    memcpy(punit->orders.list, packet->orders.data(),
            punit->orders.length * sizeof(*punit->orders.list));
   }
   punit->action_turn = packet->action_turn;
@@ -2413,9 +2413,8 @@ void handle_player_info(const struct packet_player_info *pinfo)
   /* Don't use player_iterate here, because we ignore the real number
    * of players and we want to read all the datas. */
   BV_CLR_ALL(pplayer->real_embassy);
-  fc_assert(8 * sizeof(pplayer->real_embassy)
-            >= ARRAY_SIZE(pinfo->real_embassy));
-  for (i = 0; i < ARRAY_SIZE(pinfo->real_embassy); i++) {
+  fc_assert(8 * sizeof(pplayer->real_embassy) >= pinfo->real_embassy.size());
+  for (i = 0; i < pinfo->real_embassy.size(); i++) {
     if (pinfo->real_embassy[i]) {
       BV_SET(pplayer->real_embassy, i);
     }
@@ -2445,8 +2444,8 @@ void handle_player_info(const struct packet_player_info *pinfo)
 
   /* Don't use player_iterate or player_slot_count here, because we ignore
    * the real number of players and we want to read all the datas. */
-  fc_assert(ARRAY_SIZE(pplayer->ai_common.love) >= ARRAY_SIZE(pinfo->love));
-  for (i = 0; i < ARRAY_SIZE(pinfo->love); i++) {
+  fc_assert(ARRAY_SIZE(pplayer->ai_common.love) >= pinfo->love.size());
+  for (i = 0; i < pinfo->love.size(); i++) {
     pplayer->ai_common.love[i] = pinfo->love[i];
   }
 
@@ -3672,10 +3671,10 @@ void handle_ruleset_tech(const struct packet_ruleset_tech *p)
     a->require[AR_TWO] = A_NEVER;
   } else {
     // Unpack req1 and req2 from the research_reqs requirement vector.
-    i = unpack_tech_req(AR_ONE, p->research_reqs_count, p->research_reqs, a,
-                        i);
-    i = unpack_tech_req(AR_TWO, p->research_reqs_count, p->research_reqs, a,
-                        i);
+    i = unpack_tech_req(AR_ONE, p->research_reqs_count,
+                        p->research_reqs.data(), a, i);
+    i = unpack_tech_req(AR_TWO, p->research_reqs_count,
+                        p->research_reqs.data(), a, i);
   }
 
   /* Any remaining requirements are a part of the research_reqs requirement
@@ -4959,7 +4958,7 @@ void handle_unit_actions(const struct packet_unit_actions *packet)
   struct city *target_city = game_city_by_number(packet->target_city_id);
   struct unit *target_unit = game_unit_by_number(packet->target_unit_id);
 
-  const struct act_prob *act_probs = packet->action_probabilities;
+  const struct act_prob *act_probs = packet->action_probabilities.data();
 
   bool disturb_player = packet->disturb_player;
   bool valid = false;

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -364,34 +364,13 @@ class Field:
         elif not self.array_dims:
             return c
 
-        if deltafragment and self.diff and self.array_dims == 1:
-            if self.array_dims == 2:
-                array_size_u = self.array_size1_u
-            else:
-                array_size_u = self.array_size_u
-
-            return f"""
-    {{
-      int i;
-
-      fc_assert({array_size_u} < 255);
-
-      for (i = 0; i < {array_size_u}; i++) {{
-        if (old->{self.name}[i] != real_packet->{self.name}[i]) {{
-          dio_put<std::uint8_t>(dout, i);
-
-          {c}
-        }}
-      }}
-      dio_put<std::uint8_t>(dout, 255);
-
-    }}"""
-
         if self.dataio_type in ["string", "memory"]:
             # We handle the size via array dimensions below.
             dio_arg = ""
 
-        if self.array_dims == 2:
+        if deltafragment and self.diff:
+            size_args = f", old->{self.name}"
+        elif self.array_dims == 2:
             # Invert sizes for recursive call
             size_args = f", {self.array_size1_u}, {self.array_size2_u}"
         else:

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -198,7 +198,6 @@ class Field:
                 return f"std::array<{self.struct_type}[{self.array_size2_d}], {self.array_size1_d}> {self.name}"
             else:
                 return f"std::array<std::array<{self.struct_type}, {self.array_size2_d}>, {self.array_size1_d}> {self.name}"
-                return f"std::array<{self.struct_type}, {self.array_size_d}> {self.name}"
         if self.array_dims == 1:
             if self.dataio_type in {"string", "memory"}:
                 return f"{self.struct_type} {self.name}[{self.array_size_d}]"

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -325,7 +325,7 @@ class Field:
             s = ""
 
         return f"""  if (BV_ISSET(fields, {index})) {{
-{f}{s}  {self.get_put(deltafragment)}
+{f}{s}    {self.get_put(deltafragment)}
   }}
 """
 
@@ -333,17 +333,6 @@ class Field:
         """
         Returns code which put this field.
         """
-
-        # Array indices
-        loop_dims = self.array_dims
-        if self.dataio_type in {"memory", "string"}:
-            loop_dims -= 1  # One index is used by the string
-
-        indices = ""
-        if loop_dims == 1:
-            indices = "[i]"
-        elif loop_dims == 2:
-            indices = "[i][j]"
 
         # Do we need an extra arg for dio_put?
         dio_arg = ""
@@ -354,7 +343,7 @@ class Field:
         elif self.dataio_type == "memory":
             dio_arg = f", {self.array_size_u}"
 
-        c = f"dio_put(dout, packet->{self.name}{indices}{dio_arg});"
+        c = f"dio_put(dout, packet->{self.name}{dio_arg});"
 
         # We're done for scalar types
         if self.dataio_type == "bitvector":
@@ -403,17 +392,6 @@ class Field:
         Returns code which get this field.
         """
 
-        # Array indices
-        loop_dims = self.array_dims
-        if self.dataio_type in {"memory", "string"}:
-            loop_dims -= 1  # One index is used by the string
-
-        indices = ""
-        if loop_dims == 1:
-            indices = "[i]"
-        elif loop_dims == 2:
-            indices = "[i][j]"
-
         # Do we need an extra arg for dio_get?
         dio_arg = ""
         if self.struct_type == "float":
@@ -421,12 +399,12 @@ class Field:
         elif "std::" in self.dataio_type:
             dio_arg = f", {self.dataio_type}{{}}"
         elif self.dataio_type in ["string", "memory"]:
-            dio_arg = f", sizeof(real_packet->{self.name}{indices})"
+            dio_arg = f", sizeof(real_packet->{self.name})"
 
         # dio_get call and error checking
-        c = f"""if (!dio_get(din, real_packet->{self.name}{indices}{dio_arg})) {{
-  RECEIVE_PACKET_FIELD_ERROR({self.name});
-}}"""
+        c = f"""if (!dio_get(din, real_packet->{self.name}{dio_arg})) {{
+          RECEIVE_PACKET_FIELD_ERROR({self.name});
+        }}"""
 
         # We're done for scalar types
         if self.dataio_type == "bitvector":

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -454,7 +454,7 @@ class Field:
             dio_arg = f", sizeof(real_packet->{self.name}{indices})"
 
         # dio_get call and error checking
-        if "enum" in self.struct_type or self.struct_type.endswith("_id"):
+        if self.struct_type.endswith("_id"):
             c = f"""{{
   int readin;
 

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -457,41 +457,14 @@ class Field:
         elif not self.array_dims:
             return c
 
-        if deltafragment and self.diff and self.array_dims == 1:
-            if self.array_dims == 2:
-                array_size_u = self.array_size1_u
-                array_size_d = self.array_size1_d
-            else:
-                array_size_u = self.array_size_u
-                array_size_d = self.array_size_d
-
-            return f"""
-{{
-for (int count = 0;; count++) {{
-  int i;
-
-  if (!dio_get<std::uint8_t>(din, i)) {{
-    RECEIVE_PACKET_FIELD_ERROR({self.name});
-  }}
-  if (i == 255) {{
-    break;
-  }}
-  if (i >= {array_size_u}) {{
-    RECEIVE_PACKET_FIELD_ERROR({self.name},
-                               \": unexpected value %d \"
-                               \"(> {array_size_u}) in array diff\",
-                               i);
-  }} else {{
-    {c}
-  }}
-}}
-}}"""
-
         if self.dataio_type in ["string", "memory"]:
             # We handle the size via array dimensions below.
             dio_arg = ""
 
-        if self.array_dims == 2:
+        if deltafragment and self.diff:
+            # Array-diff
+            size_args = ", array_diff{}"
+        elif self.array_dims == 2:
             # Invert sizes for recursive call
             size_args = f", {self.array_size1_u}, {self.array_size2_u}"
         else:

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -334,9 +334,6 @@ class Field:
         Returns code which put this field.
         """
 
-        # dio function name
-        dio_put = f"dio_put<{self.dataio_type}>" if "std::" in self.dataio_type else f"dio_put"
-
         # Array indices
         loop_dims = self.array_dims
         if self.dataio_type in {"memory", "string", "city_map"}:
@@ -351,13 +348,15 @@ class Field:
         # Do we need an extra arg for dio_put?
         dio_arg = ""
         if self.struct_type == "float":
-            dio_arg = f", {self.float_factor}"
+            dio_arg = f", {self.float_factor}, {self.dataio_type}{{}}"
+        elif "std::" in self.dataio_type:
+            dio_arg = f", {self.dataio_type}{{}}"
         elif self.dataio_type == "city_map":
             dio_arg = f", sizeof(real_packet->{self.name}{indices})"
         elif self.dataio_type == "memory":
             dio_arg = f", {self.array_size_u}"
 
-        c = f"{dio_put}(dout, packet->{self.name}{indices}{dio_arg});"
+        c = f"dio_put(dout, packet->{self.name}{indices}{dio_arg});"
 
         # We're done for scalar types
         if self.dataio_type == "bitvector":
@@ -434,9 +433,6 @@ class Field:
         Returns code which get this field.
         """
 
-        # dio function name
-        dio_get = f"dio_get<{self.dataio_type}>" if "std::" in self.dataio_type else f"dio_get"
-
         # Array indices
         loop_dims = self.array_dims
         if self.dataio_type in {"memory", "string", "city_map"}:
@@ -451,7 +447,9 @@ class Field:
         # Do we need an extra arg for dio_get?
         dio_arg = ""
         if self.struct_type == "float":
-            dio_arg = f", {self.float_factor}"
+            dio_arg = f", {self.float_factor}, {self.dataio_type}{{}}"
+        elif "std::" in self.dataio_type:
+            dio_arg = f", {self.dataio_type}{{}}"
         elif self.dataio_type in ["string", "city_map"]:
             dio_arg = f", sizeof(real_packet->{self.name}{indices})"
 
@@ -460,14 +458,14 @@ class Field:
             c = f"""{{
   int readin;
 
-  if (!{dio_get}(din, readin)) {{
+  if (!dio_get(din, readin{dio_arg})) {{
     RECEIVE_PACKET_FIELD_ERROR({self.name});
   }}
   real_packet->{self.name}{indices} =
     static_cast<decltype(real_packet->{self.name}{indices})>(readin);
 }}"""
         else:
-            c = f"""if (!{dio_get}(din, real_packet->{self.name}{indices}{dio_arg})) {{
+            c = f"""if (!dio_get(din, real_packet->{self.name}{indices}{dio_arg})) {{
   RECEIVE_PACKET_FIELD_ERROR({self.name});
 }}"""
 
@@ -496,7 +494,7 @@ class Field:
                 extra = ""
             if self.dataio_type == "memory":
                 return f"""{extra}
-  if (!{dio_get}(din, real_packet->{self.name}, {array_size_u})) {{
+  if (!dio_get(din, real_packet->{self.name}, {array_size_u})) {{
     RECEIVE_PACKET_FIELD_ERROR({self.name});
   }}"""
             if self.array_dims == 2 and self.dataio_type != "string":

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -126,7 +126,7 @@ def parse_fields(
         match = re.search(r"^(.*)\[(.*)\]\[(.*)\]$", name)
         if match:
             field["name"] = match.group(1)
-            field["is_array"] = 2
+            field["array_dims"] = 2
             field["array_size1_d"], field["array_size1_u"], field["array_size1_o"] = field_dims(
                 match.group(2)
             )
@@ -137,13 +137,13 @@ def parse_fields(
             match = re.search(r"^(.*)\[(.*)\]$", name)
             if match:
                 field["name"] = match.group(1)
-                field["is_array"] = 1
+                field["array_dims"] = 1
                 field["array_size_d"], field["array_size_u"], field["array_size_o"] = field_dims(
                     match.group(2)
                 )
             else:
                 field["name"] = name
-                field["is_array"] = 0
+                field["array_dims"] = 0
         fields.append(Field(field, typeinfo, flaginfo))
 
     return fields
@@ -162,7 +162,7 @@ class Field:
     float_factor: int
     diff: bool
 
-    is_array: int
+    array_dims: int
     array_size_d: int
     array_size_o: int
     array_size_u: int
@@ -183,7 +183,7 @@ class Field:
             return "const char *"
         if self.dataio_type == "worklist":
             return f"const {self.struct_type} *"
-        if self.is_array:
+        if self.array_dims:
             return f"const {self.struct_type} *"
         return self.struct_type + " "
 
@@ -193,9 +193,9 @@ class Field:
         struct.
         """
 
-        if self.is_array == 2:
+        if self.array_dims == 2:
             return f"{self.struct_type} {self.name}[{self.array_size1_d}][{self.array_size2_d}]"
-        if self.is_array:
+        if self.array_dims:
             return f"{self.struct_type} {self.name}[{self.array_size_d}]"
         else:
             return f"{self.struct_type} {self.name}"
@@ -208,11 +208,11 @@ class Field:
 
         if self.dataio_type == "worklist":
             return f"  worklist_copy(&real_packet->{self.name}, {self.name});"
-        if self.is_array == 0:
+        if self.array_dims == 0:
             return f"  real_packet->{self.name} = {self.name};"
         if self.dataio_type == "string":
             return f"  sz_strlcpy(real_packet->{self.name}, {self.name});"
-        if self.is_array == 1:
+        if self.array_dims == 1:
             tmp = f"real_packet->{self.name}[i] = {self.name}[i]"
             return f"""
   for (int i = 0; i < {self.array_size_u}; i++) {{
@@ -233,15 +233,15 @@ class Field:
             return (
                 f"  differ = !BV_ARE_EQUAL(old->{self.name}, real_packet->{self.name});"
             )
-        if self.dataio_type == "string" and self.is_array == 1:
+        if self.dataio_type == "string" and self.array_dims == 1:
             return (
                 f"  differ = (strcmp(old->{self.name}, real_packet->{self.name}) != 0);"
             )
         if self.dataio_type == "cm_parameter":
             return f"  differ = (&old->{self.name} != &real_packet->{self.name});"
-        if self.is_struct and self.is_array == 0:
+        if self.is_struct and self.array_dims == 0:
             return f"  differ = !are_{self.dataio_type}s_equal(&old->{self.name}, &real_packet->{self.name});"
-        if not self.is_array:
+        if not self.array_dims:
             return f"  differ = (old->{self.name} != real_packet->{self.name});"
 
         sizes = None, None
@@ -280,7 +280,7 @@ class Field:
         bools which gets folded in the header) the actual value of the bool.
         """
 
-        if fold_bool_into_header and self.struct_type == "bool" and not self.is_array:
+        if fold_bool_into_header and self.struct_type == "bool" and not self.array_dims:
             return f"""{self.get_cmp()}
   if (differ) {{
     different++;
@@ -305,7 +305,7 @@ class Field:
         changed. Does nothing for bools-in-header.
         """
 
-        if fold_bool_into_header and self.struct_type == "bool" and not self.is_array:
+        if fold_bool_into_header and self.struct_type == "bool" and not self.array_dims:
             return f"  /* field {index} is folded into the header */\n"
         if packet.gen_log:
             f = f"    {packet.log_macro}(\"  field '{self.name}' has changed\");\n"
@@ -331,7 +331,7 @@ class Field:
         dio_put = f"dio_put<{self.dataio_type}>" if "std::" in self.dataio_type else f"dio_put"
 
         # Array indices
-        loop_dims = self.is_array
+        loop_dims = self.array_dims
         if self.dataio_type in {"memory", "string", "city_map"}:
             loop_dims -= 1  # One index is used by the string
 
@@ -355,17 +355,17 @@ class Field:
         # We're done for scalar types
         if self.dataio_type == "bitvector":
             return c
-        elif self.dataio_type in {"memory", "string", "city_map"} and self.is_array != 2:
+        elif self.dataio_type in {"memory", "string", "city_map"} and self.array_dims != 2:
             return c
-        elif not self.is_array:
+        elif not self.array_dims:
             return c
 
-        if self.is_array == 2:
+        if self.array_dims == 2:
             array_size_u = self.array_size1_u
         else:
             array_size_u = self.array_size_u
 
-        if deltafragment and self.diff and self.is_array == 1:
+        if deltafragment and self.diff and self.array_dims == 1:
             return f"""
     {{
       int i;
@@ -382,7 +382,7 @@ class Field:
       dio_put<std::uint8_t>(dout, 255);
 
     }}"""
-        if self.is_array == 2 and self.dataio_type != "string":
+        if self.array_dims == 2 and self.dataio_type != "string":
             return f"""
     {{
       int i, j;
@@ -410,7 +410,7 @@ class Field:
         """
 
         get = self.get_get(deltafragment)
-        if fold_bool_into_header and self.struct_type == "bool" and not self.is_array:
+        if fold_bool_into_header and self.struct_type == "bool" and not self.array_dims:
             return f"  real_packet->{self.name} = BV_ISSET(fields, {index});\n"
         get = indent(get, "    ")
         if packet.gen_log:
@@ -431,7 +431,7 @@ class Field:
         dio_get = f"dio_get<{self.dataio_type}>" if "std::" in self.dataio_type else f"dio_get"
 
         # Array indices
-        loop_dims = self.is_array
+        loop_dims = self.array_dims
         if self.dataio_type in {"memory", "string", "city_map"}:
             loop_dims -= 1  # One index is used by the string
 
@@ -467,12 +467,12 @@ class Field:
         # We're done for scalar types
         if self.dataio_type == "bitvector":
             return c
-        elif self.dataio_type in ["string", "city_map"] and self.is_array != 2:
+        elif self.dataio_type in ["string", "city_map"] and self.array_dims != 2:
             return c
-        elif not self.is_array:
+        elif not self.array_dims:
             return c
 
-        if self.is_array == 2:
+        if self.array_dims == 2:
             array_size_u = self.array_size1_u
             array_size_d = self.array_size1_d
         else:
@@ -492,7 +492,7 @@ class Field:
   if (!{dio_get}(din, real_packet->{self.name}, {array_size_u})) {{
     RECEIVE_PACKET_FIELD_ERROR({self.name});
   }}"""
-            if self.is_array == 2 and self.dataio_type != "string":
+            if self.array_dims == 2 and self.dataio_type != "string":
                 return f"""
 {{
 {extra}
@@ -510,7 +510,7 @@ class Field:
     {c}
   }}
 }}"""
-        elif deltafragment and self.diff and self.is_array == 1:
+        elif deltafragment and self.diff and self.array_dims == 1:
             return f"""
 {{
 for (int count = 0;; count++) {{

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -454,18 +454,7 @@ class Field:
             dio_arg = f", sizeof(real_packet->{self.name}{indices})"
 
         # dio_get call and error checking
-        if self.struct_type.endswith("_id"):
-            c = f"""{{
-  int readin;
-
-  if (!dio_get(din, readin{dio_arg})) {{
-    RECEIVE_PACKET_FIELD_ERROR({self.name});
-  }}
-  real_packet->{self.name}{indices} =
-    static_cast<decltype(real_packet->{self.name}{indices})>(readin);
-}}"""
-        else:
-            c = f"""if (!dio_get(din, real_packet->{self.name}{indices}{dio_arg})) {{
+        c = f"""if (!dio_get(din, real_packet->{self.name}{indices}{dio_arg})) {{
   RECEIVE_PACKET_FIELD_ERROR({self.name});
 }}"""
 

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -336,7 +336,7 @@ class Field:
 
         # Array indices
         loop_dims = self.array_dims
-        if self.dataio_type in {"memory", "string", "city_map"}:
+        if self.dataio_type in {"memory", "string"}:
             loop_dims -= 1  # One index is used by the string
 
         indices = ""
@@ -351,8 +351,6 @@ class Field:
             dio_arg = f", {self.float_factor}, {self.dataio_type}{{}}"
         elif "std::" in self.dataio_type:
             dio_arg = f", {self.dataio_type}{{}}"
-        elif self.dataio_type == "city_map":
-            dio_arg = f", sizeof(real_packet->{self.name}{indices})"
         elif self.dataio_type == "memory":
             dio_arg = f", {self.array_size_u}"
 
@@ -361,17 +359,17 @@ class Field:
         # We're done for scalar types
         if self.dataio_type == "bitvector":
             return c
-        elif self.dataio_type in {"memory", "string", "city_map"} and self.array_dims != 2:
+        elif self.dataio_type in {"memory", "string"} and self.array_dims != 2:
             return c
         elif not self.array_dims:
             return c
 
-        if self.array_dims == 2:
-            array_size_u = self.array_size1_u
-        else:
-            array_size_u = self.array_size_u
-
         if deltafragment and self.diff and self.array_dims == 1:
+            if self.array_dims == 2:
+                array_size_u = self.array_size1_u
+            else:
+                array_size_u = self.array_size_u
+
             return f"""
     {{
       int i;
@@ -388,26 +386,19 @@ class Field:
       dio_put<std::uint8_t>(dout, 255);
 
     }}"""
-        if self.array_dims == 2 and self.dataio_type != "string":
-            return f"""
-    {{
-      int i, j;
 
-      for (i = 0; i < {self.array_size1_u}; i++) {{
-        for (j = 0; j < {self.array_size2_u}; j++) {{
-          {c}
-        }}
-      }}
-    }}"""
+        if self.dataio_type in ["string", "memory"]:
+            # We handle the size via array dimensions below.
+            dio_arg = ""
 
-        return f"""
-    {{
-      int i;
+        if self.array_dims == 2:
+            # Invert sizes for recursive call
+            size_args = f", {self.array_size1_u}, {self.array_size2_u}"
+        else:
+            size_args = f", {self.array_size_u}"
 
-      for (i = 0; i < {array_size_u}; i++) {{
-        {c}
-      }}
-    }}"""
+        return f"dio_put(dout, real_packet->{self.name}{size_args}{dio_arg});"
+
 
     def get_get_wrapper(self, packet, index, deltafragment):
         """
@@ -435,7 +426,7 @@ class Field:
 
         # Array indices
         loop_dims = self.array_dims
-        if self.dataio_type in {"memory", "string", "city_map"}:
+        if self.dataio_type in {"memory", "string"}:
             loop_dims -= 1  # One index is used by the string
 
         indices = ""
@@ -450,7 +441,7 @@ class Field:
             dio_arg = f", {self.float_factor}, {self.dataio_type}{{}}"
         elif "std::" in self.dataio_type:
             dio_arg = f", {self.dataio_type}{{}}"
-        elif self.dataio_type in ["string", "city_map"]:
+        elif self.dataio_type in ["string", "memory"]:
             dio_arg = f", sizeof(real_packet->{self.name}{indices})"
 
         # dio_get call and error checking
@@ -461,50 +452,19 @@ class Field:
         # We're done for scalar types
         if self.dataio_type == "bitvector":
             return c
-        elif self.dataio_type in ["string", "city_map"] and self.array_dims != 2:
+        elif self.dataio_type == "string" and self.array_dims != 2:
             return c
         elif not self.array_dims:
             return c
 
-        if self.array_dims == 2:
-            array_size_u = self.array_size1_u
-            array_size_d = self.array_size1_d
-        else:
-            array_size_u = self.array_size_u
-            array_size_d = self.array_size_d
+        if deltafragment and self.diff and self.array_dims == 1:
+            if self.array_dims == 2:
+                array_size_u = self.array_size1_u
+                array_size_d = self.array_size1_d
+            else:
+                array_size_u = self.array_size_u
+                array_size_d = self.array_size_d
 
-        if not self.diff or self.dataio_type == "memory":
-            if array_size_u != array_size_d:
-                extra = f"""
-  if ({array_size_u} > {array_size_d}) {{
-    RECEIVE_PACKET_FIELD_ERROR({self.name}, ": truncation array");
-  }}"""
-            else:
-                extra = ""
-            if self.dataio_type == "memory":
-                return f"""{extra}
-  if (!dio_get(din, real_packet->{self.name}, {array_size_u})) {{
-    RECEIVE_PACKET_FIELD_ERROR({self.name});
-  }}"""
-            if self.array_dims == 2 and self.dataio_type != "string":
-                return f"""
-{{
-{extra}
-  for (int i = 0; i < {self.array_size1_u}; i++) {{
-    for (int j = 0; j < {self.array_size2_u}; j++) {{
-      {c}
-    }}
-  }}
-}}"""
-            else:
-                return f"""
-{{
-{extra}
-  for (int i = 0; i < {array_size_u}; i++) {{
-    {c}
-  }}
-}}"""
-        elif deltafragment and self.diff and self.array_dims == 1:
             return f"""
 {{
 for (int count = 0;; count++) {{
@@ -526,11 +486,20 @@ for (int count = 0;; count++) {{
   }}
 }}
 }}"""
+
+        if self.dataio_type in ["string", "memory"]:
+            # We handle the size via array dimensions below.
+            dio_arg = ""
+
+        if self.array_dims == 2:
+            # Invert sizes for recursive call
+            size_args = f", {self.array_size1_u}, {self.array_size2_u}"
         else:
-            return f"""
-for (int i = 0; i < {array_size_u}; i++) {{
-  {c}
-}}"""
+            size_args = f", {self.array_size_u}"
+
+        return f"""if (!dio_get(din, real_packet->{self.name}{size_args}{dio_arg})) {{
+          RECEIVE_PACKET_FIELD_ERROR({self.name});
+        }}"""
 
 
 class Variant:

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -194,9 +194,16 @@ class Field:
         """
 
         if self.array_dims == 2:
-            return f"{self.struct_type} {self.name}[{self.array_size1_d}][{self.array_size2_d}]"
-        if self.array_dims:
-            return f"{self.struct_type} {self.name}[{self.array_size_d}]"
+            if self.dataio_type in {"string", "memory"}:
+                return f"std::array<{self.struct_type}[{self.array_size2_d}], {self.array_size1_d}> {self.name}"
+            else:
+                return f"std::array<std::array<{self.struct_type}, {self.array_size2_d}>, {self.array_size1_d}> {self.name}"
+                return f"std::array<{self.struct_type}, {self.array_size_d}> {self.name}"
+        if self.array_dims == 1:
+            if self.dataio_type in {"string", "memory"}:
+                return f"{self.struct_type} {self.name}[{self.array_size_d}]"
+            else:
+                return f"std::array<{self.struct_type}, {self.array_size_d}> {self.name}"
         else:
             return f"{self.struct_type} {self.name}"
 
@@ -1733,6 +1740,9 @@ def write_common_header(packets: list[Packet], output: io.TextIOWrapper) -> None
 #include "fc_types.h"
 #include "unit.h"
 
+// std
+#include <array>
+
 """
     )
 
@@ -1905,8 +1915,12 @@ bool client_handle_packet(enum packet_type type, const void *packet)
             args = packet_cast
         else:
             # static_cast(packet)->a, static_cast(packet)->b, ...
-            args = map(lambda field: packet_cast + "->" + field.name, packet.fields)
-            args = ",\n      ".join(args)
+            def format_field(field):
+                if field.array_dims > 0 and not field.dataio_type == "string":
+                    return f"{packet_cast}->{field.name}.data()"
+                return f"{packet_cast}->{field.name}"
+
+            args = ",\n      ".join(map(format_field, packet.fields))
             if args:
                 args = "\n      " + args
 
@@ -2025,6 +2039,8 @@ bool server_handle_packet(enum packet_type type, const void *packet,
                 arg = f"{cast}->{field.name}"
                 if field.dataio_type == "worklist":
                     arg = "&" + arg
+                if field.array_dims > 0 and not field.dataio_type == "string":
+                    arg += ".data()"
                 args.append(arg)
             args = ",\n      ".join(args)
             if args:

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -115,24 +115,22 @@ def parse_fields(
     for name in field_names:
         field = {}
 
-        def f(x):
-            arr = x.split(":")
-            if len(arr) == 1:
+        def field_dims(x):
+            parts = x.split(":")
+            if len(parts) == 1:
                 return [x, x, x]
 
-            assert len(arr) == 2
-            arr.append("old->" + arr[1])
-            arr[1] = "real_packet->" + arr[1]
-            return arr
+            assert len(parts) == 2
+            return [parts[0], f"real_packet->{parts[1]}", f"old->{parts[1]}"]
 
         match = re.search(r"^(.*)\[(.*)\]\[(.*)\]$", name)
         if match:
             field["name"] = match.group(1)
             field["is_array"] = 2
-            field["array_size1_d"], field["array_size1_u"], field["array_size1_o"] = f(
+            field["array_size1_d"], field["array_size1_u"], field["array_size1_o"] = field_dims(
                 match.group(2)
             )
-            field["array_size2_d"], field["array_size2_u"], field["array_size2_o"] = f(
+            field["array_size2_d"], field["array_size2_u"], field["array_size2_o"] = field_dims(
                 match.group(3)
             )
         else:
@@ -140,7 +138,7 @@ def parse_fields(
             if match:
                 field["name"] = match.group(1)
                 field["is_array"] = 1
-                field["array_size_d"], field["array_size_u"], field["array_size_o"] = f(
+                field["array_size_d"], field["array_size_u"], field["array_size_o"] = field_dims(
                     match.group(2)
                 )
             else:

--- a/common/networking/dataio_raw.cpp
+++ b/common/networking/dataio_raw.cpp
@@ -191,9 +191,9 @@ void dio_put_type_raw(QByteArray &dout, enum data_type type, int value)
 /**
    Take string. Conversion callback is used.
  */
-bool dio_get(QByteArrayView &din, char *dest, size_t max_dest_size)
+bool dio_get(QByteArrayView &din, char *dest, std::size_t max_dest_size)
 {
-  size_t offset, remaining;
+  std::size_t offset, remaining;
 
   fc_assert(max_dest_size > 0);
 
@@ -225,9 +225,11 @@ bool dio_get(QByteArrayView &din, char *dest, size_t max_dest_size)
 }
 
 /**
-   Insert nullptr-terminated string. Conversion callback is used if set.
+ * Insert nullptr-terminated string. Conversion callback is used if set.
+ * The third argument is present for compatibility with \c dio_get and is
+ * ignored.
  */
-void dio_put(QByteArray &dout, const char *value)
+void dio_put(QByteArray &dout, const char *value, std::size_t)
 {
   if (put_conv_callback) {
     size_t length;

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -263,6 +263,37 @@ bool dio_get(QByteArrayView &din, std::array<T, N> &dest, array_diff,
 }
 
 /**
+ * Writes an array of values at the end of \c dout, using the array-diff
+ * protocol. The \c ref argument contains the value with respect to which to
+ * built the diff.
+ * Additional arguments are passed to \c dio_get for the destination type.
+ */
+template <class T, std::size_t N, class... Args>
+void dio_put(QByteArray &dout, const std::array<T, N> &value,
+             const std::array<T, N> &ref, Args &&...args)
+{
+  // See the matching dio_get for a description of the format.
+
+  // The index is an uint8 and 0xff is the stop marker. Thus we can have at
+  // most 0xff - 1 elements.
+  static_assert(N < 0xff, "Array too long for the array-diff format.");
+
+  // Indices are encoded on one byte, so it wouldn't make sense to receive
+  // more than 256 values in an array-diff.
+  for (std::uint8_t i = 0; i < value.size(); ++i) {
+    if (value[i] != ref[i]) {
+      // Put the index
+      dio_put(dout, i, std::uint8_t{});
+      // And the value
+      dio_put(dout, value[i], std::forward<Args>(args)...);
+    }
+  }
+
+  // End marker.
+  dio_put(dout, 0xff, std::uint8_t{});
+}
+
+/**
  * Reads a bit vector from the beginning of \c din and puts it in \c dest.
  */
 template <unsigned bits>

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -54,9 +54,10 @@ void dio_put_type_raw(QByteArray &dout, enum data_type type, int value);
 
 /**
  * Reads a value from the beginning of \c din and puts it in \c dest.
- * The template parameter specifies the encoding.
+ * The third argument allows deduction of the template parameter, which
+ * specifies the encoding.
  */
-template <class T> bool dio_get(QByteArrayView &din, int &dest)
+template <class T> bool dio_get(QByteArrayView &din, int &dest, T = 0)
 {
   if (din.size() < sizeof(T)) {
     log_packet("Packet too short: needed %zu bytes, got %lld", sizeof(T),
@@ -74,9 +75,10 @@ template <class T> bool dio_get(QByteArrayView &din, int &dest)
 
 /**
  * Writes \c value at the end of \c dout.
- * The template parameter specifies the encoding.
+ * The third argument allows deduction of the template parameter, which
+ * specifies the encoding.
  */
-template <class T> void dio_put(QByteArray &dout, int value)
+template <class T> void dio_put(QByteArray &dout, int value, T = 0)
 {
   T tmp = value;
   tmp = qToBigEndian(tmp);
@@ -104,10 +106,11 @@ inline void dio_put(QByteArray &dout, bool value)
 
 /**
  * Reads a float from the beginning of \c din and puts it in \c dest.
- * The template parameter specifies the underlying encoding.
+ * The fourth argument allows deduction of the template parameter, which
+ * specifies the encoding.
  */
 template <class T>
-bool dio_get(QByteArrayView &din, float &dest, int precision)
+bool dio_get(QByteArrayView &din, float &dest, int precision, T = 0)
 {
   int ival;
   auto ret = dio_get<T>(din, ival);
@@ -117,9 +120,11 @@ bool dio_get(QByteArrayView &din, float &dest, int precision)
 
 /**
  * Writes a float at the end of \c dout.
- * The template parameter specifies the underlying encoding.
+ * The fourth argument allows deduction of the template parameter, which
+ * specifies the encoding.
  */
-template <class T> void dio_put(QByteArray &dout, float value, int precision)
+template <class T>
+void dio_put(QByteArray &dout, float value, int precision, T = 0)
 {
   dio_put<T>(dout, static_cast<int>(value * precision));
 }

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -219,6 +219,50 @@ void dio_put(QByteArray &dout, const std::array<T, N> &value,
 }
 
 /**
+ * Used as a marker to enable the array-diff protocol.
+ */
+struct array_diff {};
+
+/**
+ * Reads an array of values from the beginning of \c din and puts it in \c
+ * dest, using the array-diff protocol. Additional arguments are passed to
+ * \c dio_get for the destination type.
+ */
+template <class T, std::size_t N, class... Args>
+bool dio_get(QByteArrayView &din, std::array<T, N> &dest, array_diff,
+             Args &&...args)
+{
+  // The array-diff format encodes changed elements only. Each element is
+  // encoded as a 1-byte index followed by the value. An index of 255 marks
+  // the end of the diff.
+
+  // Indices are encoded on one byte, so it wouldn't make sense to receive
+  // more than 256 values in an array-diff.
+  for (int count = 0; count < 256; ++count) {
+    // Get the index in the array.
+    std::uint8_t index;
+    fc_assert_ret_val_msg(dio_get(din, index), false,
+                          "array-diff: incomplete data");
+
+    // An index of 255 represents the end of the diff.
+    if (index == 0xff) {
+      break;
+    }
+
+    // Make sure it fits.
+    fc_assert_ret_val_msg(index < dest.size(), false,
+                          "array-diff: index out of bounds");
+
+    // Read the value.
+    fc_assert_ret_val_msg(
+        dio_get(din, dest[index], std::forward<Args>(args)...), false,
+        "array-diff: invalid value");
+  }
+
+  return true;
+}
+
+/**
  * Reads a bit vector from the beginning of \c din and puts it in \c dest.
  */
 template <unsigned bits>

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -55,10 +55,11 @@ void dio_put_type_raw(QByteArray &dout, enum data_type type, int value);
 
 /**
  * Reads a value from the beginning of \c din and puts it in \c dest.
- * The third argument allows deduction of the template parameter, which
- * specifies the encoding.
+ * The third argument is for compatibility with the form with dest as an \c
+ * int.
  */
-template <class T> bool dio_get(QByteArrayView &din, int &dest, T = 0)
+template <class T, class = std::enable_if_t<std::is_integral_v<T>>>
+bool dio_get(QByteArrayView &din, T &dest, T = 0)
 {
   if (din.size() < sizeof(T)) {
     log_packet("Packet too short: needed %zu bytes, got %lld", sizeof(T),
@@ -66,12 +67,37 @@ template <class T> bool dio_get(QByteArrayView &din, int &dest, T = 0)
     return false;
   }
 
-  T tmp;
-  memcpy(&tmp, din.data(), sizeof(T));
-  din.slice(sizeof(T));
+  memcpy(&dest, din.data(), sizeof(T));
+  dest = qFromBigEndian(dest);
 
-  dest = qFromBigEndian(tmp);
+  din.slice(sizeof(T));
   return true;
+}
+
+/**
+ * Writes \c value at the end of \c dout.
+ * The third argument is for compatibility with the form with dest as an \c
+ * int.
+ */
+template <class T, class = std::enable_if_t<std::is_integral_v<T>>>
+void dio_put(QByteArray &dout, T value, T = 0)
+{
+  value = qToBigEndian(value);
+  dout.append(reinterpret_cast<char *>(&value), sizeof(T));
+}
+
+/**
+ * Reads a value from the beginning of \c din and puts it in \c dest.
+ * The third argument allows deduction of the template parameter, which
+ * specifies the encoding.
+ */
+template <class T, class = std::enable_if_t<!std::is_same_v<T, int>>>
+bool dio_get(QByteArrayView &din, int &dest, T = 0)
+{
+  T tmp;
+  auto ret = dio_get(din, tmp);
+  dest = tmp;
+  return ret;
 }
 
 /**
@@ -79,11 +105,10 @@ template <class T> bool dio_get(QByteArrayView &din, int &dest, T = 0)
  * The third argument allows deduction of the template parameter, which
  * specifies the encoding.
  */
-template <class T> void dio_put(QByteArray &dout, int value, T = 0)
+template <class T, class = std::enable_if_t<!std::is_same_v<T, int>>>
+void dio_put(QByteArray &dout, int value, T = 0)
 {
-  T tmp = value;
-  tmp = qToBigEndian(tmp);
-  dout.append(reinterpret_cast<char *>(&tmp), sizeof(T));
+  dio_put(dout, static_cast<T>(value));
 }
 
 /**

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -11,6 +11,7 @@
 // std
 #include <algorithm>
 #include <cstddef> // size_t
+#include <type_traits>
 
 // Qt
 #include <QByteArray>
@@ -127,6 +128,33 @@ template <class T>
 void dio_put(QByteArray &dout, float value, int precision, T = 0)
 {
   dio_put<T>(dout, static_cast<int>(value * precision));
+}
+
+/**
+ * Reads an enum value from the beginning of \c din and puts it in \c dest.
+ * The third argument allows deduction of the template parameter, which
+ * specifies the encoding.
+ */
+template <class Enum, class T,
+          class = std::enable_if_t<std::is_enum_v<Enum>>>
+bool dio_get(QByteArrayView &din, Enum &dest, T = 0)
+{
+  int ival;
+  auto ret = dio_get<T>(din, ival);
+  dest = static_cast<Enum>(ival);
+  return ret;
+}
+
+/**
+ * Writes an enum value at the end of \c dout.
+ * The third argument allows deduction of the template parameter, which
+ * specifies the encoding.
+ */
+template <class Enum, class T,
+          class = std::enable_if_t<std::is_enum_v<Enum>>>
+void dio_put(QByteArray &dout, Enum value, T = 0)
+{
+  dio_put<T>(dout, static_cast<int>(value));
 }
 
 /**

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -183,6 +183,42 @@ void dio_put(QByteArray &dout, Enum value, T = 0)
 }
 
 /**
+ * Reads an array of values from the beginning of \c din and puts it in \c
+ * dest. At most \c size values are written. Additional arguments are passed
+ * to \c dio_get for the destination type.
+ */
+template <class T, std::size_t N, class... Args>
+bool dio_get(QByteArrayView &din, std::array<T, N> &dest, std::size_t size,
+             Args &&...args)
+{
+  fc_assert_ret_val_msg(size <= N, false, "received to many values");
+
+  for (std::size_t i = 0; i < size; ++i) {
+    if (!dio_get(din, dest[i], std::forward<Args>(args)...)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Writes an array of values at the end of \c dout.
+ * At most \c size values are written. Additional arguments are passed to
+ * \c dio_get for the destination type.
+ */
+template <class T, std::size_t N, class... Args>
+void dio_put(QByteArray &dout, const std::array<T, N> &value,
+             std::size_t size, Args &&...args)
+{
+  fc_assert_ret_msg(size <= N, "trying to send too many values");
+
+  for (std::size_t i = 0; i < size; ++i) {
+    dio_put(dout, value[i], std::forward<Args>(args)...);
+  }
+}
+
+/**
  * Reads a bit vector from the beginning of \c din and puts it in \c dest.
  */
 template <unsigned bits>
@@ -208,9 +244,9 @@ void dio_put(QByteArray &dout, const bit_vector<bits> &value)
               value.vec.size());
 }
 
-bool dio_get(QByteArrayView &din, char *dest, size_t max_dest_size)
+bool dio_get(QByteArrayView &din, char *dest, std::size_t max_dest_size)
     fc__attribute((nonnull(2)));
-void dio_put(QByteArray &dout, const char *value)
+void dio_put(QByteArray &dout, const char *value, std::size_t = 0)
     fc__attribute((nonnull(2)));
 
 bool dio_get(QByteArrayView &din, std::byte *dest, size_t max_dest_size)

--- a/common/networking/protocol.h
+++ b/common/networking/protocol.h
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Louis Moureaux <m_louis30@yahoo.com>
+
+#pragma once
+
+// common
+#include "dataio_raw.h"
+
+// utility
+#include "bitvector.h"
+
+// std
+#include <stdexcept>
+#include <string_view>
+
+// Qt
+#include <QByteArrayView>
+
+namespace freeciv {
+
+template <int fields> class delta_get {
+  bit_vector<fields> m_fields = {{0}};
+  int m_seen = 0;
+  QByteArrayView m_data;
+
+public:
+  // The header should have been removed from data
+  delta_get(QByteArrayView data) : m_data(data)
+  {
+    if (!dio_get(m_data, m_fields)) {
+      throw std::runtime_error("<delta header>");
+    }
+  }
+
+  template <class T> void key(const std::string_view name, int &key)
+  {
+    int_field(name, key);
+    // Fetch old values...
+  }
+
+  template <class T> void int_field(const std::string_view name, int &out)
+  {
+    if (BV_ISSET(m_fields, m_seen++)) {
+      if (!dio_get<T>(m_data, out)) {
+        throw std::runtime_error(std::string(name));
+      }
+    }
+  }
+
+  template <class T> void field(const std::string_view name, T &out)
+  {
+    if (BV_ISSET(m_fields, m_seen++)) {
+      if (!dio_get(m_data, out)) {
+        throw std::runtime_error(std::string(name));
+      }
+    }
+  }
+
+  template <> void field(const std::string_view name, bool &out)
+  {
+    Q_UNUSED(name);
+    return BV_ISSET(m_fields, m_seen++);
+  }
+
+  template <class T>
+  void int_field(const std::string_view name, T out[], int size)
+  {
+    if (BV_ISSET(m_fields, m_seen++)) {
+      for (int i = 0; i < size; ++i) {
+        if (!dio_get<T>(m_data, out)) {
+          throw std::runtime_error(std::string(name));
+        }
+      }
+    }
+  }
+
+  template <class T>
+  void field(const std::string_view name, T out[], int size)
+  {
+    if (BV_ISSET(m_fields, m_seen++)) {
+      for (int i = 0; i < size; ++i) {
+        if (!dio_get(m_data, out)) {
+          throw std::runtime_error(std::string(name));
+        }
+      }
+    }
+  }
+};
+
+struct field_counter {
+  int count = 0;
+  constexpr void field() { count++; }
+};
+
+template <class Packet> constexpr void serialize(Packet &packet)
+{
+  packet.field();
+  packet.field();
+}
+
+constexpr int count_fields()
+{
+  field_counter cf;
+  serialize(cf);
+  return cf.count;
+}
+
+std::array<int, count_fields()> a;
+
+} // namespace freeciv

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -2572,7 +2572,7 @@ void package_city(struct city *pcity, struct packet_city_info *packet,
   packet->rally_point_persistent = pcity->rally_point.persistent;
   packet->rally_point_vigilant = pcity->rally_point.vigilant;
   if (pcity->rally_point.length) {
-    memcpy(packet->rally_point_orders, pcity->rally_point.orders,
+    memcpy(packet->rally_point_orders.data(), pcity->rally_point.orders,
            pcity->rally_point.length * sizeof(struct unit_order));
   }
 

--- a/server/report.cpp
+++ b/server/report.cpp
@@ -1781,7 +1781,7 @@ void report_final_scores(struct conn_list *dest)
   struct player_score_entry size[player_count()];
   struct packet_endgame_report packet;
 
-  fc_assert(score_categories_num <= ARRAY_SIZE(packet.category_name));
+  fc_assert(score_categories_num <= packet.category_name.size());
 
   if (!dest) {
     dest = game.est_connections;

--- a/server/ruleset.cpp
+++ b/server/ruleset.cpp
@@ -8278,7 +8278,7 @@ static void send_ruleset_nations(struct conn_list *dest)
     packet.init_government_id = n.init_government
                                     ? government_number(n.init_government)
                                     : government_count();
-    fc_assert(ARRAY_SIZE(packet.init_techs) == ARRAY_SIZE(n.init_techs));
+    fc_assert(packet.init_techs.size() == ARRAY_SIZE(n.init_techs));
     for (i = 0; i < MAX_NUM_TECH_LIST; i++) {
       if (n.init_techs[i] != A_LAST) {
         packet.init_techs[i] = n.init_techs[i];
@@ -8287,7 +8287,7 @@ static void send_ruleset_nations(struct conn_list *dest)
       }
     }
     packet.init_techs_count = i;
-    fc_assert(ARRAY_SIZE(packet.init_units) == n.init_units.size());
+    fc_assert(packet.init_units.size() == n.init_units.size());
     for (i = 0; i < MAX_NUM_UNIT_LIST; i++) {
       const struct unit_type *t = n.init_units[i];
       if (t) {
@@ -8297,8 +8297,7 @@ static void send_ruleset_nations(struct conn_list *dest)
       }
     }
     packet.init_units_count = i;
-    fc_assert(ARRAY_SIZE(packet.init_buildings)
-              == ARRAY_SIZE(n.init_buildings));
+    fc_assert(packet.init_buildings.size() == ARRAY_SIZE(n.init_buildings));
     for (i = 0; i < MAX_NUM_BUILDING_LIST; i++) {
       if (n.init_buildings[i] != B_LAST) {
         // Impr_type_id to int
@@ -8495,7 +8494,7 @@ static void send_ruleset_game(struct conn_list *dest)
 
   fc_assert(sizeof(misc_p.global_init_techs)
             == sizeof(game.rgame.global_init_techs));
-  fc_assert(ARRAY_SIZE(misc_p.global_init_techs)
+  fc_assert(misc_p.global_init_techs.size()
             == ARRAY_SIZE(game.rgame.global_init_techs));
   for (i = 0; i < MAX_NUM_TECH_LIST; i++) {
     if (game.rgame.global_init_techs[i] != A_LAST) {
@@ -8506,7 +8505,7 @@ static void send_ruleset_game(struct conn_list *dest)
   }
   misc_p.global_init_techs_count = i;
 
-  fc_assert(ARRAY_SIZE(misc_p.global_init_buildings)
+  fc_assert(misc_p.global_init_buildings.size()
             == ARRAY_SIZE(game.rgame.global_init_buildings));
   for (i = 0; i < MAX_NUM_BUILDING_LIST; i++) {
     if (game.rgame.global_init_buildings[i] != B_LAST) {

--- a/server/settings.cpp
+++ b/server/settings.cpp
@@ -4914,8 +4914,8 @@ void send_server_setting(struct conn_list *dest, const struct setting *pset)
           sz_strlcpy(packet.pretty_names[i], val_name->pretty);
         }
         packet.values_num = i;
-        fc_assert(i <= ARRAY_SIZE(packet.support_names));
-        fc_assert(i <= ARRAY_SIZE(packet.pretty_names));
+        fc_assert(i <= packet.support_names.size());
+        fc_assert(i <= packet.pretty_names.size());
       }
       send_packet_server_setting_enum(pconn, &packet);
     }
@@ -4938,8 +4938,8 @@ void send_server_setting(struct conn_list *dest, const struct setting *pset)
           sz_strlcpy(packet.pretty_names[i], val_name->pretty);
         }
         packet.bits_num = i;
-        fc_assert(i <= ARRAY_SIZE(packet.support_names));
-        fc_assert(i <= ARRAY_SIZE(packet.pretty_names));
+        fc_assert(i <= packet.support_names.size());
+        fc_assert(i <= packet.pretty_names.size());
       }
       send_packet_server_setting_bitwise(pconn, &packet);
     }
@@ -5011,7 +5011,7 @@ void send_server_setting_control(struct connection *pconn)
   control.settings_num = SETTINGS_NUM;
 
   // Fill in the category strings.
-  fc_assert(SSET_NUM_CATEGORIES <= ARRAY_SIZE(control.category_names));
+  fc_assert(SSET_NUM_CATEGORIES <= control.category_names.size());
   control.categories_num = SSET_NUM_CATEGORIES;
   for (i = 0; i < SSET_NUM_CATEGORIES; i++) {
     // Send untranslated name

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -5736,7 +5736,7 @@ void handle_unit_orders(struct player *pplayer,
 
   struct unit_order *order_list = nullptr;
   if (length) {
-    order_list = create_unit_orders(length, packet->orders);
+    order_list = create_unit_orders(length, packet->orders.data());
     if (!order_list) {
       qCritical("received invalid orders from %s for %s (%d).",
                 player_name(pplayer), unit_rule_name(punit),

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2896,7 +2896,7 @@ void package_unit(struct unit *punit, struct packet_unit_info *packet)
     packet->orders_index = punit->orders.index;
     packet->orders_repeat = punit->orders.repeat;
     packet->orders_vigilant = punit->orders.vigilant;
-    memcpy(packet->orders, punit->orders.list,
+    memcpy(packet->orders.data(), punit->orders.list,
            punit->orders.length * sizeof(struct unit_order));
   } else {
     packet->orders_length = packet->orders_index = 0;

--- a/tools/ruleutil/rulesave.cpp
+++ b/tools/ruleutil/rulesave.cpp
@@ -1021,7 +1021,7 @@ static bool save_game_ruleset(const char *filename, const char *name)
                    RS_DEFAULT_UPGRADE_VETERAN_LOSS,
                    "civstyle.autoupgrade_veteran_loss", nullptr);
 
-  secfile_insert_int_vec(sfile, game.info.granary_food_ini,
+  secfile_insert_int_vec(sfile, game.info.granary_food_ini.data(),
                          game.info.granary_num_inis,
                          "civstyle.granary_food_ini");
 


### PR DESCRIPTION
This builds on #2845 to move basic packet serialization logic out of `generate_packets.py`. Enums and arrays no longer need explicitly generated code; they rely on template functions in `dataio` instead. For instance, writing a packet now looks like this regardless of the data types involved:
```cpp
  ...
  /* field 5 is folded into the header */
  /* field 6 is folded into the header */
  if (BV_ISSET(fields, 7)) {
    log_packet_detailed("  field 'name' has changed");
    dio_put(dout, packet->name);
  }
  if (BV_ISSET(fields, 8)) {
    log_packet_detailed("  field 'hp' has changed");
    dio_put(dout, packet->hp, std::uint8_t{});
  }
  if (BV_ISSET(fields, 9)) {
    log_packet_detailed("  field 'activity' has changed");
    dio_put(dout, packet->activity, std::uint8_t{});
  }
  ...
```
The generated code used to contain a lot of logic such as loops. This is now entirely gone (as far as the `dio_*` part is concerned).