### PR TITLE
[stable] Update build system to emulate master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on:
   push: {}
   pull_request: {}
   schedule:
-    - cron: "0 5 * * MON"
+    - cron: "0 12 * * MON"
   workflow_dispatch: {}
 
 concurrency:
@@ -24,7 +24,7 @@ jobs:
             build_type: RelWithDebInfo
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install GCC
@@ -92,7 +92,7 @@ jobs:
     needs: clang-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -121,47 +121,51 @@ jobs:
           cmake --build build --target test
 
   windows:
-    name: "Windows MSYS2 (gcc)"
+    name: "Windows MSYS2 (clang)"
     runs-on: windows-latest
     needs: clang-format
     defaults:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: msys2/setup-msys2@v2
+      - name: Install Dependencies
+        uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           update: true
           install: |
             git
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-nsis
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-libunwind
-            mingw-w64-x86_64-readline
-            mingw-w64-x86_64-lua
-            mingw-w64-x86_64-SDL2_mixer
-            mingw-w64-x86_64-qt5
-            mingw-w64-x86_64-qt5-svg
-            mingw-w64-x86_64-karchive-qt5
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-cmake
+            mingw-w64-clang-x86_64-lua
+            mingw-w64-clang-x86_64-nsis
+            mingw-w64-clang-x86_64-readline
+            mingw-w64-clang-x86_64-SDL2_mixer
+            mingw-w64-clang-x86_64-qt5-base
+            mingw-w64-clang-x86_64-qt5-svg
+            mingw-w64-clang-x86_64-qt5-tools
       - name: Configure
         run: |
-          export PATH=/mingw64/bin:${PATH}
-          export MSYSTEM=MINGW64
-          export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+          export PATH=/clang64/bin:${PATH}
+          export MSYSTEM=CLANG64
+          export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/clang64/lib/pkgconfig:/clang64/share/pkgconfig
+          # self host kf5archive
+          wget -O qt5.tar.gz "https://drive.usercontent.google.com/download?export=download&id=1fOAGjomXKZcRRV8MTYUbDvozkQESWvPk&confirm=t"
+          pacman -U --noconfirm ./mingw-w64-clang-x86_64-karchive-qt5-5.116.0-1-any.pkg.tar.zst
+          # now configure
           cmake . -B build -G Ninja \
            -DCMAKE_INSTALL_PREFIX=$PWD/build/install \
            -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
           cmake --build build
-      #- name: Test
-      #  run: |
-      #    cmake --build build --target test
+      - name: Test
+        run: |
+          cmake --build build --target test
       - name: Install
         run: |
           cmake --build build --target install
@@ -176,7 +180,7 @@ jobs:
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe
             build/Windows-x86_64/Freeciv21-*-Windows-x86_64.exe.sha256
       - name: Upload a build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Windows-exe
           path: build/Windows-x86_64/Freeciv21-*.exe
@@ -186,17 +190,20 @@ jobs:
     runs-on: windows-latest
     needs: clang-format
     env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
+      # Prevent build errors due to long paths
+      VCPKG_ROOT: D:/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: D:/vcpkg/bincache
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: lukka/run-vcpkg@v11
-        name: Install dependencies
+      - name: Install VCPKG
+        uses: lukka/run-vcpkg@v11
         with:
           # 2026.03.18 Release
           vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
+          vcpkgDirectory: D:/vcpkg
       # Ensure we have the most recent copy of the repo
       - name: Update VCPKG
         run: |
@@ -205,8 +212,11 @@ jobs:
           git pull origin master
       - name: Configure
         run: cmake -S . -B build --preset "windows-debug"
-      - name: Building
+      - name: Build
         run: cmake --build build --config Debug
+      - name: Install
+        run: cmake --build build --target install
+      # ctest not compatible in visual studio with our build system
       #- name: Test
       #  run: cmake --build build --target test
 
