### PR TITLE
Fix a new-delete-type-mismatch found by ASAN

### DIFF
--- a/common/networking/connection.h
+++ b/common/networking/connection.h
@@ -146,6 +146,12 @@ struct connection {
 
   /// Increases for every packet sent.
   int last_request_id_used;
+
+  /*
+   * Declare a virtual default destructor to make sure that derived
+   * struct constructors get called too.
+   */
+  virtual ~connection() = default;
 };
 
 typedef void (*conn_close_fn_t)(struct connection *pconn);


### PR DESCRIPTION
No related issue. While testing an ASAN build I noticed a `new-delete-type-mismatch` error when ending a game and fixed it.

```
=================================================================
==16717==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x518000012080 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   792 bytes;
  size of the deallocated type: 784 bytes.
    #0 0x000000714662 in operator delete(void*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x0000008668e8 in client_remove_cli_conn(connection*) /home/blabber/data/hacks/freeciv21/client/client_main.cpp:952:3
    #2 0x000000863f55 in client_remove_all_cli_conn() /home/blabber/data/hacks/freeciv21/client/client_main.cpp:965:5
    #3 0x000000865691 in set_client_state(client_states) /home/blabber/data/hacks/freeciv21/client/client_main.cpp:808:7
    #4 0x000000877205 in close_socket_nomessage(connection*) /home/blabber/data/hacks/freeciv21/client/clinet.cpp:64:3
    #5 0x000000877205 in disconnect_from_server() /home/blabber/data/hacks/freeciv21/client/clinet.cpp:239:3
    #6 0x000000992575 in popup_quit_dialog()::$_0::operator()() const /home/blabber/data/hacks/freeciv21/client/gui_main.cpp:304:7
    #7 0x000000992575 in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, popup_quit_dialog()::$_0>::call(popup_quit_dialog()::$_0&, void**)::'lambda'()::operator()() const /usr/local/include/qt6/QtCore/qobjectdefs_impl.h:116:24
    #8 0x000000992575 in void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, popup_quit_dialog()::$_0>::call(popup_quit_dialog()::$_0&, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, popup_quit_dialog()::$_0>::call(popup_quit_dialog()::$_0&, void**)::'lambda'()&&) /usr/local/include/qt6/QtCore/qobjectdefs_impl.h:65:17
    #9 0x000000992575 in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long>, QtPrivate::List<>, void, popup_quit_dialog()::$_0>::call(popup_quit_dialog()::$_0&, void**) /usr/local/include/qt6/QtCore/qobjectdefs_impl.h:115:13
    #10 0x000000992575 in void QtPrivate::FunctorCallable<popup_quit_dialog()::$_0>::call<QtPrivate::List<>, void>(popup_quit_dialog()::$_0&, void*, void**) /usr/local/include/qt6/QtCore/qobjectdefs_impl.h:337:13
    #11 0x000000992575 in QtPrivate::QCallableObject<popup_quit_dialog()::$_0, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/local/include/qt6/QtCore/qobjectdefs_impl.h:547:21
    #12 0x0008035847a9  (/usr/local/lib/qt6/libQt6Core.so.6+0x3847a9)
    #13 0x000801f82f9a in QDialog::done(int) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x582f9a)
    #14 0x000801fb3830  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x5b3830)
    #15 0x0008035847a9  (/usr/local/lib/qt6/libQt6Core.so.6+0x3847a9)
    #16 0x000801f051dc  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x5051dc)
    #17 0x0008035847a9  (/usr/local/lib/qt6/libQt6Core.so.6+0x3847a9)
    #18 0x000801e30ad6  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x430ad6)
    #19 0x000801e30966  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x430966)
    #20 0x000801e31afd in QAbstractButton::mouseReleaseEvent(QMouseEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x431afd)
    #21 0x000801d5ed28 in QWidget::event(QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x35ed28)
    #22 0x000801d01e87 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x301e87)
    #23 0x000801d04417 in QApplication::notify(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x304417)
    #24 0x000803526c28 in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Core.so.6+0x326c28)
    #25 0x000801d02551 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x302551)
    #26 0x000801d7930f  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x37930f)
    #27 0x000801d78358  (/usr/local/lib/qt6/libQt6Widgets.so.6+0x378358)
    #28 0x000801d01e87 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x301e87)
    #29 0x000801d02f05 in QApplication::notify(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x302f05)
    #30 0x000803526c28 in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Core.so.6+0x326c28)
    #31 0x000802b3c181 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (/usr/local/lib/qt6/libQt6Gui.so.6+0x33c181)
    #32 0x000802ba992a in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/local/lib/qt6/libQt6Gui.so.6+0x3a992a)
    #33 0x00080308cfe3  (/usr/local/lib/qt6/libQt6Gui.so.6+0x88cfe3)
    #34 0x000804ac6080  (/usr/local/lib/libglib-2.0.so.0+0xef080)
    #35 0x000804ac6515  (/usr/local/lib/libglib-2.0.so.0+0xef515)
    #36 0x000804ac65b5 in g_main_context_iteration (/usr/local/lib/libglib-2.0.so.0+0xef5b5)
    #37 0x0008037d98a1 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/local/lib/qt6/libQt6Core.so.6+0x5d98a1)
    #38 0x000803530965 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/local/lib/qt6/libQt6Core.so.6+0x330965)
    #39 0x0008035267ae in QCoreApplication::exec() (/usr/local/lib/qt6/libQt6Core.so.6+0x3267ae)
    #40 0x00000094e339 in fc_client::fc_main(QApplication*) /home/blabber/data/hacks/freeciv21/client/fc_client.cpp:155:3
    #41 0x00000098d849 in ui_main() /home/blabber/data/hacks/freeciv21/client/gui_main.cpp:83:17
    #42 0x000000861b78 in client_main(int, char**) /home/blabber/data/hacks/freeciv21/client/client_main.cpp:607:3
    #43 0x0008039bd37e in __libc_start1 (/lib/libc.so.7+0x9137e)
    #44 0x00000066e913 in _start /usr/src/lib/csu/amd64/crt1_s.S:80

0x518000012080 is located 0 bytes inside of 792-byte region [0x518000012080,0x518000012398)
allocated by thread T0 here:
    #0 0x0000007139fd in operator new(unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x000000b946c9 in handle_conn_info(packet_conn_info const*) /home/blabber/data/hacks/freeciv21/client/packhand.cpp:2786:15
    #2 0x000000fe869f in client_handle_packet(packet_type, void const*) /home/blabber/data/hacks/freeciv21/build/client/packhand_gen.cpp:263:5
    #3 0x000000864b6f in client_packet_input(void*, int) /home/blabber/data/hacks/freeciv21/client/client_main.cpp:697:15
    #4 0x0000008779c2 in input_from_server(QIODevice*) /home/blabber/data/hacks/freeciv21/client/clinet.cpp:318:9
    #5 0x0008035847a9  (/usr/local/lib/qt6/libQt6Core.so.6+0x3847a9)
    #6 0x0008035847e0  (/usr/local/lib/qt6/libQt6Core.so.6+0x3847e0)
    #7 0x0008025f31a4 in QAbstractSocketPrivate::canReadNotification() (/usr/local/lib/qt6/libQt6Network.so.6+0x1251a4)
    #8 0x0008025fccf0  (/usr/local/lib/qt6/libQt6Network.so.6+0x12ecf0)
    #9 0x000801d01e87 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x301e87)
    #10 0x000801d02f05 in QApplication::notify(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Widgets.so.6+0x302f05)
    #11 0x000803526b28 in QCoreApplication::sendEvent(QObject*, QEvent*) (/usr/local/lib/qt6/libQt6Core.so.6+0x326b28)
    #12 0x0008037da089  (/usr/local/lib/qt6/libQt6Core.so.6+0x5da089)
    #13 0x000804ac6080  (/usr/local/lib/libglib-2.0.so.0+0xef080)
    #14 0x000804ac6515  (/usr/local/lib/libglib-2.0.so.0+0xef515)
    #15 0x000804ac65b5 in g_main_context_iteration (/usr/local/lib/libglib-2.0.so.0+0xef5b5)
    #16 0x0008037d98a1 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/local/lib/qt6/libQt6Core.so.6+0x5d98a1)
    #17 0x000803530965 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/local/lib/qt6/libQt6Core.so.6+0x330965)
    #18 0x0008035267ae in QCoreApplication::exec() (/usr/local/lib/qt6/libQt6Core.so.6+0x3267ae)
    #19 0x00000094e339 in fc_client::fc_main(QApplication*) /home/blabber/data/hacks/freeciv21/client/fc_client.cpp:155:3
    #20 0x00000098d849 in ui_main() /home/blabber/data/hacks/freeciv21/client/gui_main.cpp:83:17
    #21 0x000000861b78 in client_main(int, char**) /home/blabber/data/hacks/freeciv21/client/client_main.cpp:607:3
    #22 0x0008039bd37e in __libc_start1 (/lib/libc.so.7+0x9137e)
    #23 0x00000066e913 in _start /usr/src/lib/csu/amd64/crt1_s.S:80
    #24 0x0008016ae007  (<unknown module>)

SUMMARY: AddressSanitizer: new-delete-type-mismatch /home/blabber/data/hacks/freeciv21/client/client_main.cpp:952:3 in client_remove_cli_conn(connection*)
==16717==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
```