### PR TITLE
Updates to master build system.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
     container:
       image: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup mirror
@@ -100,7 +100,7 @@ jobs:
     container:
       image: ubuntu:25.10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup mirror
@@ -142,7 +142,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: msys2/setup-msys2@v2
@@ -194,26 +194,34 @@ jobs:
           name: Windows-exe
           path: build/Windows-x86_64/Freeciv21-*.exe
 
-#  windows_clang_msvc:
-#    name: "Windows Clang"
-#    runs-on: windows-latest
-#    needs: clang-format
-#    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-#    env:
-#      VCPKG_ROOT: ${{github.workspace}}/vcpkg
-#      VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}/vcpkg/bincache
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#      - uses: lukka/run-vcpkg@v11
-#        name: Install dependencies
-#        with:
-#          vcpkgGitCommitId: b322364f06308bdd24823f9d8f03fe0cc86fd46f
-#      - name: Configure
-#        run: cmake -S . -B build --preset "windows-debug"
-#      - name: Building
-#        run: cmake --build build --config Debug
+  windows_clang_msvc:
+    name: "Windows Clang"
+    runs-on: windows-latest
+    needs: clang-format
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install VCPKG
+        uses: lukka/run-vcpkg@v11
+        with:
+          # 2026.03.18 Release
+          vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
+      # Ensure we have the most recent copy of the repo
+      - name: Update VCPKG
+        run: |
+          cd ${{ env.VCPKG_ROOT }}
+          git fetch
+          git pull origin master
+      - name: Configure
+        run: cmake -S . -B build --preset "windows-debug"
+      - name: Build
+        run: cmake --build build --config Debug
       #- name: Test
       #  run: cmake --build build --target test
 
@@ -222,9 +230,12 @@ jobs:
     runs-on: macos-15-intel
     needs: clang-format
     env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
       VCPKG_BUILD_TYPE: release
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install build tools
@@ -245,13 +256,22 @@ jobs:
       - uses: actions/setup-python@v5  # Workaround for #2069
         with:
           python-version: '3.11'
-      - uses: lukka/run-vcpkg@v11
-        name: Install dependencies
+      - name: Install VCPKG
+        uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: e9bb3f9e7ae3bf82a861a818e8a0f1187db399c0
-      - name: Configure and Build
+          # 2026.03.18 Release
+          vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
+      # Ensure we have the most recent copy of the repo
+      - name: Update VCPKG
+        run: |
+          cd ${{ env.VCPKG_ROOT }}
+          git fetch
+          git pull origin master
+      - name: Configure
         run: |
           cmake --preset fullrelease-macos -S .
+      - name: Build
+        run: |
           cmake --build build
       - name: Test
         run: |
@@ -261,10 +281,10 @@ jobs:
           cmake --build build --target install
       - name: Split Branch Name
         env:
-          BRANCH: ${{github.ref_name}}
+          BRANCH: ${{ github.ref_name }}
         id: split
         run: echo "fragment=${BRANCH##*/}" >> $GITHUB_OUTPUT
-      - name: Create DMG package
+      - name: Create App Image
         run: |
           cd build
           create-dmg \
@@ -277,22 +297,21 @@ jobs:
             --icon "Freeciv21.app" 200 190 \
             --hide-extension "Freeciv21.app" \
             --app-drop-link 400 185 \
-            "Freeciv21-${{steps.split.outputs.fragment}}-arm64-osx.dmg" \
+            "Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg" \
             "Freeciv21.app"