@@ -219,7 +229,7 @@ jobs:
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
       VCPKG_BUILD_TYPE: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install build tools
@@ -346,7 +356,7 @@ jobs:
             zlib-devel \
             libunwind-devel \
             elfutils-libs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Configure
         # Set ALWAYS_ROOT because the container user is root and creating an
         # unpriviledged user would be too much work.
@@ -369,7 +379,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     # This has to be executed in a single step because freebsd-vm fails if run
     # twice.
     - name: Build, test, and install on FreeBSD
@@ -420,7 +430,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v22
       - run: nix flake check
       # TODO: We can add the build to a cache for others (see cachix.org)
@@ -433,7 +443,7 @@ jobs:
     needs: clang-format
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Configure
@@ -447,7 +457,7 @@ jobs:
         with:
           path: build
       - name: Upload a build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
@@ -456,7 +466,7 @@ jobs:
     name: clang-format Code Formatter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Run clang-format style check for C/C++

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -230,7 +230,8 @@ jobs:
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
       VCPKG_BUILD_TYPE: release
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install build tools
@@ -251,8 +252,8 @@ jobs:
       - uses: actions/setup-python@v5  # Workaround for #2069
         with:
           python-version: '3.11'
-      - uses: lukka/run-vcpkg@v11
-        name: Install dependencies
+      - name: Install VCPKG
+        uses: lukka/run-vcpkg@v11
         with:
           # 2026.03.18 Release
           vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
@@ -262,9 +263,11 @@ jobs:
           cd ${{ env.VCPKG_ROOT }}
           git fetch
           git pull origin master
-      - name: Configure and Build
+      - name: Configure
         run: |
           cmake --preset fullrelease-macos -S .
+      - name: Build
+        run: |
           cmake --build build
       - name: Install
         run: |
@@ -277,22 +280,9 @@ jobs:
           BRANCH: ${{ github.ref_name }}
         id: split
         run: echo "fragment=${BRANCH##*/}" >> $GITHUB_OUTPUT
-      - name: Create App Bundle
+      - name: Create App Image
         run: |
           cd build
