### PR TITLE
Unit_Reachable (stable-branch backport)

### DIFF
--- a/ai/default/aiair.cpp
+++ b/ai/default/aiair.cpp
@@ -124,8 +124,8 @@ static int dai_evaluate_tile_for_air_attack(struct unit *punit,
   int sortie_time;
 #define PROB_MULTIPLIER 100 // should unify with those in combat.c
 
-  if (!can_unit_attack_tile(punit, dst_tile)
-      || !(pdefender = get_defender(punit, dst_tile))) {
+  if (!can_unit_attack_tile(punit, dst_tile, nullptr)
+      || !(pdefender = get_defender(punit, dst_tile, nullptr))) {
     return 0;
   }
 
@@ -228,7 +228,7 @@ static int find_something_to_bomb(struct ai_type *ait, struct unit *punit,
 
     if (is_enemy_unit_tile(ptile, pplayer)
         && dai_should_we_air_attack_tile(ait, punit, ptile)
-        && can_unit_attack_tile(punit, ptile)) {
+        && can_unit_attack_tile(punit, ptile, nullptr)) {
       int new_best = dai_evaluate_tile_for_air_attack(punit, ptile);
 
       if (new_best > best) {

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -332,7 +332,7 @@ static void dai_hunter_try_launch(struct ai_type *ait,
         if (move_cost > missile->moves_left / SINGLE_MOVE) {
           break;
         }
-        if (tile_city(ptile) || !can_unit_attack_tile(punit, ptile)) {
+        if (tile_city(ptile) || !can_unit_attack_tile(punit, ptile, nullptr)) {
           continue;
         }
         unit_list_iterate(ptile->units, victim)
@@ -474,7 +474,7 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
       return 0;
     }
 
-    if (tile_city(ptile) || !can_unit_attack_tile(punit, ptile)) {
+    if (tile_city(ptile) || !can_unit_attack_tile(punit, ptile, nullptr)) {
       continue;
     }
 
@@ -536,7 +536,8 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
        * if any. */
       dai_hunter_juiciness(pplayer, punit, target, &stackthreat, &stackcost);
       stackcost *=
-          unit_win_chance(punit, get_defender(punit, unit_tile(target)));
+          unit_win_chance(punit, get_defender(punit, unit_tile(target),
+                                              nullptr));
       if (stackcost < unit_build_shield_cost_base(punit)) {
         UNIT_LOG(LOGLEVEL_HUNT, punit,
                  "%d is too expensive (it %d vs us %d)", target->id,

--- a/ai/default/aihunt.cpp
+++ b/ai/default/aihunt.cpp
@@ -332,7 +332,8 @@ static void dai_hunter_try_launch(struct ai_type *ait,
         if (move_cost > missile->moves_left / SINGLE_MOVE) {
           break;
         }
-        if (tile_city(ptile) || !can_unit_attack_tile(punit, ptile, nullptr)) {
+        if (tile_city(ptile)
+            || !can_unit_attack_tile(punit, ptile, nullptr)) {
           continue;
         }
         unit_list_iterate(ptile->units, victim)
@@ -535,9 +536,8 @@ int dai_hunter_manage(struct ai_type *ait, struct player *pplayer,
       /* Calculate juiciness of target, compare with existing target,
        * if any. */
       dai_hunter_juiciness(pplayer, punit, target, &stackthreat, &stackcost);
-      stackcost *=
-          unit_win_chance(punit, get_defender(punit, unit_tile(target),
-                                              nullptr));
+      stackcost *= unit_win_chance(
+          punit, get_defender(punit, unit_tile(target), nullptr));
       if (stackcost < unit_build_shield_cost_base(punit)) {
         UNIT_LOG(LOGLEVEL_HUNT, punit,
                  "%d is too expensive (it %d vs us %d)", target->id,

--- a/ai/default/aiparatrooper.cpp
+++ b/ai/default/aiparatrooper.cpp
@@ -138,8 +138,8 @@ static struct tile *find_best_tile_to_paradrop_to(struct ai_type *ait,
     adjc_iterate(&(wld.map), ptile, target)
     {
       if (unit_list_size(target->units) == 0
-          || !can_unit_attack_tile(punit, target) || is_ocean_tile(target)
-          || (has_handicap(pplayer, H_FOG)
+          || !can_unit_attack_tile(punit, target, nullptr)
+          || is_ocean_tile(target) || (has_handicap(pplayer, H_FOG)
               && !map_is_known_and_seen(target, pplayer, V_MAIN))) {
         continue;
       }
@@ -149,16 +149,16 @@ static struct tile *find_best_tile_to_paradrop_to(struct ai_type *ait,
         {
           if ((!has_handicap(pplayer, H_FOG)
                || can_player_see_unit(pplayer, victim))
-              && (unit_attack_unit_at_tile_result(punit, victim, target)
-                  == ATT_OK)) {
+              && (unit_attack_unit_at_tile_result(punit, victim, target,
+                                                  nullptr) == ATT_OK)) {
             val += victim->hp * 100;
           }
         }
         unit_list_iterate_end;
       } else {
-        val += get_defender(punit, target)->hp * 100;
+        val += get_defender(punit, target, nullptr)->hp * 100;
       }
-      val *= unit_win_chance(punit, get_defender(punit, target));
+      val *= unit_win_chance(punit, get_defender(punit, target, nullptr));
       val += pterrain->defense_bonus / 10;
       val -= punit->hp * 100;
 

--- a/ai/default/aiparatrooper.cpp
+++ b/ai/default/aiparatrooper.cpp
@@ -139,7 +139,8 @@ static struct tile *find_best_tile_to_paradrop_to(struct ai_type *ait,
     {
       if (unit_list_size(target->units) == 0
           || !can_unit_attack_tile(punit, target, nullptr)
-          || is_ocean_tile(target) || (has_handicap(pplayer, H_FOG)
+          || is_ocean_tile(target)
+          || (has_handicap(pplayer, H_FOG)
               && !map_is_known_and_seen(target, pplayer, V_MAIN))) {
         continue;
       }
@@ -150,7 +151,8 @@ static struct tile *find_best_tile_to_paradrop_to(struct ai_type *ait,
           if ((!has_handicap(pplayer, H_FOG)
                || can_player_see_unit(pplayer, victim))
               && (unit_attack_unit_at_tile_result(punit, victim, target,
-                                                  nullptr) == ATT_OK)) {
+                                                  nullptr)
+                  == ATT_OK)) {
             val += victim->hp * 100;
           }
         }

--- a/ai/default/aitools.cpp
+++ b/ai/default/aitools.cpp
@@ -1078,13 +1078,14 @@ int stack_cost(struct unit *pattacker, struct unit *pdefender)
     // lotsa people die
     unit_list_iterate(ptile->units, aunit)
     {
-      if (unit_attack_unit_at_tile_result(pattacker, aunit, ptile)
+      if (unit_attack_unit_at_tile_result(pattacker, aunit, ptile, nullptr)
           == ATT_OK) {
         victim_cost += unit_build_shield_cost_base(aunit);
       }
     }
     unit_list_iterate_end;
-  } else if (unit_attack_unit_at_tile_result(pattacker, pdefender, ptile)
+  } else if (unit_attack_unit_at_tile_result(pattacker, pdefender, ptile,
+                                             nullptr)
              == ATT_OK) {
     // Only one unit dies if attack is successful
     victim_cost = unit_build_shield_cost_base(pdefender);

--- a/ai/default/aiunit.cpp
+++ b/ai/default/aiunit.cpp
@@ -408,9 +408,10 @@ static bool is_my_turn(struct unit *punit, struct unit *pdef)
       if (aunit == punit || unit_owner(aunit) != unit_owner(punit)) {
         continue;
       }
-      if (unit_attack_units_at_tile_result(aunit, unit_tile(pdef)) != ATT_OK
-          || unit_attack_unit_at_tile_result(aunit, pdef, unit_tile(pdef))
-                 != ATT_OK) {
+      if (unit_attack_units_at_tile_result(aunit, unit_tile(pdef),
+                                           nullptr) != ATT_OK
+          || unit_attack_unit_at_tile_result(aunit, pdef, unit_tile(pdef),
+                                             nullptr) != ATT_OK) {
         continue;
       }
       d = get_virtual_defense_power(unit_type_get(aunit),
@@ -457,8 +458,8 @@ static int dai_rampage_want(struct unit *punit, struct tile *ptile)
 
   CHECK_UNIT(punit);
 
-  if (can_unit_attack_tile(punit, ptile)
-      && (pdef = get_defender(punit, ptile))) {
+  if (can_unit_attack_tile(punit, ptile, nullptr)
+      && (pdef = get_defender(punit, ptile, nullptr))) {
     // See description of kill_desire() about these variables.
     int attack = unit_att_rating_now(punit);
     int benefit = stack_cost(punit, pdef);
@@ -1377,8 +1378,8 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
         go_by_boat = true;
       }
 
-      if (can_unit_attack_tile(punit, city_tile(acity))
-          && (pdefender = get_defender(punit, city_tile(acity)))) {
+      if (can_unit_attack_tile(punit, city_tile(acity), nullptr)
+          && (pdefender = get_defender(punit, city_tile(acity), nullptr))) {
         vulnerability = unit_def_rating_squared(punit, pdefender);
         benefit = unit_build_shield_cost_base(pdefender);
       } else {
@@ -1544,8 +1545,8 @@ int find_something_to_kill(struct ai_type *ait, struct player *pplayer,
       /* We have to assume the attack is diplomatically ok.
        * We cannot use can_player_attack_tile, because we might not
        * be at war with aplayer yet */
-      if (!can_unit_attack_tile(punit, atile)
-          || aunit != get_defender(punit, atile)) {
+      if (!can_unit_attack_tile(punit, atile, nullptr)
+          || aunit != get_defender(punit, atile, nullptr)) {
         // We cannot attack it, or it is not the main defender.
         continue;
       }
@@ -1781,7 +1782,7 @@ static void dai_military_attack(struct ai_type *ait, struct player *pplayer,
                            &ferryboat, nullptr, nullptr);
     if (!same_pos(unit_tile(punit), dest_tile)) {
       if (!is_tiles_adjacent(unit_tile(punit), dest_tile)
-          || !can_unit_attack_tile(punit, dest_tile)) {
+          || !can_unit_attack_tile(punit, dest_tile, nullptr)) {
         /* Adjacent and can't attack usually means we are not marines
          * and on a ferry. This fixes the problem (usually). */
         UNIT_LOG(LOG_DEBUG, punit, "mil att gothere -> (%d, %d)",
@@ -3055,8 +3056,10 @@ void dai_consider_tile_dangerous(struct ai_type *ait, struct tile *ptile,
     unit_list_iterate(ptile1->units, enemy)
     {
       if (pplayers_at_war(unit_owner(enemy), unit_owner(punit))
-          && unit_attack_unit_at_tile_result(enemy, punit, ptile) == ATT_OK
-          && unit_attack_units_at_tile_result(enemy, ptile) == ATT_OK) {
+          && unit_attack_unit_at_tile_result(enemy, punit, ptile,
+                                             nullptr) == ATT_OK
+          && unit_attack_units_at_tile_result(enemy, ptile,
+                                              nullptr) == ATT_OK) {
         a += adv_unit_att_rating(enemy);
         if ((a * a * 10) >= d) {
           // The enemies combined strength is too big!

--- a/ai/default/aiunit.cpp
+++ b/ai/default/aiunit.cpp
@@ -408,10 +408,11 @@ static bool is_my_turn(struct unit *punit, struct unit *pdef)
       if (aunit == punit || unit_owner(aunit) != unit_owner(punit)) {
         continue;
       }
-      if (unit_attack_units_at_tile_result(aunit, unit_tile(pdef),
-                                           nullptr) != ATT_OK
+      if (unit_attack_units_at_tile_result(aunit, unit_tile(pdef), nullptr)
+              != ATT_OK
           || unit_attack_unit_at_tile_result(aunit, pdef, unit_tile(pdef),
-                                             nullptr) != ATT_OK) {
+                                             nullptr)
+                 != ATT_OK) {
         continue;
       }
       d = get_virtual_defense_power(unit_type_get(aunit),
@@ -3056,10 +3057,10 @@ void dai_consider_tile_dangerous(struct ai_type *ait, struct tile *ptile,
     unit_list_iterate(ptile1->units, enemy)
     {
       if (pplayers_at_war(unit_owner(enemy), unit_owner(punit))
-          && unit_attack_unit_at_tile_result(enemy, punit, ptile,
-                                             nullptr) == ATT_OK
-          && unit_attack_units_at_tile_result(enemy, ptile,
-                                              nullptr) == ATT_OK) {
+          && unit_attack_unit_at_tile_result(enemy, punit, ptile, nullptr)
+                 == ATT_OK
+          && unit_attack_units_at_tile_result(enemy, ptile, nullptr)
+                 == ATT_OK) {
         a += adv_unit_att_rating(enemy);
         if ((a * a * 10) >= d) {
           // The enemies combined strength is too big!

--- a/ai/default/daieffects.cpp
+++ b/ai/default/daieffects.cpp
@@ -581,6 +581,7 @@ adv_want dai_effect_value(struct player *pplayer, struct government *gov,
   case EFT_WONDER_VISIBLE:
   case EFT_NATION_INTELLIGENCE:
   case EFT_NUKE_INFRASTRUCTURE_PCT:
+  case EFT_UNIT_REACHABLE:
     break;
     // This has no effect for AI
   case EFT_VISIBLE_WALLS:

--- a/ai/default/daimilitary.cpp
+++ b/ai/default/daimilitary.cpp
@@ -1231,7 +1231,7 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
       find_something_to_kill(ait, pplayer, myunit, &ptile, &path, &ferry_map,
                              &ferryboat, &boattype, &move_time);
   if (nullptr == ptile || ptile == unit_tile(myunit)
-      || !can_unit_attack_tile(myunit, ptile)) {
+      || !can_unit_attack_tile(myunit, ptile, nullptr)) {
     goto cleanup;
   }
 
@@ -1272,7 +1272,7 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
       def_vet = 0;
     }
 
-    pdef = get_defender(myunit, ptile);
+    pdef = get_defender(myunit, ptile, nullptr);
     if (pdef) {
       int m = unittype_def_rating_squared(
           unit_type_get(myunit), unit_type_get(pdef), city_owner(acity),
@@ -1304,7 +1304,7 @@ static struct adv_choice *kill_something_with(struct ai_type *ait,
       ferry_map = nullptr;
     }
 
-    pdef = get_defender(myunit, ptile);
+    pdef = get_defender(myunit, ptile, nullptr);
     if (!pdef) {
       // Nobody to attack!
       goto cleanup;

--- a/client/control.cpp
+++ b/client/control.cpp
@@ -1073,7 +1073,7 @@ static bool can_units_attack_at(const std::vector<unit *> &units,
                                 const struct tile *ptile)
 {
   return std::any_of(units.begin(), units.end(), [&](const auto *unit) {
-    return is_attack_unit(unit) && can_unit_attack_tile(unit, ptile);
+    return is_attack_unit(unit) && can_unit_attack_tile(unit, ptile, nullptr);
   });
 }
 

--- a/client/control.cpp
+++ b/client/control.cpp
@@ -1073,7 +1073,8 @@ static bool can_units_attack_at(const std::vector<unit *> &units,
                                 const struct tile *ptile)
 {
   return std::any_of(units.begin(), units.end(), [&](const auto *unit) {
-    return is_attack_unit(unit) && can_unit_attack_tile(unit, ptile, nullptr);
+    return is_attack_unit(unit)
+           && can_unit_attack_tile(unit, ptile, nullptr);
   });
 }
 

--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -3254,7 +3254,7 @@ static enum fc_tristate is_action_possible(
     break;
 
   case ACTRES_NUKE_UNITS:
-    if (unit_attack_units_at_tile_result(actor_unit, target_tile)
+    if (unit_attack_units_at_tile_result(actor_unit, target_tile, paction)
         != ATT_OK) {
       // Unreachable.
       return TRI_NO;
@@ -3371,7 +3371,7 @@ static enum fc_tristate is_action_possible(
 
   case ACTRES_ATTACK:
     // Reason: Keep the old rules.
-    if (!can_unit_attack_tile(actor_unit, target_tile)) {
+    if (!can_unit_attack_tile(actor_unit, target_tile, paction)) {
       return TRI_NO;
     }
     break;
@@ -4638,7 +4638,7 @@ static struct act_prob action_prob(
     chance = ACTPROB_CERTAIN;
     break;
   case ACTRES_ATTACK: {
-    struct unit *defender_unit = get_defender(actor_unit, target_tile);
+    struct unit *defender_unit = get_defender(actor_unit, target_tile, paction);
 
     if (can_player_see_unit(actor_player, defender_unit)) {
       double unconverted = unit_win_chance(actor_unit, defender_unit);

--- a/common/actions.cpp
+++ b/common/actions.cpp
@@ -4638,7 +4638,8 @@ static struct act_prob action_prob(
     chance = ACTPROB_CERTAIN;
     break;
   case ACTRES_ATTACK: {
-    struct unit *defender_unit = get_defender(actor_unit, target_tile, paction);
+    struct unit *defender_unit =
+        get_defender(actor_unit, target_tile, paction);
 
     if (can_player_see_unit(actor_player, defender_unit)) {
       double unconverted = unit_win_chance(actor_unit, defender_unit);

--- a/common/aicore/pf_tools.cpp
+++ b/common/aicore/pf_tools.cpp
@@ -59,7 +59,6 @@ static inline bool pf_attack_possible(const struct tile *ptile,
 
     // Unit reachability test.
     if (BV_ISSET(param->utype->targets, uclass_index(unit_class_get(punit)))
-        || tile_has_native_base(ptile, unit_type_get(punit))
         || get_unit_bonus(punit, EFT_UNIT_REACHABLE)) {
       attack_any = true;
     } else if (game.info.unreachable_protects) {

--- a/common/aicore/pf_tools.cpp
+++ b/common/aicore/pf_tools.cpp
@@ -59,7 +59,8 @@ static inline bool pf_attack_possible(const struct tile *ptile,
 
     // Unit reachability test.
     if (BV_ISSET(param->utype->targets, uclass_index(unit_class_get(punit)))
-        || tile_has_native_base(ptile, unit_type_get(punit))) {
+        || tile_has_native_base(ptile, unit_type_get(punit))
+        || get_unit_bonus(punit, EFT_UNIT_REACHABLE)) {
       attack_any = true;
     } else if (game.info.unreachable_protects) {
       // We would need to be able to attack all, this is not the case.

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -92,6 +92,10 @@ bool is_unit_reachable_at(const struct unit *defender,
     return true;
   }
 
+  if (get_unit_bonus(defender, EFT_UNIT_REACHABLE) > 0) {
+    return true;
+  }
+
   if (tile_has_native_base(location, unit_type_get(defender))) {
     return true;
   }

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -82,13 +82,19 @@ static bool is_unit_reachable_by_unit(const struct unit *defender,
  */
 bool is_unit_reachable_at(const struct unit *defender,
                           const struct unit *attacker,
-                          const struct tile *location)
+                          const struct tile *location,
+                          const struct action *paction)
 {
   if (is_unit_reachable_by_unit(defender, attacker)) {
     return true;
   }
 
-  if (get_unit_bonus(defender, EFT_UNIT_REACHABLE) > 0) {
+  if (get_target_bonus_effects(nullptr, unit_owner(defender), nullptr,
+                               unit_tile(defender) ?
+                                 tile_city(unit_tile(defender)) : nullptr,
+                               nullptr, unit_tile(defender), defender,
+                               unit_type_get(defender), nullptr, nullptr,
+                               paction, EFT_UNIT_REACHABLE) > 0) {
     return true;
   }
 
@@ -116,7 +122,8 @@ bool is_unit_reachable_at(const struct unit *defender,
 enum unit_attack_result
 unit_attack_unit_at_tile_result(const struct unit *punit,
                                 const struct unit *pdefender,
-                                const struct tile *dest_tile)
+                                const struct tile *dest_tile,
+                                const struct action *paction)
 {
   // 1. Can we attack _anything_ ?
   if (!(utype_can_do_action(unit_type_get(punit), ACTION_ATTACK)
@@ -145,7 +152,7 @@ unit_attack_unit_at_tile_result(const struct unit *punit,
   }
 
   // 4. Only fighters can attack planes, except in city or airbase attacks
-  if (!is_unit_reachable_at(pdefender, punit, dest_tile)) {
+  if (!is_unit_reachable_at(pdefender, punit, dest_tile, paction)) {
     return ATT_UNREACHABLE;
   }
 
@@ -162,7 +169,8 @@ unit_attack_unit_at_tile_result(const struct unit *punit,
  */
 static enum unit_attack_result
 unit_attack_all_at_tile_result(const struct unit *punit,
-                               const struct tile *ptile)
+                               const struct tile *ptile,
+                               const struct action *paction)
 {
   bool any_reachable_unit = false;
   bool any_neverprotect_unit = false;
@@ -177,7 +185,7 @@ unit_attack_all_at_tile_result(const struct unit *punit,
     if (!unit_transported(aunit)) {
       enum unit_attack_result result;
 
-      result = unit_attack_unit_at_tile_result(punit, aunit, ptile);
+      result = unit_attack_unit_at_tile_result(punit, aunit, ptile, paction);
       if (result == ATT_UNREACHABLE
           && unit_has_type_flag(aunit, UTYF_NEVER_PROTECTS)) {
         // Doesn't prevent us from attacking other units on the tile
@@ -204,7 +212,8 @@ unit_attack_all_at_tile_result(const struct unit *punit,
  */
 static enum unit_attack_result
 unit_attack_any_at_tile_result(const struct unit *punit,
-                               const struct tile *ptile)
+                               const struct tile *ptile,
+                               const struct action *paction)
 {
   enum unit_attack_result result = ATT_OK;
 
@@ -213,7 +222,7 @@ unit_attack_any_at_tile_result(const struct unit *punit,
     /* HACK: we don't count transported units here.  This prevents some
      * bugs like a cargoplane carrying a land unit being vulnerable. */
     if (!unit_transported(aunit)) {
-      result = unit_attack_unit_at_tile_result(punit, aunit, ptile);
+      result = unit_attack_unit_at_tile_result(punit, aunit, ptile, paction);
       if (result == ATT_OK) {
         return result;
       }
@@ -231,12 +240,13 @@ unit_attack_any_at_tile_result(const struct unit *punit,
  */
 enum unit_attack_result
 unit_attack_units_at_tile_result(const struct unit *punit,
-                                 const struct tile *ptile)
+                                 const struct tile *ptile,
+                                 const struct action *paction)
 {
   if (game.info.unreachable_protects) {
-    return unit_attack_all_at_tile_result(punit, ptile);
+    return unit_attack_all_at_tile_result(punit, ptile, paction);
   } else {
-    return unit_attack_any_at_tile_result(punit, ptile);
+    return unit_attack_any_at_tile_result(punit, ptile, paction);
   }
 }
 
@@ -245,10 +255,12 @@ unit_attack_units_at_tile_result(const struct unit *punit,
    to do so?
  */
 bool can_unit_attack_tile(const struct unit *punit,
-                          const struct tile *dest_tile)
+                          const struct tile *dest_tile,
+                          const struct action *paction)
 {
   return (can_player_attack_tile(unit_owner(punit), dest_tile)
-          && unit_attack_units_at_tile_result(punit, dest_tile) == ATT_OK);
+          && unit_attack_units_at_tile_result(punit, dest_tile,
+                                              paction) == ATT_OK);
 }
 
 /**
@@ -715,7 +727,8 @@ static int get_defense_rating(const struct unit *attacker,
    this.
  */
 struct unit *get_defender(const struct unit *attacker,
-                          const struct tile *ptile)
+                          const struct tile *ptile,
+                          const struct action *paction)
 {
   struct unit *bestdef = nullptr;
   int bestvalue = -99, best_cost = 0, rating_of_best = 0;
@@ -734,7 +747,7 @@ struct unit *get_defender(const struct unit *attacker,
     /* We used to skip over allied units, but the logic for that is
      * complicated and is now handled elsewhere. */
     if (unit_can_defend_here(&(wld.map), defender)
-        && unit_attack_unit_at_tile_result(attacker, defender, ptile)
+        && unit_attack_unit_at_tile_result(attacker, defender, ptile, paction)
                == ATT_OK) {
       bool change = false;
       int build_cost = unit_build_shield_cost_base(defender);

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -84,10 +84,6 @@ bool is_unit_reachable_at(const struct unit *defender,
                           const struct unit *attacker,
                           const struct tile *location)
 {
-  if (nullptr != tile_city(location)) {
-    return true;
-  }
-
   if (is_unit_reachable_by_unit(defender, attacker)) {
     return true;
   }

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -96,10 +96,6 @@ bool is_unit_reachable_at(const struct unit *defender,
     return true;
   }
 
-  if (tile_has_native_base(location, unit_type_get(defender))) {
-    return true;
-  }
-
   return false;
 }
 

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -89,12 +89,12 @@ bool is_unit_reachable_at(const struct unit *defender,
     return true;
   }
 
-  if (get_target_bonus_effects(nullptr, unit_owner(defender), nullptr,
-                               unit_tile(defender) ?
-                                 tile_city(unit_tile(defender)) : nullptr,
-                               nullptr, unit_tile(defender), defender,
-                               unit_type_get(defender), nullptr, nullptr,
-                               paction, EFT_UNIT_REACHABLE) > 0) {
+  if (get_target_bonus_effects(
+          nullptr, unit_owner(defender), nullptr,
+          unit_tile(defender) ? tile_city(unit_tile(defender)) : nullptr,
+          nullptr, unit_tile(defender), defender, unit_type_get(defender),
+          nullptr, nullptr, paction, EFT_UNIT_REACHABLE)
+      > 0) {
     return true;
   }
 
@@ -119,11 +119,9 @@ bool is_unit_reachable_at(const struct unit *defender,
    2) Adjacency
    3) Diplomatic status
  */
-enum unit_attack_result
-unit_attack_unit_at_tile_result(const struct unit *punit,
-                                const struct unit *pdefender,
-                                const struct tile *dest_tile,
-                                const struct action *paction)
+enum unit_attack_result unit_attack_unit_at_tile_result(
+    const struct unit *punit, const struct unit *pdefender,
+    const struct tile *dest_tile, const struct action *paction)
 {
   // 1. Can we attack _anything_ ?
   if (!(utype_can_do_action(unit_type_get(punit), ACTION_ATTACK)
@@ -259,8 +257,8 @@ bool can_unit_attack_tile(const struct unit *punit,
                           const struct action *paction)
 {
   return (can_player_attack_tile(unit_owner(punit), dest_tile)
-          && unit_attack_units_at_tile_result(punit, dest_tile,
-                                              paction) == ATT_OK);
+          && unit_attack_units_at_tile_result(punit, dest_tile, paction)
+                 == ATT_OK);
 }
 
 /**
@@ -747,7 +745,8 @@ struct unit *get_defender(const struct unit *attacker,
     /* We used to skip over allied units, but the logic for that is
      * complicated and is now handled elsewhere. */
     if (unit_can_defend_here(&(wld.map), defender)
-        && unit_attack_unit_at_tile_result(attacker, defender, ptile, paction)
+        && unit_attack_unit_at_tile_result(attacker, defender, ptile,
+                                           paction)
                == ATT_OK) {
       bool change = false;
       int build_cost = unit_build_shield_cost_base(defender);

--- a/common/combat.h
+++ b/common/combat.h
@@ -32,16 +32,20 @@ enum unit_attack_result {
 
 bool is_unit_reachable_at(const struct unit *defender,
                           const struct unit *attacker,
-                          const struct tile *location);
+                          const struct tile *location,
+                          const struct action *paction);
 enum unit_attack_result
 unit_attack_unit_at_tile_result(const struct unit *punit,
                                 const struct unit *pdefender,
-                                const struct tile *dest_tile);
+                                const struct tile *dest_tile,
+                                const struct action *paction);
 enum unit_attack_result
 unit_attack_units_at_tile_result(const struct unit *punit,
-                                 const struct tile *ptile);
+                                 const struct tile *ptile,
+                                 const struct action *paction);
 bool can_unit_attack_tile(const struct unit *punit,
-                          const struct tile *ptile);
+                          const struct tile *ptile,
+                          const struct action *paction);
 
 double win_chance(int as, int ahp, int afp, int ds, int dhp, int dfp);
 
@@ -72,7 +76,8 @@ int get_total_attack_power(const struct unit *attacker,
                            const struct unit *defender);
 
 struct unit *get_defender(const struct unit *attacker,
-                          const struct tile *ptile);
+                          const struct tile *ptile,
+                          const struct action *paction);
 
 struct unit *get_diplomatic_defender(const struct unit *act_unit,
                                      const struct unit *pvictim,

--- a/common/combat.h
+++ b/common/combat.h
@@ -34,17 +34,14 @@ bool is_unit_reachable_at(const struct unit *defender,
                           const struct unit *attacker,
                           const struct tile *location,
                           const struct action *paction);
-enum unit_attack_result
-unit_attack_unit_at_tile_result(const struct unit *punit,
-                                const struct unit *pdefender,
-                                const struct tile *dest_tile,
-                                const struct action *paction);
+enum unit_attack_result unit_attack_unit_at_tile_result(
+    const struct unit *punit, const struct unit *pdefender,
+    const struct tile *dest_tile, const struct action *paction);
 enum unit_attack_result
 unit_attack_units_at_tile_result(const struct unit *punit,
                                  const struct tile *ptile,
                                  const struct action *paction);
-bool can_unit_attack_tile(const struct unit *punit,
-                          const struct tile *ptile,
+bool can_unit_attack_tile(const struct unit *punit, const struct tile *ptile,
                           const struct action *paction);
 
 double win_chance(int as, int ahp, int afp, int ds, int dhp, int dfp);

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -1243,6 +1243,7 @@ QString effect_type_unit_text(effect_type type, int value)
   case EFT_CASUS_BELLI_COMPLETE:
   case EFT_WONDER_VISIBLE:
   case EFT_NATION_INTELLIGENCE:
+  case EFT_UNIT_REACHABLE:
   case EFT_COUNT:
     return QStringLiteral("%1").arg(value);
   }

--- a/common/effects.h
+++ b/common/effects.h
@@ -317,6 +317,8 @@
 #define SPECENUM_VALUE135NAME "Growth_Surplus_Pct"
 #define SPECENUM_VALUE136 EFT_POLLU_TRADE_PCT
 #define SPECENUM_VALUE136NAME "Pollu_Trade_Pct"
+#define SPECENUM_VALUE137 EFT_UNIT_REACHABLE
+#define SPECENUM_VALUE137NAME "Unit_Reachable"
 // keep this last
 #define SPECENUM_COUNT EFT_COUNT
 #include "specenum_gen.h"

--- a/docs/Modding/Rulesets/effects.rst
+++ b/docs/Modding/Rulesets/effects.rst
@@ -1091,3 +1091,12 @@ Nation_Intelligence
         :hidden:
 
         Effects/Nation_Intelligence.rst
+
+.. _effect-unit-reachable:
+
+Unit_Reachable
+    If the value of this effect for a unit is larger than 0, the unit is reachable (can be attacked) regardless of unit-class-flag `Unreachable` and attacker's ``targets`` value.
+
+    .. note::
+        This effect is added automatically for units in cities and native bases. This behavior can be turned
+        off by requiring the ``+Unit_Reachable`` option in :file:`effects.ruleset`.

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -352,8 +352,10 @@ bool adv_danger_at(struct unit *punit, struct tile *ptile)
     unit_list_iterate(ptile1->units, enemy)
     {
       if (pplayers_at_war(unit_owner(enemy), unit_owner(punit))
-          && unit_attack_unit_at_tile_result(enemy, punit, ptile) == ATT_OK
-          && unit_attack_units_at_tile_result(enemy, ptile) == ATT_OK) {
+          && unit_attack_unit_at_tile_result(enemy, punit, ptile,
+                                             nullptr) == ATT_OK
+          && unit_attack_units_at_tile_result(enemy, ptile,
+                                              nullptr) == ATT_OK) {
         a += adv_unit_att_rating(enemy);
         if ((a * a * 10) >= d) {
           // The enemies combined strength is too big!

--- a/server/advisors/advgoto.cpp
+++ b/server/advisors/advgoto.cpp
@@ -352,10 +352,10 @@ bool adv_danger_at(struct unit *punit, struct tile *ptile)
     unit_list_iterate(ptile1->units, enemy)
     {
       if (pplayers_at_war(unit_owner(enemy), unit_owner(punit))
-          && unit_attack_unit_at_tile_result(enemy, punit, ptile,
-                                             nullptr) == ATT_OK
-          && unit_attack_units_at_tile_result(enemy, ptile,
-                                              nullptr) == ATT_OK) {
+          && unit_attack_unit_at_tile_result(enemy, punit, ptile, nullptr)
+                 == ATT_OK
+          && unit_attack_units_at_tile_result(enemy, ptile, nullptr)
+                 == ATT_OK) {
         a += adv_unit_att_rating(enemy);
         if ((a * a * 10) >= d) {
           // The enemies combined strength is too big!

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1230,6 +1230,28 @@ static void rscompat_optional_capabilities(rscompat_info *info)
                       info->cap_effects.data())) {
     rscompat_migrate_eft_nation_intelligence();
   }
+
+  if (!has_capability(CAP_EFT_UNIT_REACHABLE, info->cap_effects.data())) {
+    // Add effects to make units on native bases reachable
+    extra_type_by_cause_iterate(EC_BASE, pextra)
+    {
+      unit_class_iterate(uclass)
+      {
+        if (uclass_has_flag(uclass, UCF_UNREACHABLE)
+            && is_native_extra_to_uclass(pextra, uclass)) {
+          auto effect = effect_new(EFT_UNIT_REACHABLE, 1, nullptr);
+          effect_req_append(effect,
+                            req_from_str("UnitClass", "Local", false, true,
+                                         false, uclass_rule_name(uclass)));
+          effect_req_append(effect,
+                            req_from_str("Extra", "Tile", false, true, false,
+                                         extra_rule_name(pextra)));
+        }
+      }
+      unit_class_iterate_end;
+    }
+    extra_type_by_cause_iterate_end;
+  }
 }
 
 /**

--- a/server/rscompat.cpp
+++ b/server/rscompat.cpp
@@ -1251,6 +1251,10 @@ static void rscompat_optional_capabilities(rscompat_info *info)
       unit_class_iterate_end;
     }
     extra_type_by_cause_iterate_end;
+    // Add effect to make units in cities reachable
+    auto effect = effect_new(EFT_UNIT_REACHABLE, 1, nullptr);
+    effect_req_append(effect, req_from_str("CityTile", "Local", false, true,
+                                           false, "Center"));
   }
 }
 

--- a/server/ruleset.h
+++ b/server/ruleset.h
@@ -19,10 +19,12 @@
 #define CAP_EFT_WONDER_VISIBLE "Wonder_Visible"
 #define CAP_VUT_VISIONLAYER "Vision_Layer"
 #define CAP_EFT_NATION_INTELLIGENCE "Nation_Intelligence"
+#define CAP_EFT_UNIT_REACHABLE "Unit_Reachable"
 #define RULESET_CAPABILITIES                                                \
   "+Freeciv-ruleset-Devel-2017.Jan.02 " CAP_EFT_HP_REGEN_MIN                \
   " " CAP_EFT_BOMBARD_LIMIT_PCT " " CAP_EFT_WONDER_VISIBLE                  \
-  " " CAP_VUT_VISIONLAYER " " CAP_EFT_NATION_INTELLIGENCE
+  " " CAP_VUT_VISIONLAYER " " CAP_EFT_NATION_INTELLIGENCE                   \
+  " " CAP_EFT_UNIT_REACHABLE
 /*
  * Ruleset capabilities acceptable to this program:
  *

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -1151,12 +1151,12 @@ static struct ane_expl *expl_act_not_enabl(struct unit *punit,
       action_custom = test_unit_can_airlift_to(nullptr, punit, target_city);
       break;
     case ACTRES_NUKE_UNITS:
-      action_custom = unit_attack_units_at_tile_result(punit, target_tile,
-                                                       paction);
+      action_custom =
+          unit_attack_units_at_tile_result(punit, target_tile, paction);
       break;
     case ACTRES_ATTACK:
-      action_custom = unit_attack_units_at_tile_result(punit, target_tile,
-                                                       paction);
+      action_custom =
+          unit_attack_units_at_tile_result(punit, target_tile, paction);
       break;
     case ACTRES_CONQUER_CITY:
       if (target_city) {

--- a/server/unithand.cpp
+++ b/server/unithand.cpp
@@ -1151,10 +1151,12 @@ static struct ane_expl *expl_act_not_enabl(struct unit *punit,
       action_custom = test_unit_can_airlift_to(nullptr, punit, target_city);
       break;
     case ACTRES_NUKE_UNITS:
-      action_custom = unit_attack_units_at_tile_result(punit, target_tile);
+      action_custom = unit_attack_units_at_tile_result(punit, target_tile,
+                                                       paction);
       break;
     case ACTRES_ATTACK:
-      action_custom = unit_attack_units_at_tile_result(punit, target_tile);
+      action_custom = unit_attack_units_at_tile_result(punit, target_tile,
+                                                       paction);
       break;
     case ACTRES_CONQUER_CITY:
       if (target_city) {
@@ -3718,7 +3720,7 @@ static bool unit_bombard(struct unit *punit, struct tile *ptile,
         "alliance at (%d, %d).",
         TILE_XY(unit_tile(pdefender)));
 
-    if (is_unit_reachable_at(pdefender, punit, ptile)) {
+    if (is_unit_reachable_at(pdefender, punit, ptile, paction)) {
       bool adj;
       enum direction8 facing;
       int att_hp, def_hp;
@@ -3755,7 +3757,7 @@ static bool unit_bombard(struct unit *punit, struct tile *ptile,
   // Send updates about affected units
   unit_list_iterate_safe(ptile->units, pdefender)
   {
-    if (is_unit_reachable_at(pdefender, punit, ptile)) {
+    if (is_unit_reachable_at(pdefender, punit, ptile, paction)) {
       send_unit_info(nullptr, pdefender);
     }
   }
@@ -3964,7 +3966,7 @@ static bool do_attack(struct unit *punit, struct tile *def_tile,
   int def_power, att_power;
   struct unit *pdefender;
 
-  if (!(pdefender = get_defender(punit, def_tile))) {
+  if (!(pdefender = get_defender(punit, def_tile, paction))) {
     // Can't fight air...
     return false;
   }
@@ -4253,7 +4255,8 @@ static bool do_attack(struct unit *punit, struct tile *def_tile,
     punit->moved = true; // We moved
     kill_unit(punit, pdefender,
               punit->veteran == old_unit_vet
-                  && !utype_is_consumed_by_action(paction, punit->utype));
+                  && !utype_is_consumed_by_action(paction, punit->utype),
+              paction);
 
     /* Now that dead defender is certainly no longer listed as unit
      * supported by the city, we may even remove the city

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -2462,7 +2462,8 @@ struct unit *unit_change_owner(struct unit *punit, struct player *pplayer,
    iterations could have. E.g. notify_player, when pointed to nullptr,
    will send messages to _everyone_.
  */
-void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
+void kill_unit(struct unit *pkiller, struct unit *punit, bool vet,
+               const struct action *paction)
 {
   char pkiller_link[MAX_LEN_LINK], punit_link[MAX_LEN_LINK];
   struct player *pvictim = unit_owner(punit);
@@ -2609,7 +2610,7 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
       struct player *vplayer = unit_owner(vunit);
 
       if (pplayers_at_war(pvictor, vplayer)
-          && is_unit_reachable_at(vunit, pkiller, ptile)) {
+          && is_unit_reachable_at(vunit, pkiller, ptile, paction)) {
         escaped = false;
 
         if (unit_has_type_flag(vunit, UTYF_CANESCAPE)
@@ -2754,7 +2755,7 @@ void kill_unit(struct unit *pkiller, struct unit *punit, bool vet)
     unit_list_iterate_safe(ptile->units, punit2)
     {
       if (pplayers_at_war(pvictor, unit_owner(punit2))
-          && is_unit_reachable_at(punit2, pkiller, ptile)) {
+          && is_unit_reachable_at(punit2, pkiller, ptile, paction)) {
         wipe_unit(punit2, ULR_KILLED, pvictor);
       }
     }
@@ -3546,7 +3547,8 @@ static bool unit_survive_autoattack(struct unit *punit)
   {
     int sanity2 = penemy->id;
     struct tile *ptile = unit_tile(penemy);
-    struct unit *enemy_defender = get_defender(punit, ptile);
+    struct unit *enemy_defender = get_defender(punit, ptile,
+                                               action_by_number(ACTION_ATTACK));
     double punitwin, penemywin;
     double threshold = 0.25;
     struct tile *tgt_tile = unit_tile(punit);

--- a/server/unittools.cpp
+++ b/server/unittools.cpp
@@ -3547,8 +3547,8 @@ static bool unit_survive_autoattack(struct unit *punit)
   {
     int sanity2 = penemy->id;
     struct tile *ptile = unit_tile(penemy);
-    struct unit *enemy_defender = get_defender(punit, ptile,
-                                               action_by_number(ACTION_ATTACK));
+    struct unit *enemy_defender =
+        get_defender(punit, ptile, action_by_number(ACTION_ATTACK));
     double punitwin, penemywin;
     double threshold = 0.25;
     struct tile *tgt_tile = unit_tile(punit);

--- a/server/unittools.h
+++ b/server/unittools.h
@@ -151,7 +151,8 @@ void unit_recover_hitpoints(struct unit *punit, int amount);
 void unit_set_hitpoints(struct unit *punit, int amount);
 void wipe_unit(struct unit *punit, enum unit_loss_reason reason,
                struct player *killer);
-void kill_unit(struct unit *pkiller, struct unit *punit, bool vet);
+void kill_unit(struct unit *pkiller, struct unit *punit, bool vet,
+               const struct action *paction);
 
 struct unit *
 unit_change_owner(struct unit *punit, struct player *pplayer, int homecity,


### PR DESCRIPTION
Implements an effect `Unit_Reachable`, and uses it to unhardcode the existing rule that units in cities and native bases are always reachable regardless of `UCF_UNREACHABLE`.

This PR is against `stable` because my system is not new enough to build (and hence test) `master`.  There are conflicts with `master` because many specenums have moved to `fc_types.h`.  So someone else will have to do a nonzero amount of work to port and re-test on `master`.  (It's your own fault for always needlessly updating your deps to the bleeding edge… 😛️)