### PR TITLE
Fix two fcdb/sol2 crashes

### DIFF
--- a/server/scripting/script_fcdb.cpp
+++ b/server/scripting/script_fcdb.cpp
@@ -254,7 +254,7 @@ void script_fcdb_free()
    Parse and execute the script in str in the lua instance for the freeciv
    database.
  */
-bool script_fcdb_do_string(struct connection *caller, const char *str)
+bool script_fcdb_do_string(server_connection *caller, const char *str)
 {
   /* Set a log callback function which allows to send the results of the
    * command to the clients. */
@@ -263,7 +263,12 @@ bool script_fcdb_do_string(struct connection *caller, const char *str)
   fcl_compat.output_fct = script_fcdb_cmd_reply;
   fcl_compat.caller = caller;
 
-  auto result = fcl->safe_script(str).valid();
+  bool result = false;
+  try {
+    result = fcl->safe_script(str).valid();
+  } catch (const std::exception &e) {
+    cmd_reply(CMD_FCDB, caller, C_FAIL, "%s", e.what());
+  }
 
   // Reset the changes.
   fcl_compat.caller = save_caller;

--- a/server/scripting/script_fcdb.cpp
+++ b/server/scripting/script_fcdb.cpp
@@ -205,30 +205,32 @@ bool script_fcdb_init(const QString &fcdb_luafile)
     tolua_game_open(fcl->lua_state());
     script_fcdb_register_functions();
     luascript_common_z(fcl->lua_state());
+
+    // Define the prototypes for the needed lua functions.
+    if (!fcl->safe_script_file(qUtf8Printable(fcdb_luafile_resolved))
+             .valid()) {
+      qCritical("Error loading the Freeciv21 database lua script '%s'.",
+                qUtf8Printable(fcdb_luafile_resolved));
+      script_fcdb_free();
+      return false;
+    }
+    script_fcdb_functions_check(qUtf8Printable(fcdb_luafile_resolved));
   } catch (const std::exception &e) {
     qCritical() << "Error loading the Freeciv21 database lua definition:"
                 << e.what();
-    script_fcdb_free();
+
+    // We haven't called database_init() yet and it may not exist.
+    delete fcl;
+    fcl = nullptr;
     return false;
   }
-
-  //   luascript_func_init(fcl->lua_state());
-
-  // Define the prototypes for the needed lua functions.
-  if (!fcl->safe_script_file(qUtf8Printable(fcdb_luafile_resolved))
-           .valid()) {
-    qCritical("Error loading the Freeciv21 database lua script '%s'.",
-              qUtf8Printable(fcdb_luafile_resolved));
-    script_fcdb_free();
-    return false;
-  }
-  script_fcdb_functions_check(qUtf8Printable(fcdb_luafile_resolved));
 
   if (!script_fcdb_database_init()) {
     qCritical("Error connecting to the database");
     script_fcdb_free();
     return false;
   }
+
   return true;
 }
 

--- a/server/scripting/script_fcdb.h
+++ b/server/scripting/script_fcdb.h
@@ -26,7 +26,8 @@ struct player;
 bool script_fcdb_init(const QString &fcdb_luafile);
 void script_fcdb_free();
 
-bool script_fcdb_do_string(struct connection *caller, const char *str);
+bool script_fcdb_do_string(struct server_connection *caller,
+                           const char *str);
 
 // Call Lua functions
 bool script_fcdb_user_delegate_to(connection *pconn, player *pplayer,


### PR DESCRIPTION
See commit messages. These are both related to tolua's `safe_*` functions throwing on error.