-          mkdir -pv Freeciv21.app/Contents/MacOS Freeciv21.app/Contents/Resources/doc
-          cp -v dist/Info.plist Freeciv21.app/Contents/
-          cp -rv install/share/doc/freeciv21/* Freeciv21.app/Contents/Resources/doc
-          cp -rv install/share/freeciv21/* Freeciv21.app/Contents/Resources
-          cp -v install/bin/freeciv21-* Freeciv21.app/Contents/MacOS
-          mkdir client.iconset
-          cp -v ../data/icons/16x16/freeciv21-client.png client.iconset/icon_16x16.png
-          cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_16x16@2x.png
-          cp -v ../data/icons/32x32/freeciv21-client.png client.iconset/icon_32x32.png
-          cp -v ../data/icons/64x64/freeciv21-client.png client.iconset/icon_32x32@2x.png
-          cp -v ../data/icons/128x128/freeciv21-client.png client.iconset/icon_128x128.png
-          iconutil -c icns client.iconset
-          cp -v client.icns Freeciv21.app/Contents/Resources
           #
           # The currently available github macos runners have a bug that cause occasional create-dmg failures
           # with the message "hdiutil: create failed - Resource busy". We do a retry loop as a workaround.
@@ -304,12 +294,12 @@ jobs:
             --volname "Freeciv21 Game Installer" \
             --volicon "client.icns" \
             --window-pos 200 120 \
-            --window-size 800 400 \
+            --window-size 600 400 \
             --icon-size 128 \
             --icon "Freeciv21.app" 200 190 \
             --hide-extension "Freeciv21.app" \
-            --app-drop-link 600 185 \
-            "Freeciv21-${{ steps.split.outputs.fragment }}.dmg" \
+            --app-drop-link 400 185 \
+            "Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg" \
             "Freeciv21.app"
           do
             if [ $i -eq $max_tries ]
@@ -320,7 +310,7 @@ jobs:
             sleep 60
             ((i++))
           done
-          shasum -a 256 Freeciv21-${{ steps.split.outputs.fragment }}.dmg > Freeciv21-${{ steps.split.outputs.fragment }}.dmg.sha256
+          shasum -a 256 Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg > Freeciv21-${{ steps.split.outputs.fragment }}-x64-osx.dmg.sha256
       - name: Upload package
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,6 +155,7 @@ jobs:
           export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/clang64/lib/pkgconfig:/clang64/share/pkgconfig
           # self host kf5archive
           wget -O qt5.tar.gz "https://drive.usercontent.google.com/download?export=download&id=1fOAGjomXKZcRRV8MTYUbDvozkQESWvPk&confirm=t"
+          tar xf qt5.tar.gz
           pacman -U --noconfirm ./mingw-w64-clang-x86_64-karchive-qt5-5.116.0-1-any.pkg.tar.zst
           # now configure
           cmake . -B build -G Ninja \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
-# Win32 et al requires cmake version 3.16 because we use a newer command
-#   "file(GET_RUNTIME_DEPENDENCIES ..." that is only available at v3.16+
-# On other platforms (*nix, MacOS) we need to support older 3.12+ for the
-#   server and other components
-cmake_minimum_required(VERSION 3.21...3.22 FATAL_ERROR)
+#
+# Root CMakeLists.txt for Freeciv21
+#
+cmake_minimum_required(VERSION 3.21...4.3 FATAL_ERROR)
 
 # Set vcpkg if exists. Used by MacOS and Visual Studio
 if(DEFINED ENV{VCPKG_ROOT} AND FREECIV_USE_VCPKG)
@@ -63,11 +62,11 @@ project(freeciv21 VERSION ${FREECIV21_VERSION} LANGUAGES C CXX)
 # Gather all the tailored settings we need for Windows builds early.
 if(WIN32 OR MSYS OR MINGW)
   # We need to alter the out of box values of these variables for Win32 et al builds
-  set(CMAKE_INSTALL_DATAROOTDIR ".")
   set(CMAKE_INSTALL_BINDIR ".")
-  set(PROJECT_NAME "data")
+  set(CMAKE_INSTALL_DATAROOTDIR ".")
   set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/")
-  get_filename_component(MINGW_PATH ${CMAKE_CXX_COMPILER} PATH)
+  set(PROJECT_NAME "data")
+  get_filename_component(CLANG_PATH ${CMAKE_CXX_COMPILER} PATH)
 endif()
 
 add_compile_definitions(PUBLIC $<$<CONFIG:Debug>:FREECIV_DEBUG>)
@@ -80,7 +79,7 @@ include(FreecivHelpers)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # We do this after all targets with third-party code have been created, so
-#   the options only apply to code we own.
+# the options only apply to code we own.
 include(EnableCompilerWarnings)
 
 # Include subdirectories with the actual project definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Root CMakeLists.txt for Freeciv21
 #
-cmake_minimum_required(VERSION 3.21...4.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21...3.28 FATAL_ERROR)
 
 # Set vcpkg if exists. Used by MacOS and Visual Studio
 if(DEFINED ENV{VCPKG_ROOT} AND FREECIV_USE_VCPKG)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,33 +93,6 @@
       }
     },
     {
-      "name": "windows-release",
-      "description": "Target Windows with the Visual Studio development environment (Release)",
-      "generator": "Visual Studio 17 2022",
-      "binaryDir": "${sourceDir}/build-vs",
-      "installDir": "${sourceDir}/build-vs/install",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "FREECIV_ENABLE_TOOLS": "ON",
-        "FREECIV_ENABLE_SERVER": "ON",
-        "FREECIV_ENABLE_CLIENT": "ON",
-        "FREECIV_ENABLE_NLS": "ON",
-        "FREECIV_USE_VCPKG": "ON"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-clang-x64",
-          "enableClangTidyCodeAnalysis": true,
-          "enableMicrosoftCodeAnalysis": true
-        }
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
       "name": "windows-debug",
       "description": "Target Windows with the Visual Studio development environment (Debug)",
       "generator": "Visual Studio 17 2022",
@@ -156,10 +129,6 @@
       "name": "fullrelease-macos",
       "configurePreset": "fullrelease-macos",
       "targets": "install"
-    },
-    {
-      "name": "fullrelease-windows",
-      "configurePreset": "windows-release"
     },
     {
       "name": "debug-windows",

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -273,16 +273,6 @@ if(UNIX AND NOT APPLE)
   endif(FREECIV_ENABLE_RULEDIT)
 endif(UNIX AND NOT APPLE)
 
-if(APPLE)
-  # Use Auto Revision variables to convert some templates to real files at build
-  # time. Avoid overwriting if the version didn't change.
-  configure_file("dist/Info.plist.in" dist/Info.plist.new
-                @ONLY NEWLINE_STYLE UNIX)
-  file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist.new"
-                "${CMAKE_BINARY_DIR}/dist/Info.plist"
-      ONLY_IF_DIFFERENT)
-endif(APPLE)
-
 # We grab the Libertinus Font package online for the client
 if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
   message(STATUS "Downloading Libertinus Font Package")
@@ -318,3 +308,64 @@ if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
   endif(MSYS OR WIN32)
 endif()
 
+if(APPLE)
+  # Use Auto Revision variables to convert some templates to real files at build
+  # time. Avoid overwriting if the version didn't change.
+  configure_file("dist/Info.plist.in" dist/Info.plist.new
+                @ONLY NEWLINE_STYLE UNIX)
+  file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist.new"
+                "${CMAKE_BINARY_DIR}/dist/Info.plist"
+      ONLY_IF_DIFFERENT)
+
+  install(CODE [[
+    message(STATUS "Creating Freeciv21 App Bundle for macOS...")
+
+    # Check to see if the app bundle was already created in a previous run
+    if(EXISTS "${CMAKE_BINARY_DIR}/Freeciv21.app")
+      message(STATUS "App Bundle exists, removing...")
+      file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/Freeciv21.app")
+      file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/client.iconset")
+      file(REMOVE "${CMAKE_BINARY_DIR}/client.icns")
+      file(GLOB DMG_FILES "${CMAKE_BINARY_DIR}/Freeciv21*.dmg*")
+      file(REMOVE ${DMG_FILES})
+    endif()
+
+    # Create app bundle
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/MacOS")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/doc")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/dist/Info.plist"
+                   "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Info.plist")
+    file(COPY "${CMAKE_INSTALL_PREFIX}/bin/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/MacOS/"
+      FILES_MATCHING PATTERN "Freeciv21-*"
+    )
+    file(COPY "${CMAKE_INSTALL_PREFIX}/share/freeciv21/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/"
+      FILES_MATCHING PATTERN "*"
+    )
+    file(COPY "${CMAKE_INSTALL_PREFIX}/share/doc/freeciv21/"
+      DESTINATION "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/doc/"
+      FILES_MATCHING PATTERN "*"
+    )
+
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/client.iconset")
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/16x16/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16.png")
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/32x32/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_16x16@2x.png")
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/32x32/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32.png")
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/64x64/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_32x32@2x.png")
+    file(COPY_FILE "${CMAKE_INSTALL_PREFIX}/share/freeciv21/icons/128x128/freeciv21-client.png"
+                   "${CMAKE_BINARY_DIR}/client.iconset/icon_128x128.png")
+    execute_process(
+      COMMAND iconutil --convert icns "${CMAKE_BINARY_DIR}/client.iconset")
+    file(COPY_FILE "${CMAKE_BINARY_DIR}/client.icns"
+                   "${CMAKE_BINARY_DIR}/Freeciv21.app/Contents/Resources/client.icns")
+    message(STATUS "Freeciv21 App Bundle successfully created. Open from '${CMAKE_BINARY_DIR}' to play.")
+    ]] COMPONENT freeciv21)
+endif(APPLE)

--- a/cmake/FreecivInstall.cmake
+++ b/cmake/FreecivInstall.cmake
@@ -1,6 +1,6 @@
-#############################################
+#
 # Installation configuration for Freeciv21
-#############################################
+#
 
 # Always install the base documentation
 install(
@@ -35,7 +35,7 @@ install(
   COMPONENT freeciv21)
 
 # Common installation for all Win32 et al platforms
-if(WIN32 OR MSYS OR MINGW)
+if(MSYS OR WIN32)
   # Custom command files to run the applications
   install(
     FILES
@@ -51,21 +51,12 @@ endif()
 # MSYS2 and MINGW specific installation
 if(MSYS OR MINGW)
   # Install OpenSSL library, not found with GET_RUNTIME_DEPENDENCIES
-  if("$ENV{MSYSTEM}" STREQUAL "MINGW32")
-    install(
-      FILES
-      ${MINGW_PATH}/libcrypto-3.dll
-      ${MINGW_PATH}/libssl-3.dll
-      DESTINATION ${CMAKE_INSTALL_BINDIR}
-      COMPONENT freeciv21)
-  else()
-    install(
-      FILES
-      ${MINGW_PATH}/libcrypto-3-x64.dll
-      ${MINGW_PATH}/libssl-3-x64.dll
-      DESTINATION ${CMAKE_INSTALL_BINDIR}
-      COMPONENT freeciv21)
-  endif()
+  install(
+    FILES
+    ${CLANG_PATH}/libcrypto-3-x64.dll
+    ${CLANG_PATH}/libssl-3-x64.dll
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT freeciv21)
 
   # This allows us to determine the external libraries we need to include at install time
   #   dynamically instead of doing it manually.
@@ -74,16 +65,20 @@ if(MSYS OR MINGW)
     set(CMAKE_GET_RUNTIME_DEPENDENCIES_TOOL objdump)
 
     # Take a variable that is available at "install" time and repurpose
-    string(REGEX REPLACE "objdump.exe" "" MINGW_PATH ${CMAKE_OBJDUMP})
+    string(REGEX REPLACE "/llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
+
+    # This new policy was defined in cmake 4.3. We force adoption of new
+    # filepath normalization.
+    cmake_policy(SET CMP0207 NEW)
 
     # Function to analyze the third party dll files linked to the exe's
-    #   Uses the repurposed variable from above to tell the function where
-    #   the dll files are located. Ignores dll's that come with Windows.
+    # Uses the repurposed variable from above to tell the function where
+    # the dll files are located. Ignores dll's that come with Windows.
     file(GLOB exes "${CMAKE_INSTALL_PREFIX}/freeciv21-*.exe")
 	  file(GET_RUNTIME_DEPENDENCIES
       RESOLVED_DEPENDENCIES_VAR r_deps
       UNRESOLVED_DEPENDENCIES_VAR u_deps
-      DIRECTORIES ${MINGW_PATH}
+      DIRECTORIES ${CLANG_PATH}
       PRE_EXCLUDE_REGEXES "^api-ms-*"
       POST_EXCLUDE_REGEXES "C:[\\\\/][Ww][Ii][Nn][Dd][Oo][Ww][Ss][\\\\/].*"
       EXECUTABLES ${exes}
@@ -93,18 +88,18 @@ if(MSYS OR MINGW)
     ]] COMPONENT freeciv21)
 
   # Qt5 Plugins and required DLLs
-  #   Before installation, run a series of commands that copy each of the Qt
-  #   runtime files to the appropriate directory for installation
+  # Before installation, run a series of commands that copy each of the Qt
+  # runtime files to the appropriate directory for installation
   install(CODE [[
 
     message(STATUS "Collecting Qt dependencies for freeciv21 GUI executables...")
 
     # Take a variable that is available at "install" time and repurpose
-    string(REGEX REPLACE "objdump.exe" "" MINGW_PATH ${CMAKE_OBJDUMP})
+    string(REGEX REPLACE "/llvm-objdump.exe" "" CLANG_PATH ${CMAKE_OBJDUMP})
 
     # Run Qt's windeployqt.exe to find the required DLLs for the GUI apps.
     execute_process(
-      COMMAND ${MINGW_PATH}/windeployqt-qt5.exe --no-translations --no-virtualkeyboard --no-compiler-runtime
+      COMMAND ${CLANG_PATH}/windeployqt-qt5.exe --no-translations --no-virtualkeyboard --no-compiler-runtime
         --no-webkit2 --no-angle --no-opengl-sw --list mapping ${CMAKE_INSTALL_PREFIX}
       OUTPUT_VARIABLE _output
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -113,28 +108,29 @@ if(MSYS OR MINGW)
     message(STATUS "Installing Qt library dependencies for freeciv21 GUI executables...")
     separate_arguments(_files WINDOWS_COMMAND ${_output})
       while(_files)
-          list(GET _files 0 _src)
-          list(GET _files 1 _dest)
-          execute_process(
-            COMMAND cp ${_src} "${CMAKE_INSTALL_PREFIX}/${_dest}"
-          )
-          message(STATUS "Installing: ${CMAKE_INSTALL_PREFIX}/${_dest}")
-          list(REMOVE_AT _files 0 1)
+        list(GET _files 0 _src)
+        list(GET _files 1 _dest)
+        execute_process(
+          COMMAND cp ${_src} "${CMAKE_INSTALL_PREFIX}/${_dest}"
+        )
+        message(STATUS "Installing: ${CMAKE_INSTALL_PREFIX}/${_dest}")
+        list(REMOVE_AT _files 0 1)
       endwhile()
     ]] COMPONENT freeciv21)
+
 elseif(WIN32)
   # The Visual Studio generator places all files and associated DLL libraries
-  #  into a build directory. So we just grab those for install.
+  # into a build directory. So we just grab those for install.
   install(
     DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21
     FILES_MATCHING PATTERN *.dll PATTERN *.pdb)
 
   # Install the Qt framework DLL's'
   install(
     DIRECTORY ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/plugins/
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21
     FILES_MATCHING PATTERN *.dll)
 
@@ -143,7 +139,7 @@ elseif(WIN32)
     FILES
     ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2.dll
     ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2_mixer.dll
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT freeciv21)
 endif()
 
@@ -305,7 +301,7 @@ if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
     URL_HASH SHA256=2cce08507441d8ae7b835cfe51fb643ad5d9f6b44db4360c4e244f0e474a72f6
   )
 
-  if(MSYS OR MINGW OR WIN32)
+  if(MSYS OR WIN32)
     install(
       DIRECTORY ${CMAKE_BINARY_DIR}/src/Libertinus
       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/fonts
@@ -319,6 +315,6 @@ if(FREECIV_ENABLE_CLIENT AND FREECIV_DOWNLOAD_FONTS)
       COMPONENT freeciv21
       FILES_MATCHING PATTERN *.otf PATTERN *.txt
     )
-  endif(MSYS OR MINGW OR WIN32)
+  endif(MSYS OR WIN32)
 endif()
 


### PR DESCRIPTION
As mentioned in #2861, bringing more standardization across `master` and `stable` in our build system. This PR covers all the CI components except for macOS, which will be step 2 (of 2) after this is merged.

One thing that does diverge between the two is we now self-host the `kf5archive` package for the MSYS2 environment as it has been removed from mainline repositories. The downloaded `gz` also has the rest of qt5 in case those packages are also removed in the future.