-          shasum -a 256 Freeciv21-${{steps.split.outputs.fragment}}-arm64-osx.dmg > Freeciv21-${{steps.split.outputs.fragment}}-arm64-osx.dmg.sha256
-      # 2025-08-20: jwrober - disabled while we get signing and other packaging fixed
-      #- name: Upload package
-      # -uses: softprops/action-gh-release@v2
-      #  if: startsWith(github.ref, 'refs/tags/')
-      #  with:
-      #    files: |
-      #      build/Freeciv21-*.dmg
-      #      build/Freeciv21-*.dmg.sha256
-      #- name: Upload a build
-      #  uses: actions/upload-artifact@v4
-      #  with:
-      #    name: macOS-dmg
-      #    path: build/Freeciv21-*.dmg
+          shasum -a 256 Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg > Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg.sha256
+      - name: Upload package
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/Freeciv21-*.dmg
+            build/Freeciv21-*.dmg.sha256
+      - name: Upload a build
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS-dmg
+          path: build/Freeciv21-*.dmg
 
   fedora:
     runs-on: ubuntu-latest
@@ -318,7 +337,7 @@ jobs:
             zlib-devel \
             libunwind-devel \
             elfutils-libs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Configure
         # Set ALWAYS_ROOT because the container user is root and creating an
         # unpriviledged user would be too much work.
@@ -341,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     # This has to be executed in a single step because freebsd-vm fails if run
     # twice.
     - name: Build, test, and install on FreeBSD
@@ -388,7 +407,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v22
       - run: nix flake check
       # TODO: We can add the build to a cache for others (see cachix.org)
@@ -400,7 +419,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Configure
@@ -423,7 +442,7 @@ jobs:
     name: clang-format Code Formatter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Run clang-format style check for C/C++

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -230,6 +230,8 @@ jobs:
       #    cat D:\a\freeciv21\freeciv21\build\vcpkg-manifest-install.log
       - name: Build
         run: cmake --build build --config Debug
+      - name: Install
+        run: cmake --build build --target install
       # ctest not compatible in visual studio with our build system
       #- name: Test
       #  run: cmake --build build --target test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Build
         run: |
           cmake --build build
+      # New DIO test segfaults starting Apr 2026 see #2869
       #- name: Test
       #  run: |
       #    cmake --build build --target test
@@ -172,9 +173,9 @@ jobs:
       - name: Build
         run: |
           cmake --build build
-      #- name: Test
-      #  run: |
-      #    cmake --build build --target test
+      - name: Test
+        run: |
+          cmake --build build --target test
       - name: Install
         run: |
           cmake --build build --target install
@@ -200,8 +201,9 @@ jobs:
     needs: clang-format
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
+      # Prevent build errors due to long paths
+      VCPKG_ROOT: D:/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: D:/vcpkg/bincache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -212,6 +214,7 @@ jobs:
         with:
           # 2026.03.18 Release
           vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
+          vcpkgDirectory: D:/vcpkg
       # Ensure we have the most recent copy of the repo
       - name: Update VCPKG
         run: |
@@ -220,8 +223,14 @@ jobs:
           git pull origin master
       - name: Configure
         run: cmake -S . -B build --preset "windows-debug"
+      #- name: Debug Configure Failure
+      #  if: failure()
+      #  run: |
+      #    cat D:\a\freeciv21\freeciv21\vcpkg\buildtrees\qtdeclarative\install-x64-windows-dbg-out.log
+      #    cat D:\a\freeciv21\freeciv21\build\vcpkg-manifest-install.log
       - name: Build
         run: cmake --build build --config Debug
+      # ctest not compatible in visual studio with our build system
       #- name: Test
       #  run: cmake --build build --target test
 
@@ -350,9 +359,15 @@ jobs:
       - name: Build
         run: |
           cmake --build build
-      - name: Test
-        run: |
-          cmake --build build --target test
+      # New DIO test segfaults starting Apr 2026 see #2869
+      #- name: Test
+      #  run: |
+      #    cmake --build build --target test
+      #- name: Debug Test Failure
+      #  if: failure()
+      #  run: |
+      #    build/test_dio -v2
+      #    cat build/Testing/Temporary/LastTest.log
       - name: Install
         run: |
           DESTDIR=$PWD/build/install cmake --build build --target install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,7 +189,7 @@ jobs:
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe.sha256
       - name: Upload a build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Windows-exe
           path: build/Windows-x86_64/Freeciv21-*.exe
