### PR TITLE
Allow querying and modifying buildings from Lua

### DIFF
--- a/client/packhand.cpp
+++ b/client/packhand.cpp
@@ -626,12 +626,12 @@ static bool update_improvement_from_packet(struct city *pcity,
                                            bool have_impr)
 {
   if (have_impr) {
-    if (pcity->built[improvement_index(pimprove)].turn <= I_NEVER) {
+    if (city_improvement_built_turn(pcity, pimprove) <= I_NEVER) {
       city_add_improvement(pcity, pimprove);
       return true;
     }
   } else {
-    if (pcity->built[improvement_index(pimprove)].turn > I_NEVER) {
+    if (city_improvement_built_turn(pcity, pimprove) > I_NEVER) {
       city_remove_improvement(pcity, pimprove);
       return true;
     }
@@ -900,7 +900,7 @@ void handle_city_info(const struct packet_city_info *packet)
     bool have = BV_ISSET(packet->improvements, improvement_index(pimprove));
 
     if (have && !city_is_new
-        && pcity->built[improvement_index(pimprove)].turn <= I_NEVER) {
+        && city_improvement_built_turn(pcity, pimprove) <= I_NEVER) {
       audio_play_sound(pimprove->soundtag, pimprove->soundtag_alt);
     }
     need_economy_dialog_update |=

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -3281,7 +3281,23 @@ void city_add_improvement(struct city *pcity,
 }
 
 /**
-  Removes an improvement (and its effects) from a city.
+ * Changes the turn on which an improvement has been built in a city. This
+ * can affect its 'Age' in effects. Note: this is a local change only.
+ */
+void city_improvement_built_turn_set(struct city *pcity,
+                                     const struct impr_type *pimprove,
+                                     int turn)
+{
+  log_debug("History rewrite: Improvement %s that was built on turn %d in "
+            "%s was now built on turn %d",
+            improvement_rule_name(pimprove),
+            pcity->built[improvement_index(pimprove)].turn, pcity->name,
+            turn);
+  pcity->built[improvement_index(pimprove)].turn = turn;
+}
+
+/**
+ * Removes an improvement (and its effects) from a city.
  */
 void city_remove_improvement(struct city *pcity,
                              const struct impr_type *pimprove)
@@ -3295,6 +3311,32 @@ void city_remove_improvement(struct city *pcity,
     // Client just read the info from the packets.
     wonder_destroyed(pcity, pimprove);
   }
+}
+
+/**
+ * Removes an improvement (and its effects) from a city, as if it had never
+ * been built.
+ */
+void city_improvement_unmake(struct city *pcity,
+                             const struct impr_type *pimprove)
+{
+  log_debug("History rewrite: Improvement %s was never built in city %s",
+            improvement_rule_name(pimprove), pcity->name);
+  pcity->built[improvement_index(pimprove)].turn = I_NEVER;
+  if (is_server() && is_wonder(pimprove)) {
+    // Client just read the info from the packets.
+    wonder_unmade(pcity, pimprove);
+  }
+}
+
+/**
+ * Gets the turn on which an improvement was built. If it was never built, it
+ * returns I_NEVER. If it was destroyed, it returns I_DESTROYED.
+ */
+int city_improvement_built_turn(struct city *pcity,
+                                const struct impr_type *pimprove)
+{
+  return pcity->built[improvement_index(pimprove)].turn;
 }
 
 /**

--- a/common/city.cpp
+++ b/common/city.cpp
@@ -3284,9 +3284,9 @@ void city_add_improvement(struct city *pcity,
  * Changes the turn on which an improvement has been built in a city. This
  * can affect its 'Age' in effects. Note: this is a local change only.
  */
-void city_improvement_built_turn_set(struct city *pcity,
-                                     const struct impr_type *pimprove,
-                                     int turn)
+void city_improvement_built_turn_override(struct city *pcity,
+                                          const struct impr_type *pimprove,
+                                          int turn)
 {
   log_debug("History rewrite: Improvement %s that was built on turn %d in "
             "%s was now built on turn %d",
@@ -3333,7 +3333,7 @@ void city_improvement_unmake(struct city *pcity,
  * Gets the turn on which an improvement was built. If it was never built, it
  * returns I_NEVER. If it was destroyed, it returns I_DESTROYED.
  */
-int city_improvement_built_turn(struct city *pcity,
+int city_improvement_built_turn(const struct city *pcity,
                                 const struct impr_type *pimprove)
 {
   return pcity->built[improvement_index(pimprove)].turn;

--- a/common/city.h
+++ b/common/city.h
@@ -679,12 +679,12 @@ void city_add_improvement(struct city *pcity,
                           const struct impr_type *pimprove);
 void city_remove_improvement(struct city *pcity,
                              const struct impr_type *pimprove);
-void city_improvement_built_turn_set(struct city *pcity,
-                                     const struct impr_type *pimprove,
-                                     int turn);
+void city_improvement_built_turn_override(struct city *pcity,
+                                          const struct impr_type *pimprove,
+                                          int turn);
 void city_improvement_unmake(struct city *pcity,
                              const struct impr_type *pimprove);
-int city_improvement_built_turn(struct city *pcity,
+int city_improvement_built_turn(const struct city *pcity,
                                 const struct impr_type *pimprove);
 
 // city update functions
@@ -735,7 +735,7 @@ bool city_exist(int id);
 #define city_built_iterate(_pcity, _p)                                      \
   improvement_iterate(_p)                                                   \
   {                                                                         \
-    if ((_pcity)->built[improvement_index(_p)].turn <= I_NEVER) {           \
+    if (city_improvement_built_turn(_pcity, _p) <= I_NEVER) {               \
       continue;                                                             \
     }
 

--- a/common/city.h
+++ b/common/city.h
@@ -679,6 +679,13 @@ void city_add_improvement(struct city *pcity,
                           const struct impr_type *pimprove);
 void city_remove_improvement(struct city *pcity,
                              const struct impr_type *pimprove);
+void city_improvement_built_turn_set(struct city *pcity,
+                                     const struct impr_type *pimprove,
+                                     int turn);
+void city_improvement_unmake(struct city *pcity,
+                             const struct impr_type *pimprove);
+int city_improvement_built_turn(struct city *pcity,
+                                const struct impr_type *pimprove);
 
 // city update functions
 void city_refresh_from_main_map(

--- a/common/improvement.cpp
+++ b/common/improvement.cpp
@@ -787,8 +787,8 @@ void wonder_built(const struct city *pcity, const struct impr_type *pimprove)
 }
 
 /**
- * Remove a wonder from a city as if it had never been built, allowing it to
- * be constructed again.
+ * Called when a wonder is deleted from a city to ensure it is also deleted
+ * from the player and game info so that it can be constructed again.
  */
 void wonder_unmade(const struct city *pcity,
                    const struct impr_type *pimprove)
@@ -806,8 +806,9 @@ void wonder_unmade(const struct city *pcity,
 }
 
 /**
-   Remove a wonder from a city and destroy it if it's a great wonder.  To
-   transfer a great wonder, use great_wonder_transfer.
+ * Called when a wonder is destroyed to ensure it is marked as lost for the
+ * player and marked as destroyed in game info so that it cannot be built
+ * again.
  */
 void wonder_destroyed(const struct city *pcity,
                       const struct impr_type *pimprove)

--- a/common/improvement.cpp
+++ b/common/improvement.cpp
@@ -787,6 +787,25 @@ void wonder_built(const struct city *pcity, const struct impr_type *pimprove)
 }
 
 /**
+ * Remove a wonder from a city as if it had never been built, allowing it to
+ * be constructed again.
+ */
+void wonder_unmade(const struct city *pcity,
+                   const struct impr_type *pimprove)
+{
+  fc_assert_ret(pcity);
+  fc_assert_ret(is_wonder(pimprove));
+  int windex = improvement_number(pimprove);
+  fc_assert_ret(city_owner(pcity)->wonders[windex]);
+  city_owner(pcity)->wonders[windex] = WONDER_NOT_BUILT;
+  if (is_great_wonder(pimprove)) {
+    fc_assert_ret(game.info.great_wonder_owners[windex]
+                  == player_number(city_owner(pcity)));
+    game.info.great_wonder_owners[windex] = WONDER_NOT_BUILT;
+  }
+}
+
+/**
    Remove a wonder from a city and destroy it if it's a great wonder.  To
    transfer a great wonder, use great_wonder_transfer.
  */

--- a/common/improvement.h
+++ b/common/improvement.h
@@ -105,6 +105,8 @@ improvement_replacement(const struct impr_type *pimprove);
 
 void wonder_built(const struct city *pcity,
                   const struct impr_type *pimprove);
+void wonder_unmade(const struct city *pcity,
+                   const struct impr_type *pimprove);
 void wonder_destroyed(const struct city *pcity,
                       const struct impr_type *pimprove);
 

--- a/common/scriptcore/stubs/game.lua
+++ b/common/scriptcore/stubs/game.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- Represents a nation in the game controlled by a specific player.
@@ -72,7 +72,7 @@ function Player:shares_research(tech) end
 function Player:research_rule_name() end
 
 --- 
---- @return string name As :lua:obj:`Player:research_rule_name` but translated.
+--- @return string name As :lua:obj:`Player.research_rule_name` but translated.
 function Player:research_name_translation() end
 
 --- 
@@ -85,7 +85,7 @@ function Player:culture() end
 ---    * - Flag
 ---      - Description
 ---    * - "ai"
----      - Same as :lua:obj:`~Player:ai_controlled`.
+---      - Inverse of :lua:obj:`Player.is_human`.
 ---    * - "ScenarioReserved"
 ---      - Not listed on game starting screen.
 ---
@@ -106,14 +106,24 @@ function Player:exists()
 end
 
 --- Safe iteration over each :lua:obj:`Unit` that belongs to a :lua:obj:`Player`.
-function Player:units_iterate()
-  return safe_iterate_list(private.Player.unit_list_head(self))
-end
+function Player:units_iterate() end
 
 --- Safe iteration over each :lua:obj:`City` that belongs to a :lua:obj:`Player`.
-function Player:cities_iterate()
-  return safe_iterate_list(private.Player.city_list_head(self))
-end
+function Player:cities_iterate() end
+
+--- Safe iteration over each wonder :lua:obj:`Building_Type` that belongs to a
+--- :lua:obj:`Player` using a snapshot of owned wonders at the start of
+--- iteration.
+---
+--- Version added: 3.2
+function Player:wonders_iterate() end
+
+--- Safe iteration over each :lua:obj:`Tech_Type` that belongs to a
+--- :lua:obj:`Player` using a snapshot of known technologies at the start of
+--- iteration.
+---
+--- Version added: 3.2
+function Player:technologies_iterate() end
 
 --- Represents a Team of players that are locked together as allies.
 ---
@@ -140,6 +150,12 @@ City = {}
 --- @param building Building_Type The building type to check.
 --- @return boolean present True if the given building type is in this city.
 function City:has_building(building) end
+
+--- Safe iteration over each :lua:obj:`Building_Type` in the city using a
+--- snapshot of buildings present at the start of the iteration.
+---
+--- Version added: 3.2
+function City:buildings_iterate() end
 
 --- 
 --- @return int sq-radius The square radius of the city working area.
@@ -227,7 +243,7 @@ function Unit:facing() end
 
 --- .. attention::
 ---    Warning: If unit is going to be removed, you must use 
----    :lua:obj:`Unit:tile_link_text` instead.
+---    :lua:obj:`Unit.tile_link_text` instead.
 ---
 --- @return string link-text Link string fragment to add to messages sent to client.
 function Unit:link_text() end
@@ -317,18 +333,18 @@ function Tile:has_extra(name) end
 
 --- 
 --- @param name boolean The ruleset name of any base-type extra.
---- @return boolean True, if the base is present on this tile.
+--- @return boolean present True, if the base is present on this tile.
 function Tile:has_base(name) end
 
 --- 
 --- @param name boolean The ruleset name of any road-type extra.
---- @return boolean True, if the road-type is present on this tile.
+--- @return boolean present True, if the road-type is present on this tile.
 function Tile:has_road(name) end
 
 --- The primary tile resource persists even if the terrain is changed to an
 --- incompatible type, and can be recovered if the terrain is changed back.
 --- This will report the name of the hidden resource in this case. Whereas
---- :lua:obj:`~Tile:has_extra` will only report whether the resource is
+--- :lua:obj:`Tile.has_extra` will only report whether the resource is
 --- currently visible.
 --- @return string name The ruleset name of the primary tile resource, or nil.
 function Tile:primary_resource_name() end
@@ -636,6 +652,11 @@ find = {}
 --- @return Player player The player with the given ID or name if they exist, or nil.
 function find.player(player_id_or_name) end
 
+--- Safe iteration over each :lua:obj:`Player` in the game.
+---
+--- Version added: 3.2
+function find.players_iterate() end
+
 --- 
 --- @param team_id_or_name int|string The unique ID or name of the player to search for.
 --- @return Team team The team with the given ID or name if they exist, or nil.
@@ -650,11 +671,25 @@ function find.teams_iterate() end
 --- @return City city The city if it exists and belongs to player, or nil
 function find.city(player, city_id) end
 
+--- Safe iteration over each :lua:obj:`City` in the game. See 
+--- :lua:obj:`Player.cities_iterate` for iterating over a specific player's
+--- cities.
+---
+--- Version added: 3.2
+function find.cities_iterate() end
+
 --- 
 --- @param player Player The player who owns the unit, or nil for any player
 --- @param unit_id int The unique ID for the unit to search for
 --- @return Unit unit The unit if it exists and belongs to player, or nil
 function find.unit(player, unit_id) end
+
+--- Safe iteration over each :lua:obj:`Unit` in the game. See
+--- :lua:obj:`Player.units_iterate` for iterating over a specific player's
+--- units.
+---
+--- Version added: 3.2
+function find.units_iterate() end
 
 --- Looks for an existing unit that can transport unit_type at tile. Intended
 --- to be used with create_unit_full, to spawn it directly into the hold of the
@@ -677,6 +712,11 @@ function find.tile(nat_x, nat_y) end
 --- @return Tile tile The found tile.
 function find.tile(tindex) end
 
+--- Safe iteration over each :lua:obj:`Tile` in the world.
+---
+--- Version added: 3.2
+function find.tiles_iterate() end
+
 --- Finds a government by its name.
 --- @param name string The ruleset name of the government.
 --- @return Government government The found government.
@@ -687,6 +727,11 @@ function find.government(name) end
 --- @return Government government The found government.
 function find.government(government_id) end
 
+--- Safe iteration over each :lua:obj:`Government` type in the game.
+---
+--- Version added: 3.2
+function find.government_types_iterate() end
+
 --- Finds a nation type by its name.
 --- @param name string The ruleset name of the nation type.
 --- @return Nation_Type nation The found nation type.
@@ -696,6 +741,11 @@ function find.nation_type(name) end
 --- @param nation_type_id int The ID of the nation type.
 --- @return Nation_Type nation The found nation type.
 function find.nation_type(nation_type_id) end
+
+--- Safe iteration over each :lua:obj:`Nation_Type` in the game.
+---
+--- Version added: 3.2
+function find.nation_types_iterate() end
 
 --- Finds an action by its rule name.
 --- @param name string The ruleset name of the action.
@@ -711,6 +761,11 @@ function find.action(name) end
 --- @return Action action The found action.
 function find.action(action_type_id) end
 
+--- Safe iteration over each :lua:obj:`Action` in the game.
+---
+--- Version added: 3.2
+function find.action_types_iterate() end
+
 --- Finds a building type by its name.
 --- @param name string The ruleset name of the building type.
 --- @return Building_Type building The found building type.
@@ -720,6 +775,11 @@ function find.building_type(name) end
 --- @param building_type_id int The ID of the building type.
 --- @return Building_Type building The found building type.
 function find.building_type(building_type_id) end
+
+--- Safe iteration over each :lua:obj:`Building_Type` in the game.
+---
+--- Version added: 3.2
+function find.building_types_iterate() end
 
 --- Finds a unit type by its name.
 --- @param name string The ruleset name of the unit type.
@@ -764,6 +824,11 @@ function find.tech_type(name) end
 --- @return Tech_Type tech The found tech type.
 function find.tech_type(tech_type_id) end
 
+--- Safe iteration over each :lua:obj:`Tech_Type` in the game.
+---
+--- Version added: 3.2
+function find.technologies_iterate() end
+
 --- Finds a terrain by its name.
 --- @param name string The ruleset name of the terrain.
 --- @return Terrain terrain The found terrain.
@@ -774,10 +839,15 @@ function find.terrain(name) end
 --- @return Terrain terrain The found terrain.
 function find.terrain(terrain_id) end
 
+--- Safe iteration over each :lua:obj:`Terrain_Type` in the game.
+---
+--- Version added: 3.2
+function find.terrain_types_iterate() end
+
 
 --- Calculate the current value of a 
 --- :ref:`ruleset effect <modding-rulesets-effects>`. Effect names are the same
---- as in rulesets, e.g., "``Upkeep_Free``". 
+--- as in rulesets, e.g., ":ref:`effect-upkeep-free`". 
 ---
 --- !doctype table
 --- @class effects
@@ -827,11 +897,15 @@ function direction.opposite(direction) end
 
 
 --- Iterate over each :lua:obj:`Player` in the game.
+---
+--- Deprecated: 3.2 - Use :lua:obj:`find.players_iterate` instead.
 function players_iterate()
   return index_iterate(find.player)
 end
 
 --- Iterate over each :lua:obj:`Tile` on the map.
+---
+--- Deprecated: 3.2 - Use :lua:obj:`find.tiles_iterate` instead.
 function whole_map_iterate()
   return index_iterate(find.tile)
 end

--- a/common/scriptcore/stubs/game.lua
+++ b/common/scriptcore/stubs/game.lua
@@ -654,6 +654,11 @@ function find.player(player_id_or_name) end
 
 --- Safe iteration over each :lua:obj:`Player` in the game.
 ---
+--- .. note::
+---    If there is a chance that a :lua:obj:`Player` is deleted during
+---    iteration, it is a good idea to use :lua:obj:`~Nonexistent.exists` to
+---    check it is still present before attempting to use it.
+---
 --- Version added: 3.2
 function find.players_iterate() end
 
@@ -675,6 +680,11 @@ function find.city(player, city_id) end
 --- :lua:obj:`Player.cities_iterate` for iterating over a specific player's
 --- cities.
 ---
+--- .. note::
+---    If there is a chance that a :lua:obj:`City` is destroyed during
+---    iteration, it is a good idea to use :lua:obj:`~Nonexistent.exists` to
+---    check it is still present before attempting to use it.
+---
 --- Version added: 3.2
 function find.cities_iterate() end
 
@@ -687,6 +697,11 @@ function find.unit(player, unit_id) end
 --- Safe iteration over each :lua:obj:`Unit` in the game. See
 --- :lua:obj:`Player.units_iterate` for iterating over a specific player's
 --- units.
+---
+--- .. note::
+---    If there is a chance that a :lua:obj:`Unit` dies during
+---    iteration, it is a good idea to use :lua:obj:`~Nonexistent.exists` to
+---    check it is still present before attempting to use it.
 ---
 --- Version added: 3.2
 function find.units_iterate() end

--- a/common/scriptcore/stubs/luascript.lua
+++ b/common/scriptcore/stubs/luascript.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- @param text String The raw text to translate.

--- a/common/scriptcore/stubs/notify_events.lua
+++ b/common/scriptcore/stubs/notify_events.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- The E module contains a set of event types, for example :lua:obj:`E.SCRIPT`.

--- a/common/scriptcore/stubs/signal.lua
+++ b/common/scriptcore/stubs/signal.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- Signals are emitted by the server when certain events occur. 

--- a/common/scriptcore/stubs/signal_events.lua
+++ b/common/scriptcore/stubs/signal_events.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 
@@ -27,8 +27,8 @@
 ---    signal.connect(signal_name, callback_name)
 ---
 --- Currently, signals are only sent to ruleset scripts running on the server.
---- The set of signals is defined in :file:`server/scripting/script_server.cpp`
---- (search for "``script_server_signals_create``").
+--- The set of signals is defined in
+--- `server/scripting/script_server.cpp <https://github.com/longturn/freeciv21/blob/a6ce76be735fea0a61b39495631f86e12fdafd96/server/scripting/script_server.cpp#L391>`_.
 ---
 --- If false is returned from a signal handler function, the signal will not
 --- propagate to any subsequent signal handlers.

--- a/common/scriptcore/stubs/signal_events.lua
+++ b/common/scriptcore/stubs/signal_events.lua
@@ -28,7 +28,7 @@
 ---
 --- Currently, signals are only sent to ruleset scripts running on the server.
 --- The set of signals is defined in
---- `server/scripting/script_server.cpp <https://github.com/longturn/freeciv21/blob/a6ce76be735fea0a61b39495631f86e12fdafd96/server/scripting/script_server.cpp#L391>`_.
+--- `server/scripting/script_server.cpp <https://github.com/search?q=repo%3Alongturn%2Ffreeciv21+path%3Aserver%2Fscripting%2Fscript_server.cpp+%22luascript_signal_create%22&type=code>`_.
 ---
 --- If false is returned from a signal handler function, the signal will not
 --- propagate to any subsequent signal handlers.

--- a/common/scriptcore/tolua_common_a.lua
+++ b/common/scriptcore/tolua_common_a.lua
@@ -12,7 +12,7 @@
 
 -- For code documentation, see:
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- Checks if the object (still) exists.

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -706,6 +706,18 @@ do
     return value_iterator(objs)
   end
 
+  -- Iterate over the values in the iterator, apply a filter, and create a safe
+  -- copy
+  local function safe_iterate_filtered(iterator, filter)
+    local objs = {}
+    for obj in iterator() do
+      if filter(obj) then
+        objs[#objs + 1] = obj
+      end
+    end
+    return value_iterator(objs)
+  end
+
   -- Safe iteration over all units that belong to Player
   function Player:units_iterate()
     return safe_iterate_list(private.Player.unit_list_head(self))
@@ -729,6 +741,30 @@ do
   -- Safe iteration over the units transported by Unit
   function Unit:cargo_iterate()
     return safe_iterate_list(private.Unit.cargo_list_head(self))
+  end
+
+  -- Safe iteration over each Building_Type present in the City
+  function City:buildings_iterate()
+    local function has_building(building)
+      return self:has_building(building)
+    end
+    return safe_iterate_filtered(find.building_types_iterate, has_building)
+  end
+
+  -- Safe iteration over each wonder a Player has
+  function Player:wonders_iterate()
+    local function has_wonder(building)
+      return self:has_wonder(building)
+    end
+    return safe_iterate_filtered(find.building_types_iterate, has_wonder)
+  end
+
+  -- Safe iteration over each Tech_Type a Player has
+  function Player:technologies_iterate()
+    local function knows_tech(tech_type)
+      return self:knows_tech(tech_type)
+    end
+    return safe_iterate_filtered(find.technologies_iterate, knows_tech)
   end
 end
 
@@ -787,9 +823,57 @@ do
     return iterator
   end
 
+  -- Iterate over all players in the game
+  function find.players_iterate()
+    return index_iterate(find.player)
+  end
+
   -- Iterate over all teams in the game
   function find.teams_iterate()
     return index_iterate(find.team)
+  end
+
+  local function find_city(city_id)
+    return find.city(nil, city_id)
+  end
+
+  -- Iterate over all cities in the world regardless of nation
+  function find.cities_iterate()
+    return index_iterate(find_city)
+  end
+
+  local function find_unit(unit_id)
+    return find.unit(nil, unit_id)
+  end
+
+  -- Iterate over all cities in the world regardless of nation
+  function find.units_iterate()
+    return index_iterate(find_unit)
+  end
+
+  -- Iterate over all tiles of the game
+  function find.tiles_iterate()
+    return index_iterate(find.tile)
+  end
+
+  -- Iterate over all government types in the game
+  function find.government_types_iterate()
+    return index_iterate(find.government)
+  end
+
+  -- Iterate over all nation types in the game
+  function find.nation_types_iterate()
+    return index_iterate(find.nation_type)
+  end
+
+  -- Iterate over all action types in the game
+  function find.action_types_iterate()
+    return index_iterate(find.action)
+  end
+
+  -- Iterate over all building types in the game
+  function find.building_types_iterate()
+    return index_iterate(find.building_type)
   end
 
   -- Iterate over all unit types in the game
@@ -802,18 +886,25 @@ do
     return index_iterate(find.unit_class)
   end
 
-  -- Iterate over all players of the game
+  -- Iterate over all technologies in the game
+  function find.technologies_iterate()
+    return index_iterate(find.tech_type)
+  end
+
+  -- Iterate over all terrain types in the game
+  function find.terrain_types_iterate()
+    return index_iterate(find.terrain)
+  end
+
+  -- DEPRECATED: use find.players_iterate instead
   function players_iterate()
     return index_iterate(find.player)
   end
 
-  -- Iterate over all tiles of the game
+  -- DEPRECATED: use find.tiles_iterate instead
   function whole_map_iterate()
     return index_iterate(find.tile)
   end
-
-  -- NOTE: Identical further definitions can be made for
-  -- governments, tech_types, building_types etc
 end
 
 $]

--- a/data/default/default.lua
+++ b/data/default/default.lua
@@ -13,7 +13,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- Get gold from entering a hut.

--- a/docs/Modding/Rulesets/script.rst
+++ b/docs/Modding/Rulesets/script.rst
@@ -7,7 +7,7 @@
 .. https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 .. https://luals.github.io/wiki/definition-files
 .. https://luals.github.io/wiki/annotations/#documenting-types
-.. https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+.. https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 .. https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 .. include:: /global-include.rst

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -2826,19 +2826,32 @@ void do_sell_building(struct player *pplayer, struct city *pcity,
 }
 
 /**
+ * Emits a 'building_lost' signal, and returns true if the city survived.
+ */
+bool signal_building_lost(struct city *pcity,
+                          const struct impr_type *pimprove,
+                          const char *reason, struct unit *destroyer)
+{
+  fc_assert_ret_val(pcity, true);
+  fc_assert_ret_val(pimprove, true);
+  fc_assert_ret_val(reason, true);
+  int city_id = pcity->id;
+  script_server_signal_emit("building_lost", pcity, pimprove, reason,
+                            destroyer);
+  return city_exist(city_id);
+}
+
+/**
    Remove building from the city. Emits lua signal.
  */
 bool building_removed(struct city *pcity, const struct impr_type *pimprove,
                       const char *reason, struct unit *destroyer)
 {
-  int backup = pcity->id;
-
+  fc_assert_ret_val(pcity, true);
+  fc_assert_ret_val(pimprove, true);
+  fc_assert_ret_val(reason, true);
   city_remove_improvement(pcity, pimprove);
-
-  script_server_signal_emit("building_lost", pcity, pimprove, reason,
-                            destroyer);
-
-  return city_exist(backup);
+  return signal_building_lost(pcity, pimprove, reason, destroyer);
 }
 
 /**
@@ -2872,6 +2885,150 @@ void building_lost(struct city *pcity, const struct impr_type *pimprove,
      * range increases or decreases. */
     city_refresh_vision(pcity);
   }
+}
+
+/**
+ * Called when a city's improvement has changed. The city is updated, with
+ * workers being rearranged if needed, the city's vision radius may be
+ * refreshed, and data about the city and wonder statuses are sent to
+ * clients.
+ */
+void send_city_improvement_changed_data(struct city *pcity,
+                                        const struct impr_type *pimprove)
+{
+  fc_assert_ret(pcity);
+  if (city_refresh(pcity)) {
+    auto_arrange_workers(pcity);
+  }
+  city_refresh_vision(pcity);
+  send_city_info(nullptr, pcity);
+  if (is_wonder(pimprove)) {
+    if (is_great_wonder(pimprove)) {
+      send_game_info(nullptr);
+    }
+    send_player_info_c(city_owner(pcity), nullptr);
+  }
+}
+
+/**
+ * Record the build turn of a wonder. Used in city processing to figure
+ * out which wonders are built on the same turn and not yet effective.
+ */
+void wonder_set_build_turn(struct player *pplayer,
+                           const struct impr_type *pimprove, int turn)
+{
+  int windex = improvement_number(pimprove);
+  if (!is_wonder(pimprove)) {
+    return;
+  }
+  pplayer->wonder_build_turn[windex] = turn;
+}
+
+/**
+ * Called when a national wonder is built to ensure that it is unique within
+ * the nation by removing it if it already exists in a previous location.
+ */
+void small_wonder_moved(struct city *pcity, const struct impr_type *pimprove)
+{
+  fc_assert_ret(pcity);
+  fc_assert_ret(pimprove);
+  if (!is_small_wonder(pimprove)) {
+    return;
+  }
+  city_list_iterate(city_owner(pcity)->cities, wcity)
+  {
+    if (pcity != wcity && city_has_building(wcity, pimprove)) {
+      city_remove_improvement(wcity, pimprove);
+      send_city_improvement_changed_data(wcity, pimprove);
+      break;
+    }
+  }
+  city_list_iterate_end;
+}
+
+/**
+ * Emits a 'building_built' signal, and returns true if the city still
+ * exists. Should be called when a building is completed.
+ */
+bool signal_building_built(struct city *pcity,
+                           const struct impr_type *pimprove)
+{
+  fc_assert_ret_val(pcity, true);
+  fc_assert_ret_val(pimprove, true);
+  int city_id = pcity->id;
+  script_server_signal_emit("building_built", pimprove, pcity);
+  return city_exist(city_id);
+}
+
+/**
+ * Creates a building if it doesn't already exist in the given city.
+ */
+void do_building_create(struct city *pcity, const struct impr_type *pimprove)
+{
+  fc_assert_ret(pcity);
+  fc_assert_ret(pimprove);
+  fc_assert_ret(!is_special_improvement(pimprove));
+  if (city_has_building(pcity, pimprove)) {
+    return;
+  }
+  small_wonder_moved(pcity, pimprove);
+  city_add_improvement(pcity, pimprove);
+}
+
+/**
+ * Sets the turn a building was created on to the given turn. This can affect
+ * the 'Age' in requirements.
+ */
+void do_building_built_turn_set(struct city *pcity,
+                                const struct impr_type *pimprove, int turn)
+{
+  fc_assert_ret(pcity);
+  fc_assert_ret(pimprove);
+  fc_assert_ret(!is_special_improvement(pimprove));
+  fc_assert_ret(turn >= 0);
+  fc_assert_ret(turn <= game.info.turn);
+  fc_assert_ret(city_has_building(pcity, pimprove));
+  wonder_set_build_turn(city_owner(pcity), pimprove, turn);
+  city_improvement_built_turn_set(pcity, pimprove, turn);
+}
+
+/**
+ * Deletes a building from a city as if it had never been built. Great
+ * wonders removed this way can be built again. A removed palace can cause a
+ * reset of spaceship progress.
+ */
+void do_building_unmake(struct city *pcity, const struct impr_type *pimprove)
+{
+  fc_assert_ret(pcity);
+  fc_assert_ret(pimprove);
+  fc_assert_ret(city_has_building(pcity, pimprove));
+  struct player *owner = city_owner(pcity);
+  bool was_capital = is_capital(pcity);
+  city_improvement_unmake(pcity, pimprove);
+  if (was_capital && !is_capital(pcity)
+      && (owner->spaceship.state == SSHIP_STARTED
+          || owner->spaceship.state == SSHIP_LAUNCHED)) {
+    spaceship_lost(owner);
+  }
+}
+
+/**
+ * Destroy a building in a city, emit a 'building_lost' lua signal event with
+ * the given reason and optional destroyer unit, and update the city. Does
+ * not send a destruction notification or update clients. Returns true if the
+ * city still exists afterwards.
+ */
+bool do_building_destroy(struct city *pcity,
+                         const struct impr_type *pimprove,
+                         const char *reason, struct unit *destroyer)
+{
+  fc_assert_ret_val(pcity, true);
+  fc_assert_ret_val(pimprove, true);
+  fc_assert_ret_val(city_has_building(pcity, pimprove), true);
+  fc_assert_ret_val(reason, true);
+  int city_id = pcity->id;
+  building_lost(pcity, pimprove, reason, destroyer);
+  return city_exist(city_id);
 }
 
 /**

--- a/server/citytools.cpp
+++ b/server/citytools.cpp
@@ -2989,7 +2989,7 @@ void do_building_built_turn_set(struct city *pcity,
   fc_assert_ret(turn <= game.info.turn);
   fc_assert_ret(city_has_building(pcity, pimprove));
   wonder_set_build_turn(city_owner(pcity), pimprove, turn);
-  city_improvement_built_turn_set(pcity, pimprove, turn);
+  city_improvement_built_turn_override(pcity, pimprove, turn);
 }
 
 /**

--- a/server/citytools.h
+++ b/server/citytools.h
@@ -72,10 +72,30 @@ void city_illness_strike(struct city *pcity);
 
 void do_sell_building(struct player *pplayer, struct city *pcity,
                       struct impr_type *pimprove, const char *reason);
+bool signal_building_lost(struct city *pcity,
+                          const struct impr_type *pimprove,
+                          const char *reason, struct unit *destroyer);
 bool building_removed(struct city *pcity, const struct impr_type *pimprove,
                       const char *reason, struct unit *destroyer);
 void building_lost(struct city *pcity, const struct impr_type *pimprove,
                    const char *reason, struct unit *destroyer);
+void send_city_improvement_changed_data(struct city *pcity,
+                                        const struct impr_type *pimprove);
+void wonder_set_build_turn(struct player *pplayer,
+                           const struct impr_type *pimprove, int turn);
+void small_wonder_moved(struct city *pcity,
+                        const struct impr_type *pimprove);
+bool signal_building_built(struct city *pcity,
+                           const struct impr_type *pimprove);
+void do_building_create(struct city *pcity,
+                        const struct impr_type *pimprove);
+void do_building_built_turn_set(struct city *pcity,
+                                const struct impr_type *pimprove, int turn);
+void do_building_unmake(struct city *pcity,
+                        const struct impr_type *pimprove);
+bool do_building_destroy(struct city *pcity,
+                         const struct impr_type *pimprove,
+                         const char *reason, struct unit *destroyer);
 void city_units_upkeep(const struct city *pcity);
 
 void change_build_target(struct player *pplayer, struct city *pcity,

--- a/server/cityturn.cpp
+++ b/server/cityturn.cpp
@@ -89,8 +89,6 @@ static bool worklist_change_build_target(struct player *pplayer,
 
 static bool city_distribute_surplus_shields(struct player *pplayer,
                                             struct city *pcity);
-static void wonder_set_build_turn(struct player *pplayer,
-                                  const struct impr_type *pimprove);
 static bool city_build_building(struct player *pplayer, struct city *pcity);
 static bool city_build_unit(struct player *pplayer, struct city *pcity);
 static bool city_build_stuff(struct player *pplayer, struct city *pcity);
@@ -2316,22 +2314,6 @@ static bool city_distribute_surplus_shields(struct player *pplayer,
 }
 
 /**
-  Record the build turn of a wonder. Used in city processing to figure
-  out which wonders are built on the same turn and not yet effective.
- */
-static void wonder_set_build_turn(struct player *pplayer,
-                                  const struct impr_type *pimprove)
-{
-  int windex = improvement_number(pimprove);
-
-  if (!is_wonder(pimprove)) {
-    return;
-  }
-
-  pplayer->wonder_build_turn[windex] = game.info.turn;
-}
-
-/**
    Returns FALSE when the city is removed, TRUE otherwise.
  */
 static bool city_build_building(struct player *pplayer, struct city *pcity)
@@ -2392,7 +2374,7 @@ static bool city_build_building(struct player *pplayer, struct city *pcity)
       space_part = false;
       city_add_improvement(pcity, pimprove);
       /* New city turn: wonders only take effect next turn */
-      wonder_set_build_turn(pplayer, pimprove);
+      wonder_set_build_turn(pplayer, pimprove, game.info.turn);
     }
     cost = impr_build_shield_cost(pcity, pimprove);
     pcity->bought_shields = 0;

--- a/server/scripting/api_server_edit.cpp
+++ b/server/scripting/api_server_edit.cpp
@@ -685,10 +685,10 @@ bool api_edit_city_building_construct(lua_State *L, City *pcity,
 
 /**
  * Instantly construct a building in the given city as if it had been built
- * on a given turn. Or modifies the turn if it has already been built. No
- * notifications are generated, and data about the change is sent to clients
- * immediately. Returns false if the building was already built on the given
- * turn.
+ * on a given turn as far as the 'Age' requirement is concerned. Or modifies
+ * the turn if it has already been built. No notifications are generated, and
+ * data about the change is sent to clients immediately. Returns false if the
+ * building was already built on the given turn.
  */
 bool api_edit_city_building_built_turn_set(lua_State *L, City *pcity,
                                            Building_Type *impr, int turn)

--- a/server/scripting/api_server_edit.cpp
+++ b/server/scripting/api_server_edit.cpp
@@ -663,6 +663,102 @@ void api_edit_remove_city(lua_State *L, City *pcity)
 }
 
 /**
+ * Instantly construct a building in the given city. A notification is
+ * generated for the city owner, and data is sent to clients about the change
+ * immediately. Returns false if the building was already present.
+ */
+bool api_edit_city_building_construct(lua_State *L, City *pcity,
+                                      Building_Type *impr)
+{
+  LUASCRIPT_CHECK_STATE(L, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, pcity, 2, City, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, impr, 3, Building_Type, false);
+  if (city_has_building(pcity, impr)) {
+    return false;
+  }
+  do_building_create(pcity, impr);
+  if (signal_building_built(pcity, impr)) {
+    send_city_improvement_changed_data(pcity, impr);
+  }
+  return true;
+}
+
+/**
+ * Instantly construct a building in the given city as if it had been built
+ * on a given turn. Or modifies the turn if it has already been built. No
+ * notifications are generated, and data about the change is sent to clients
+ * immediately. Returns false if the building was already built on the given
+ * turn.
+ */
+bool api_edit_city_building_built_turn_set(lua_State *L, City *pcity,
+                                           Building_Type *impr, int turn)
+{
+  LUASCRIPT_CHECK_STATE(L, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, pcity, 2, City, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, impr, 3, Building_Type, false);
+  LUASCRIPT_CHECK(
+      L, turn > 0 && turn <= game.info.turn,
+      "built turn must be between 1 and the current turn (inclusive)",
+      false);
+  if (city_improvement_built_turn(pcity, impr) == turn) {
+    return false;
+  }
+  if (!city_has_building(pcity, impr)) {
+    do_building_create(pcity, impr);
+  }
+  do_building_built_turn_set(pcity, impr, turn);
+  send_city_improvement_changed_data(pcity, impr);
+  return true;
+}
+
+/**
+ * Instantly destroy a building in the given city, including a reason and
+ * optionally a unit responsible for the destruction that will appear in
+ * 'building_lost' lua signal events. This can be any arbitrary string. Great
+ * wonders destroyed in this way will become lost and so are ineligible for
+ * rebuilding. Data about this change is sent to clients immediately, and
+ * notifications are generated. Returns false if this building wasn't present
+ * in the city.
+ */
+bool api_edit_city_building_destroy(lua_State *L, City *pcity,
+                                    Building_Type *impr, const char *reason,
+                                    Unit *destroyer)
+{
+  LUASCRIPT_CHECK_STATE(L, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, pcity, 2, City, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, impr, 3, Building_Type, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, reason, 4, string, false);
+  if (!city_has_building(pcity, impr)) {
+    return false;
+  }
+  if (do_building_destroy(pcity, impr, reason, destroyer)) {
+    send_city_improvement_changed_data(pcity, impr);
+  }
+  return true;
+}
+
+/**
+ * Instantly remove a building in the given city as if it had never been
+ * built. Great wonders removed in this way will become buildable again. No
+ * notifications are generated, and the data about this change is sent to
+ * clients immediately. Returns false if the building wasn't present in the
+ * city.
+ */
+bool api_edit_city_building_unmake(lua_State *L, City *pcity,
+                                   Building_Type *impr)
+{
+  LUASCRIPT_CHECK_STATE(L, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, pcity, 2, City, false);
+  LUASCRIPT_CHECK_ARG_NIL(L, impr, 3, Building_Type, false);
+  if (!city_has_building(pcity, impr)) {
+    return false;
+  }
+  do_building_unmake(pcity, impr);
+  send_city_improvement_changed_data(pcity, impr);
+  return true;
+}
+
+/**
    Create a new player.
  */
 Player *api_edit_create_player(lua_State *L, const char *username,

--- a/server/scripting/api_server_edit.h
+++ b/server/scripting/api_server_edit.h
@@ -73,6 +73,15 @@ void api_edit_create_city(lua_State *L, Player *pplayer, Tile *ptile,
 void api_edit_resize_city(lua_State *L, City *pcity, int size,
                           const char *reason);
 void api_edit_remove_city(lua_State *L, City *pcity);
+bool api_edit_city_building_construct(lua_State *L, City *pcity,
+                                      Building_Type *impr);
+bool api_edit_city_building_built_turn_set(lua_State *L, City *pcity,
+                                           Building_Type *impr, int turn);
+bool api_edit_city_building_destroy(lua_State *L, City *pcity,
+                                    Building_Type *impr, const char *reason,
+                                    Unit *destroyer);
+bool api_edit_city_building_unmake(lua_State *L, City *pcity,
+                                   Building_Type *impr);
 Player *api_edit_create_player(lua_State *L, const char *username,
                                Nation_Type *pnation, const char *ai);
 void api_edit_change_gold(lua_State *L, Player *pplayer, int amount);

--- a/server/scripting/stubs/server.lua
+++ b/server/scripting/stubs/server.lua
@@ -264,6 +264,10 @@ function edit.remove_city(city) end
 --- generated for the city owner, and data is sent to clients about the change
 --- immediately.
 ---
+--- .. note::
+---    This does not check building requirements so you can use it to place
+---    improvements in cities where they would normally be invalid.
+---
 --- Version added: 3.2
 ---
 --- @param city City The city to construct the building in
@@ -271,10 +275,14 @@ function edit.remove_city(city) end
 --- @return bool success False, if the building was already present
 function edit.city_building_construct(city, building_type) end
 
---- Instantly construct a building in the given city as if it had been built on
---- a given turn. Or modifies the turn if it has already been built. No
---- notifications are generated, and data about the change is sent to clients
---- immediately.
+--- Instantly construct a building in the given city as if it had been built
+--- on a given turn as far as the 'Age' requirement is concerned. Or modifies
+--- the turn if it has already been built. No notifications are generated, and
+--- data about the change is sent to clients immediately.
+---
+--- .. note::
+---    This does not check building requirements so you can use it to place
+---    improvements in cities where they would normally be invalid.
 ---
 --- Version added: 3.2
 ---

--- a/server/scripting/stubs/server.lua
+++ b/server/scripting/stubs/server.lua
@@ -16,7 +16,7 @@
 -- https://longturn.readthedocs.io/en/latest/Contributing/style-guide.html
 -- https://luals.github.io/wiki/definition-files
 -- https://luals.github.io/wiki/annotations/#documenting-types
--- https://taminomara.github.io/sphinx-lua-ls/index.html#autodoc-directives
+-- https://sphinx-lua-ls.readthedocs.io/en/stable/autodoc.html#autodoc-directives
 -- https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer
 
 --- The server module is for interacting with the server, and getting
@@ -37,7 +37,7 @@ function server.save(filename) end
 --- @return boolean started True, if the game has been started.
 function server.started() end
 
---- Same as :lua:obj:`Player:civilization_score`
+--- Same as :lua:obj:`Player.civilization_score`
 --- @param player Player
 --- @return int score
 function server.civilization_score(player) end
@@ -250,7 +250,7 @@ function edit.change_terrain(tile, terrain) end
 function edit.create_city(player, tile, name) end
 
 --- Resizes a city. The reason is a user-defined value that will show up in
---- :lua:obj:`~Event.city_size_change` signal events.
+--- :lua:obj:`~Events.city_size_change` signal events.
 --- @param city City The city to resize.
 --- @param size int The new size of the city.
 --- @param reason string The reason for resizing the city.
@@ -259,6 +259,57 @@ function edit.resize_city(city, size, reason) end
 --- Removes a city.
 --- @param city City The city to be removed.
 function edit.remove_city(city) end
+
+--- Instantly construct a building in the given city. A notification is
+--- generated for the city owner, and data is sent to clients about the change
+--- immediately.
+---
+--- Version added: 3.2
+---
+--- @param city City The city to construct the building in
+--- @param building_type Building_Type The building to construct
+--- @return bool success False, if the building was already present
+function edit.city_building_construct(city, building_type) end
+
+--- Instantly construct a building in the given city as if it had been built on
+--- a given turn. Or modifies the turn if it has already been built. No
+--- notifications are generated, and data about the change is sent to clients
+--- immediately.
+---
+--- Version added: 3.2
+---
+--- @param city City The city of the building being modified
+--- @param building_type Building_Type The building to edit the built date of
+--- @param turn int The turn the building should be considered to have been built on
+--- @return bool success False, if the building was already built on that turn
+function edit.city_building_built_turn_set(city, building_type, turn) end
+
+--- Instantly destroy a building in the given city. Great wonders destroyed in
+--- this way will become lost and so are ineligible for rebuilding. Data about
+--- this change is sent to clients immediately, a
+--- :lua:obj:`~Events.building_lost` signal is propagated, and notifications are
+--- generated.
+---
+--- Version added: 3.2
+---
+--- @param city City The city of the building being destroyed
+--- @param building_type Building_Type The building to destroy
+--- @param reason string A reason to provide to :lua:obj:`~Events.building_lost` for the destruction. Can be any arbitrary string.
+--- @param destroyer Unit A unit credited with the destruction, if any, or nil
+--- @return bool success False, if that building was not present to destroy
+function edit.city_building_destroy(city, building_type, reason, destroyer) end
+
+--- Instantly remove a building in the given city as if it had never been built.
+--- Great wonders removed in this way will become buildable again. No
+--- notifications are generated, no :lua:obj:`~Events.building_lost` signal is
+--- propagated, and the data about this change is sent to clients immediately.
+---
+--- Version added: 3.2
+---
+--- @param city City The city of the building being deleted
+--- @param building_type Building_Type The building to delete
+--- @return bool success False, if the building wasn't present in the city.
+function edit.city_building_unmake(city, building_type) end
 
 --- Creates an owned extra on a tile. This will claim ownership of any other
 --- ownable extras on the tile too.
@@ -269,14 +320,14 @@ function edit.create_owned_extra(tile, name, player) end
 
 --- Creates an extra on a tile. Note that this does not affect the primary
 --- resource of a tile. If you want to change the primary resource, use 
---- :lua:obj:`edit.set_primary_resource` instead.
+--- :lua:obj:`edit.tile_primary_resource_set` instead.
 --- @param tile Tile The tile where the extra is created.
 --- @param name string The name of the extra.
 function edit.create_extra(tile, name) end
 
 --- Removes an extra from a tile. Note that this does not affect the primary
 --- resource of a tile. If you want to change the primary resource, use 
---- :lua:obj:`edit.set_primary_resource` instead.
+--- :lua:obj:`edit.tile_primary_resource_set` instead.
 --- @param tile Tile The tile from which the extra is removed.
 --- @param name string The name of the extra to remove.
 function edit.remove_extra(tile, name) end
@@ -284,7 +335,7 @@ function edit.remove_extra(tile, name) end
 --- Changes the primary resource for a tile. The primary resource persists even
 --- if the terrain changes to an incompatible type, and can be recovered if the
 --- terrain is changed to a compatible type again. Unlike resources created by
---- :lua:obj:`~edit.create_extra` which disappear forever.
+--- :lua:obj:`edit.create_extra` which disappear forever.
 --- @param tile Tile The tile to set the primary resource for.
 --- @param name string The name of the resource, or nil to remove.
 function edit.tile_primary_resource_set(tile, name) end
@@ -572,6 +623,53 @@ function City:add_history(amount)
   edit.add_city_history(self, amount)
 end
 
+--- Instantly construct a building in the given city. A notification is
+--- generated for the city owner, and data is sent to clients about the change
+--- immediately.
+---
+--- Version added: 3.2
+---
+--- @param building_type Building_Type The building to construct
+--- @return bool success False, if the building was already present
+function City:building_construct(building_type) end
+
+--- Instantly construct a building in the given city as if it had been built on
+--- a given turn. Or modifies the turn if it has already been built. No
+--- notifications are generated, and data about the change is sent to clients
+--- immediately.
+---
+--- Version added: 3.2
+---
+--- @param building_type Building_Type The building to edit the built date of
+--- @param turn int The turn the building should be considered to have been built on
+--- @return bool success False, if the building was already built on that turn
+function City:building_built_turn_set(building_type, turn) end
+
+--- Instantly destroy a building in the given city. Great wonders destroyed in
+--- this way will become lost and so are ineligible for rebuilding. Data about
+--- this change is sent to clients immediately, a
+--- :lua:obj:`~Events.building_lost` signal is propagated, and notifications are
+--- generated.
+---
+--- Version added: 3.2
+---
+--- @param building_type Building_Type The building to destroy
+--- @param reason string A reason to provide to :lua:obj:`~Events.building_lost` for the destruction. Can be any arbitrary string.
+--- @param destroyer Unit A unit credited with the destruction, if any, or nil
+--- @return bool success False, if that building was not present to destroy
+function City:building_destroy(building_type, reason, destroyer) end
+
+--- Instantly remove a building in the given city as if it had never been built.
+--- Great wonders removed in this way will become buildable again. No
+--- notifications are generated, no :lua:obj:`~Events.building_lost` signal is
+--- propagated, and the data about this change is sent to clients immediately.
+---
+--- Version added: 3.2
+---
+--- @param building_type Building_Type The building to delete
+--- @return bool success False, if the building wasn't present in the city.
+function City:building_unmake(building_type) end
+
 --- 
 --- @class Unit
 Unit = {}
@@ -761,7 +859,7 @@ function Unit:veteran_level_set(veteran) end
 
 --- .. note::
 ---    This will be capped between zero and 
----    :lua:obj:`Unit_Type:max_veteran_level`.
+---    :lua:obj:`Unit_Type.max_veteran_level`.
 ---
 --- .. note::
 ---    This does not automatically :lua:obj:`notify` the :lua:obj:`Player`

--- a/server/scripting/tolua_server.pkg
+++ b/server/scripting/tolua_server.pkg
@@ -143,6 +143,16 @@ module edit {
     @ resize_city (lua_State *L, City *pcity, int size, const char *reason);
   void api_edit_remove_city
     @ remove_city (lua_State *L, City *pcity);
+  bool api_edit_city_building_construct
+    @ city_building_construct (lua_State *L, City *pcity, Building_Type *impr);
+  bool api_edit_city_building_built_turn_set
+    @ city_building_built_turn_set (lua_State *L, City *pcity,
+                                    Building_Type *impr, int built_turn);
+  bool api_edit_city_building_destroy
+    @ city_building_destroy (lua_State *L, City *pcity, Building_Type *impr,
+                             const char *reason, Unit *destroyer);
+  bool api_edit_city_building_unmake
+    @ city_building_unmake (lua_State *L, City *pcity, Building_Type *impr);
   void api_edit_create_owned_extra
     @ create_owned_extra (lua_State *L, Tile *ptile,
                           const char *name, Player *pplayer);
@@ -375,6 +385,22 @@ end
 
 function City:add_history(amount)
   edit.add_city_history(self, amount)
+end
+
+function City:building_construct(building_type)
+  return edit.city_building_construct(self, building_type)
+end
+
+function City:building_built_turn_set(building_type, turn)
+  return edit.city_building_built_turn_set(self, building_type, turn)
+end
+
+function City:building_destroy(building_type, reason, destroyer_unit)
+  return edit.city_building_destroy(self, building_type, reason, destroyer_unit)
+end
+
+function City:building_unmake(building_type)
+  return edit.city_building_unmake(self, building_type)
 end
 
 -- Server functions for Unit module


### PR DESCRIPTION
Closes #2640

Tested with Lua commands on the console and chat window:
```
/lua cmd for obj in find.government_types_iterate() do log.debug("%s", obj) end
-- Repeated for each iterator in find
/lua cmd for obj in find.city(nil, 192):buildings_iterate() do log.debug("%s", obj) end
/lua cmd log.debug("%s", find.city(nil, 192):building_construct(find.building_type(16)))
/lua cmd log.debug("%s", find.city(nil, 192):building_built_turn_set(find.building_type(16), 1000))
/lua cmd log.debug("%s", find.city(nil, 192):building_destroy(find.building_type(16), "scripted", nil))
/lua cmd log.debug("%s", find.city(nil, 192):building_unmake(find.building_type(16)))
```