### PR TITLE
Reset conn_loss_widget visibilty for each new connect

### DIFF
--- a/client/clinet.cpp
+++ b/client/clinet.cpp
@@ -127,6 +127,9 @@ static int try_to_connect(const QUrl &url, char *errbuf, int errbufsize)
   if (client.conn.sock) {
     client.conn.sock->disconnect(client.conn.sock);
     client.conn.sock->deleteLater();
+    if (queen()) {
+      queen()->conn_loss->hide();
+    }
   }
   client.conn.used = true; // Now there will be a connection :)
 


### PR DESCRIPTION
For single player games it is not uncommon that at least the first try to connect the server fails because of a race condition, where the server has not yet created the local domain socket that the client tries to connect to.

The client retries to connect but the first error already triggered the show for `conn_loss_widget`. Without resetting the visibility before trying to connect the server, the widget is displayed permanently.

Fixes #2855.