### PR TITLE
Explicitly ignore unused [[nodiscard]] values

### DIFF
--- a/client/servers.cpp
+++ b/client/servers.cpp
@@ -369,7 +369,7 @@ static bool meta_read_response(struct server_scan *scan)
   struct server_list *srvrs;
 
   auto *f = new QBuffer(&scan->meta.mem);
-  f->open(QIODevice::ReadWrite);
+  std::ignore = f->open(QIODevice::ReadWrite);
 
   // parse message body
   srvrs = parse_metaserver_data(f);

--- a/server/savegame/civ2.cpp
+++ b/server/savegame/civ2.cpp
@@ -525,7 +525,7 @@ bool read_saved_game(const QString &path, game &g)
 {
   // Open the file
   auto file = QFile(path);
-  file.open(QIODevice::ReadOnly);
+  std::ignore = file.open(QIODevice::ReadOnly);
   QDataStream bytes(&file);
   bytes.setByteOrder(QDataStream::LittleEndian);
 

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -252,7 +252,7 @@ void detail::async_readline_wrapper::wait_for_input()
       line = QString::fromLocal8Bit(buffer);
     } else {
       QFile f;
-      f.open(stdin, QIODevice::ReadOnly);
+      std::ignore = f.open(stdin, QIODevice::ReadOnly);
       line = QString::fromLocal8Bit(f.readLine());
     }
   }
@@ -712,7 +712,7 @@ void server::input_on_stdin()
     rl_callback_read_char();
   } else {
     QFile f;
-    f.open(stdin, QIODevice::ReadOnly);
+    std::ignore = f.open(stdin, QIODevice::ReadOnly);
     // Force it to try and read something
     f.peek(1);
     // Read from the input

--- a/utility/inputfile.cpp
+++ b/utility/inputfile.cpp
@@ -206,7 +206,7 @@ struct inputfile *inf_from_file(const QString &filename,
   fc_assert_ret_val(!filename.isEmpty(), nullptr);
   fc_assert_ret_val(0 < filename.length(), nullptr);
   auto *fp = new KCompressionDevice(filename);
-  fp->open(QIODevice::ReadOnly);
+  std::ignore = fp->open(QIODevice::ReadOnly);
   if (!fp->isOpen()) {
     delete fp;
     return nullptr;
@@ -802,7 +802,7 @@ static QString get_token_value(struct inputfile *inf)
       return "";
     }
     auto fp = new KCompressionDevice(rfname);
-    fp->open(QIODevice::ReadOnly);
+    std::ignore = fp->open(QIODevice::ReadOnly);
     if (!fp->isOpen()) {
       qCCritical(inf_category, _("Cannot open stringfile \"%s\"."),
                  qUtf8Printable(rfname));

--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -627,7 +627,7 @@ bool secfile_save(const struct section_file *secfile, QString filename)
 
   auto real_filename = interpret_tilde(filename);
   auto fs = std::make_unique<KCompressionDevice>(real_filename);
-  fs->open(QIODevice::WriteOnly);
+  std::ignore = fs->open(QIODevice::WriteOnly);
 
   if (!fs->isOpen()) {
     SECFILE_LOG(secfile, nullptr, _("Could not open %s for writing"),


### PR DESCRIPTION
This fixes the debug build on the author's machine, where the flag `-Werror=unused-value` seems to imply `-Werror=unused-result`.

No related issue.