@@ -308,7 +308,7 @@ jobs:
             build/Freeciv21-*.dmg
             build/Freeciv21-*.dmg.sha256
       - name: Upload a build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macOS-dmg
           path: build/Freeciv21-*.dmg
@@ -433,7 +433,7 @@ jobs:
         with:
           path: build
       - name: Upload a build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,6 +251,7 @@ jobs:
             cmake \
             create-dmg \
             libtool \
+            nasm \
             ninja \
             pkgconf
       - uses: actions/setup-python@v5  # Workaround for #2069

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-# We set the top end of minimum version to 4.3 to support a new policy that
-#   we set during Win32 install.
-# On other platforms (*nix, MacOS) we need to support older 3.21+ for the
-#   server and other components as a minimum.
+#
+# Root CMakeLists.txt for Freeciv21
+#
 cmake_minimum_required(VERSION 3.21...4.3 FATAL_ERROR)
 
 # Set vcpkg if exists. Used by MacOS and Visual Studio
@@ -81,7 +80,7 @@ include(FreecivHelpers)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # We do this after all targets with third-party code have been created, so
-#   the options only apply to code we own.
+# the options only apply to code we own.
 include(EnableCompilerWarnings)
 
 # Include subdirectories with the actual project definitions

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -110,33 +110,6 @@
       }
     },
     {
-      "name": "windows-release",
-      "description": "Target Windows with the Visual Studio development environment (Release)",
-      "generator": "Visual Studio 17 2022",
-      "binaryDir": "${sourceDir}/build-vs",
-      "installDir": "${sourceDir}/build-vs/install",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "FREECIV_ENABLE_TOOLS": "ON",
-        "FREECIV_ENABLE_SERVER": "ON",
-        "FREECIV_ENABLE_CLIENT": "ON",
-        "FREECIV_ENABLE_NLS": "ON",
-        "FREECIV_USE_VCPKG": "ON"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-clang-x64",
-          "enableClangTidyCodeAnalysis": true,
-          "enableMicrosoftCodeAnalysis": true
-        }
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
       "name": "windows-debug",
       "description": "Target Windows with the Visual Studio development environment (Debug)",
       "generator": "Visual Studio 17 2022",
@@ -175,12 +148,9 @@
       "targets": "install"
     },
     {
-      "name": "fullrelease-windows",
-      "configurePreset": "windows-release"
-    },
-    {
       "name": "debug-windows",
-      "configurePreset": "windows-debug"
+      "configurePreset": "windows-debug",
+      "targets": "install"
     }
   ]
 }

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -44,7 +44,7 @@ if(WIN32 OR MSYS OR WIN32)
     ${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-server.ico
     ${CMAKE_SOURCE_DIR}/dist/windows/freeciv21-server.cmd
     ${CMAKE_SOURCE_DIR}/dist/windows/qt.conf
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT freeciv21)
 endif()
 
@@ -55,7 +55,7 @@ if(MSYS OR MINGW)
     FILES
     ${CLANG_PATH}/libcrypto-3-x64.dll
     ${CLANG_PATH}/libssl-3-x64.dll
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT freeciv21)
 
   # This allows us to determine the external libraries we need to include at install time

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -35,7 +35,7 @@ install(
   COMPONENT freeciv21)
 
 # Common installation for all Win32 et al platforms
