### PR TITLE
Fix displaying city output breakdowns when "<" appears

### DIFF
--- a/client/citydlg_common.cpp
+++ b/client/citydlg_common.cpp
@@ -181,7 +181,8 @@ namespace {
  */
 QString html_pre(const QString &content)
 {
-  return QStringLiteral("<pre>") + content + QStringLiteral("</pre>");
+  return QStringLiteral("<pre>") + content.toHtmlEscaped()
+         + QStringLiteral("</pre>");
 }
 
 /**


### PR DESCRIPTION
Qt interprets "<" as the start of a HTML tag and swallows everything until the next ">" (which only comes at the end). This can happen with the MaxUnitsOnTile requirement.

Testing: use LT92 rules, grow your city until it has more than 20 trade, put a unit inside. Check the breakdown of trade contributions that appears in a tooltip in the city screen.

Backport requested - but we better check what Qt 5 does in this case.