-if(WIN32 OR MSYS OR WIN32)
+if(MSYS OR WIN32)
   # Custom command files to run the applications
   install(
     FILES

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -1,6 +1,6 @@
-#############################################
+#
 # Installation configuration for Freeciv21
-#############################################
+#
 
 # Always install the base documentation
 install(
@@ -35,7 +35,7 @@ install(
   COMPONENT freeciv21)
 
 # Common installation for all Win32 et al platforms
-if(WIN32 OR MSYS)
+if(WIN32 OR MSYS OR WIN32)
   # Custom command files to run the applications
   install(
     FILES
@@ -44,7 +44,7 @@ if(WIN32 OR MSYS)
     ${CMAKE_SOURCE_DIR}/data/icons/128x128/freeciv21-server.ico
     ${CMAKE_SOURCE_DIR}/dist/windows/freeciv21-server.cmd
     ${CMAKE_SOURCE_DIR}/dist/windows/qt.conf
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21)
 endif()
 
@@ -55,7 +55,7 @@ if(MSYS OR MINGW)
     FILES
     ${CLANG_PATH}/libcrypto-3-x64.dll
     ${CLANG_PATH}/libssl-3-x64.dll
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21)
 
   # This allows us to determine the external libraries we need to include at install time
@@ -66,7 +66,7 @@ if(MSYS OR MINGW)
 
     # We need the CLANG_PATH variable that isn't available in a install(CODE ) block.
     # So we find the llvm-objdump.exe and use its path to set
-    string(REGEX REPLACE "llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
+    string(REGEX REPLACE "/llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
 
     # This new policy was defined in cmake 4.3. We force adoption of new
     # filepath normalization.
@@ -93,7 +93,7 @@ if(MSYS OR MINGW)
   # runtime files to the appropriate directory for installation
   install(CODE [[
     message(STATUS "Collecting Qt dependencies for freeciv21 GUI executables...")
-    string(REGEX REPLACE "llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
+    string(REGEX REPLACE "/llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
 
     # Run Qt's windeployqt6.exe to find the required DLLs for the GUI apps.
     # It also copies the files we need to where we need them.
@@ -106,26 +106,25 @@ if(MSYS OR MINGW)
 
 elseif(WIN32)
   # The Visual Studio generator places all files and associated DLL libraries
-  #  into a build directory. So we just grab those for install.
+  # into a build directory. So we just grab those for install based on build
+  # type. Debug builds are only supported at this time.
   install(
     DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21
     FILES_MATCHING PATTERN *.dll PATTERN *.pdb)
-
-  # Install the Qt framework DLL's'
   install(
-    DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/plugins/
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/Qt6/plugins/
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21
-    FILES_MATCHING PATTERN *.dll)
+    FILES_MATCHING PATTERN *.dll PATTERN *.pdb)
 
   # Grab some files that get missed
   install(
     FILES
     ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2.dll
     ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2_mixer.dll
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21)
 endif()
 

--- a/server/console.cpp
+++ b/server/console.cpp
@@ -11,10 +11,11 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
-#include <fc_config.h>
+// self
+#include "console.h"
 
-#include <cstdarg>
-#include <cstdio>
+// generated
+#include <fc_config.h>
 
 // utility
 #include "fcbacktrace.h"
@@ -23,14 +24,18 @@
 #include "log.h"
 #include "support.h"
 
-// ms clang wants readline to included here
-#include <readline/readline.h>
 // common
 #include "game.h"
 
+// deps
+#include <readline/readline.h>
+
 // server
-#include "console.h"
 #include "notify.h"
+
+// std
+#include <cstdarg>
+#include <cstdio>
 
 static bool console_show_prompt = false;
 static bool console_prompt_is_showing = false;

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -11,34 +11,11 @@
     \_____/ /                     If not, see https://www.gnu.org/licenses/.
       \____/        ********************************************************/
 
+// self
+#include "stdinhand.h"
+
+// generated
 #include <fc_config.h>
-
-#include <algorithm>
-#include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <set>
-#include <string>
-
-// Qt
-#include <QCoreApplication>
-#include <QRegularExpression>
-
-#include <readline/readline.h>
-
-// utility
-#include "astring.h"
-#include "bitvector.h"
-#include "connection.h"
-#include "fciconv.h"
-#include "fcintl.h"
-#include "log.h"
-#include "registry.h"
-#include "section_file.h"
-#include "shared.h"
-#include "support.h" // fc__attribute, bool type, etc.
-#include "timing.h"
 
 // common
 #include "chat.h"
@@ -55,8 +32,28 @@
 #include "unitlist.h"
 #include "version.h"
 
+// utility
+#include "astring.h"
+#include "bitvector.h"
+#include "connection.h"
+#include "fciconv.h"
+#include "fcintl.h"
+#include "log.h"
+#include "registry.h"
+#include "section_file.h"
+#include "shared.h"
+#include "support.h" // fc__attribute, bool type, etc.
+#include "timing.h"
+
+// ai
+#include "difficulty.h"
+
+// deps
+#include <readline/readline.h>
+
 // server
 #include "aiiface.h"
+#include "civ2.h"
 #include "commands.h"
 #include "connecthand.h"
 #include "diplhand.h"
@@ -67,6 +64,9 @@
 #include "plrhand.h"
 #include "ruleset.h"
 #include "sanitycheck.h"
+#include "savemain.h"
+#include "script_fcdb.h"
+#include "script_server.h"
 #include "server_connection.h"
 #include "settings.h"
 #include "srv_log.h"
@@ -74,18 +74,19 @@
 #include "techtools.h"
 #include "voting.h"
 
-/* server/savegame */
-#include "civ2.h"
-#include "savemain.h"
 
-/* server/scripting */
-#include "script_fcdb.h"
-#include "script_server.h"
+// Qt
+#include <QCoreApplication>
+#include <QRegularExpression>
 
-// ai
-#include "difficulty.h"
-
-#include "stdinhand.h"
+// std
+#include <algorithm>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <set>
+#include <string>
 
 #define OPTION_NAME_SPACE 25
 #define REG_EXP "\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)"

--- a/server/stdinhand.cpp
+++ b/server/stdinhand.cpp
@@ -74,7 +74,6 @@
 #include "techtools.h"
 #include "voting.h"
 
-
 // Qt
 #include <QCoreApplication>
 #include <QRegularExpression>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,23 +1,37 @@
 {
   "name": "freeciv21",
-  "version-string": "3.2.0",
-  "builtin-baseline": "e9bb3f9e7ae3bf82a861a818e8a0f1187db399c0",
+  "version-string": "3.2",
+  "builtin-baseline": "77df67cfff9c12ccfdb52284e07c87c75092f723",
   "dependencies": [
-    "qtbase",
-    "qtmultimedia",
-    "qtsvg",
-    "openssl",
-    "lua",
     {
       "name": "gettext",
-      "features": [ "tools" ]
+      "features": [
+        "tools"
+      ]
     },
+    "lua",
     "kf6archive",
-    "sdl2-mixer",
-    "sqlite3",
+    "openssl",
+    "qtbase",
+    "qtmultimedia",
+    {
+      "name": "qttools",
+      "features": [
+        "linguist"
+      ]
+    },
+    "qtsvg",
     {
       "name": "readline",
       "platform": "windows"
+    },
+    "sdl2-mixer",
+    "sqlite3"
+  ],
+  "overrides": [
+    {
+      "name": "lua",
+      "version": "5.4.8"
     }
   ]
 }


### PR DESCRIPTION
This PR started as an effort to get the Visual Studio CI working again. After spending time troubleshooting the macOS CI in `stable` and also doing some cleanup to the build system on both `master` and `stable`, this PR morphed a bit to a bigger update.

- Fixes Visual Studio -- Required header reorg in two server files to fix a locale header macro expansion issue, plus pinning lua in vcpkg to 5.4.8 as in `stable` for consistency.
- Updates build.yaml to re-enable to Visual Studio CI, plus brings over knowledge gained while working on the macOS vcpkg stuff in `stable` and since I was in there I also updated a collection of actions to use node-24 as node-20 is going EOL in a few months. NOTE: snapcore action has not been updated to a v2 or something to support node-24 as of yet.
- Removed Visual Studio release from the preset. It turns out that VS just doesn't want to support a plain release, everything requires some form of a debug library. Found a number of articles online about it. Since we don't ever build/package with VS and we just offer as a dev env, I figured it wasn't worth worrying about.

I don't think there is a related issue ticket for this work.

See: https://github.com/jwrober/freeciv21/actions/runs/24040687265

Closes #2122 