### PR TITLE
Refactor: Utility and Common IWYU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ build.ninja
 /*.sh
 
 # Build directories
-/build*
+build*
 .flatpak-builder
 
 # Nix build artifacts
@@ -59,12 +59,9 @@ result
 # IDE files
 .cache
 .clangd
-# Folder
 .kdev4
-.vs
-# Project file
 *.kdev4
-# Visual Studio Code 
+.vs
 .vscode
 
 # In case someone runs Doxygen

--- a/common/combat.cpp
+++ b/common/combat.cpp
@@ -19,6 +19,7 @@
 #include "map.h"
 #include "movement.h"
 #include "player.h"
+#include "requirements.h"
 #include "tile.h"
 #include "unit.h"
 #include "unitlist.h"

--- a/common/effects.cpp
+++ b/common/effects.cpp
@@ -29,6 +29,7 @@
 
 // Qt
 #include <QByteArrayAlgorithms> // qstrlen, qstrdup, qstrncpy
+#include <QString>
 #include <QStringLiteral>
 #include <QtContainerFwd> // QVector<QString>
 

--- a/common/generate_packets.py
+++ b/common/generate_packets.py
@@ -1508,6 +1508,7 @@ def write_common_source(packets: list[Packet], output: io.TextIOWrapper) -> None
 #include <packets_gen.h>
 
 // utility
+#include "bitvector.h"
 #include "capability.h"
 #include "log.h"
 #include "support.h"
@@ -1526,11 +1527,15 @@ def write_common_source(packets: list[Packet], output: io.TextIOWrapper) -> None
 
 // Qt
 #include <QBitArray>
-#include <QtLogging> // qDebug, qWarning, qCritical, etc
+#include <QByteArray>
+#include <QtLogging>             // qDebug, qWarning, qCritical, etc
+#include <QtPreprocessorSupport> // Q_UNUSED
+
 
 // std
-#include <cstdlib> // EXIT_FAILURE, free, at_quick_exit
+#include <cstdint> // std::int*, std::uint*
 #include <cstring> // str*, mem*
+#include <memory>  // std::make_unique
 """
     )
     output.write(

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -4191,7 +4191,7 @@ void helptext_government(char *buf, size_t bufsz, struct player *pplayer,
                            ratio);
             }
           } // else this effect somehow has no effect; keep quiet
-        } // else there was some extra condition making it complicated
+        }   // else there was some extra condition making it complicated
         break;
       case EFT_UNIT_UPKEEP_FREE_PER_CITY:
         if (!unittype) {

--- a/common/helpdata.cpp
+++ b/common/helpdata.cpp
@@ -15,7 +15,6 @@
 // utility
 #include "astring.h"
 #include "bitvector.h"
-#include "fciconv.h"
 #include "fcintl.h"
 #include "log.h"
 #include "registry.h"
@@ -60,6 +59,7 @@
 #include <QStringLiteral>
 #include <QtConfig>              // QT_VERSION_STR
 #include <QtContainerFwd>        // QVector<QString>
+#include <QtGlobal>              // qUtf8Printable
 #include <QtLogging>             // qDebug, qWarning, qCricital, etc
 #include <QtPreprocessorSupport> // Q_UNUSED
 #include <QtVersion>             // qVersion
@@ -2478,7 +2478,8 @@ char *helptext_unit(char *buf, size_t bufsz, struct player *pplayer,
 
         struct universal req_pattern[] = {
             {.value = {.action = paction}, .kind = VUT_ACTION},
-            {.kind = VUT_DIPLREL, /* value filled in later */},
+            {.kind = VUT_DIPLREL,
+             /* value filled in later */},
         };
 
         /* First group by effect (currently getting caught and successfully
@@ -4190,7 +4191,7 @@ void helptext_government(char *buf, size_t bufsz, struct player *pplayer,
                            ratio);
             }
           } // else this effect somehow has no effect; keep quiet
-        }   // else there was some extra condition making it complicated
+        } // else there was some extra condition making it complicated
         break;
       case EFT_UNIT_UPKEEP_FREE_PER_CITY:
         if (!unittype) {

--- a/common/networking/connection.cpp
+++ b/common/networking/connection.cpp
@@ -22,11 +22,14 @@
 #include "player.h"
 
 // Qt
+#include <QByteArrayList>
+#include <QByteArrayView>
 #include <QChar>
 #include <QLocalSocket>
 #include <QObject>
 #include <QString>
 #include <QTcpSocket>
+#include <QtGlobal>  // qUtf8Printable
 #include <QtLogging> // qDebug, qWarning, qCricital, etc
 
 // std

--- a/common/networking/connection.h
+++ b/common/networking/connection.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// generated
+#include <packets_gen.h>
+
 // utility
 #include "support.h"
 #include "timing.h"
@@ -17,12 +20,12 @@
 #include "packets.h"
 
 // Qt
+#include <QByteArrayView>
 #include <QList>
 #include <QString>
 
 // std
 #include <array>
-#include <ctime> // time_t
 #include <memory>
 
 // Forward declarations

--- a/common/networking/dataio_raw.cpp
+++ b/common/networking/dataio_raw.cpp
@@ -23,12 +23,14 @@
 #include "worklist.h"
 
 // Qt
+#include <QBitArray>
+#include <QByteArray>
 #include <QByteArrayAlgorithms> // qstrlen, qstrdup, qstrncpy
 #include <QtEndian>
 #include <QtLogging> // qDebug, qWarning, qCricital, etc
 
 // std
-#include <cmath>
+#include <cstddef> // std:byte
 #include <cstdint>
 #include <cstring>
 

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -18,6 +18,11 @@
 #include <QByteArray>
 #include <QByteArrayView>
 #include <QtEndian>
+#include <QtLogging> // qDebug, qWarning, qCricital
+
+// std
+#include <array>   // std::array
+#include <cstdint> // std::int*, std::uint*
 
 struct cm_parameter;
 struct worklist;

--- a/common/networking/dataio_raw.h
+++ b/common/networking/dataio_raw.h
@@ -18,7 +18,7 @@
 #include <QByteArray>
 #include <QByteArrayView>
 #include <QtEndian>
-#include <QtLogging> // qDebug, qWarning, qCricital
+#include <QtLogging> // qDebug, qWarning, qCritical
 
 // std
 #include <array>   // std::array

--- a/common/networking/packets.cpp
+++ b/common/networking/packets.cpp
@@ -31,6 +31,7 @@
 #include <QtPreprocessorSupport> // Q_UNUSED
 
 // std
+#include <cstdint> // std::int*, std::uint*
 #include <cstdlib> // EXIT_FAILURE, free, at_quick_exit
 #include <cstring> // str*, mem*
 #include <zconf.h> // uLongf, Bytef

--- a/common/networking/packets.h
+++ b/common/networking/packets.h
@@ -3,13 +3,10 @@
 
 #pragma once
 
-struct connection;
-
 // generated
 #include <packets_gen.h>
 
 // utility
-#include "log.h"
 #include "shared.h" // MAX_LEN_ADDR
 
 // common
@@ -17,13 +14,19 @@ struct connection;
 #include "player.h"
 #include "traderoutes.h"
 
-// std
-#include <array>
-#include <memory>
-
 // Qt
 #include <QBitArray>
-#include <QtContainerFwd> // QVector<QString>
+#include <QByteArrayView>
+#include <QtContainerFwd>        // QVector<QString>
+#include <QtLogging>             // qDebug, qWarning, qCricital
+#include <QtPreprocessorSupport> // Q_UNUSED
+
+// std
+#include <array>
+#include <cstdint> // std::int*, std::uint*
+#include <memory>
+
+struct connection;
 
 using packet_capabilities_type = std::uint32_t;
 

--- a/common/networking/packets.h
+++ b/common/networking/packets.h
@@ -18,7 +18,7 @@
 #include <QBitArray>
 #include <QByteArrayView>
 #include <QtContainerFwd>        // QVector<QString>
-#include <QtLogging>             // qDebug, qWarning, qCricital
+#include <QtLogging>             // qDebug, qWarning, qCritical
 #include <QtPreprocessorSupport> // Q_UNUSED
 
 // std

--- a/common/rgbcolor.h
+++ b/common/rgbcolor.h
@@ -11,7 +11,7 @@
 #include "fc_types.h"
 
 // Qt
-#include <QtLogging> // qDebug, qWarning, qCricital, etc
+#include <QtLogging> // qDebug, qWarning, qCritical, etc
 
 // std
 #include <cstddef> // size_t

--- a/common/scriptcore/api_common_intl.cpp
+++ b/common/scriptcore/api_common_intl.cpp
@@ -1,20 +1,17 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "api_common_intl.h"
+
+// dependencies/sol2
+#include "sol/sol.hpp"
 
 // utility
 #include "fcintl.h"
 
-/* common/scriptcore */
+// common
 #include "luascript.h"
-
-#include "api_common_intl.h"
 
 /**
    Translation helper function.

--- a/common/scriptcore/api_common_intl.h
+++ b/common/scriptcore/api_common_intl.h
@@ -1,15 +1,9 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-// sol2
+// dependencies/sol2
 #include "sol/sol.hpp"
 
 const char *api_intl__(sol::this_state s, const char *untranslated);

--- a/common/scriptcore/api_common_utilities.cpp
+++ b/common/scriptcore/api_common_utilities.cpp
@@ -1,33 +1,36 @@
-/*
-    Copyright (c) 1996-2020 Freeciv21 and Freeciv  contributors. This file
-                         is part of Freeciv21. Freeciv21 is free software:
-|\_/|,,_____,~~`        you can redistribute it and/or modify it under the
-(.".)~~     )`~}}    terms of the GNU General Public License  as published
- \o/\ /---~\\ ~}}     by the Free Software Foundation, either version 3 of
-   _//    _// ~}       the License, or (at your option) any later version.
-                        You should have received a copy of the GNU General
-                          Public License along with Freeciv21. If not, see
-                                            https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cmath>
+// self
+#include "api_common_utilities.h"
 
-// Sol
+// dependencies/lua
+extern "C" {
+#include "lua.h"
+}
+
+// dependencies/sol2
 #include "sol/sol.hpp"
 
 // utilities
 #include "deprecations.h"
-#include "fcintl.h"
 #include "rand.h"
+#include "shared.h"
+#include "support.h"
 
 // common
+#include "fc_types.h"
+#include "luascript.h"
+#include "luascript_types.h"
 #include "map.h"
 #include "version.h"
 
-/* common/scriptcore */
-#include "luascript.h"
+// Qt
+#include <QLoggingCategory> // qCDebug, qCWarning, qCCricital
+#include <QtLogging>        // QtMsgType
 
-#include "api_common_utilities.h"
+// std
+#include <cmath>
 
 /**
    Generate random number.

--- a/common/scriptcore/api_common_utilities.h
+++ b/common/scriptcore/api_common_utilities.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
-// dependencies/sol2
+// dependencies
+extern "C" {
+#include "lua.h"
+}
 #include "sol/sol.hpp"
 
 // common

--- a/common/scriptcore/api_common_utilities.h
+++ b/common/scriptcore/api_common_utilities.h
@@ -1,18 +1,12 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-// sol2
+// dependencies/sol2
 #include "sol/sol.hpp"
 
-/* common/scriptcore */
+// common
 #include "luascript_types.h"
 
 struct lua_State;

--- a/common/scriptcore/api_game_effects.cpp
+++ b/common/scriptcore/api_game_effects.cpp
@@ -1,23 +1,22 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "api_game_effects.h"
+
+// dependencies/lua
+extern "C" {
+#include "lua.h"
+}
 
 // utility
-#include "fcintl.h"
+#include "support.h"
 
 // common
 #include "effects.h"
-
-/* common/scriptcore */
+#include "fc_types.h"
 #include "luascript.h"
-
-#include "api_game_effects.h"
+#include "luascript_types.h"
 
 /**
    Returns the effect bonus in the world

--- a/common/scriptcore/api_game_effects.h
+++ b/common/scriptcore/api_game_effects.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+// dependencies
+extern "C" {
+#include "lua.h"
+}
+
 // common
 #include "luascript_types.h"
 

--- a/common/scriptcore/api_game_effects.h
+++ b/common/scriptcore/api_game_effects.h
@@ -1,15 +1,9 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-/* common/scriptcore */
+// common
 #include "luascript_types.h"
 
 struct lua_State;

--- a/common/scriptcore/api_game_find.cpp
+++ b/common/scriptcore/api_game_find.cpp
@@ -1,24 +1,35 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "api_game_find.h"
+
+// dependencies/lua
+extern "C" {
+#include "lua.h"
+}
 
 // utility
-#include "fcintl.h"
+#include "support.h"
 
 // common
+#include "actions.h"
+#include "fc_types.h"
+#include "game.h"
+#include "government.h"
 #include "idex.h"
-#include "map.h"
-
-/* common/scriptcore */
+#include "improvement.h"
 #include "luascript.h"
-
-#include "api_game_find.h"
+#include "luascript_types.h"
+#include "map.h"
+#include "nation.h"
+#include "player.h"
+#include "team.h"
+#include "tech.h"
+#include "terrain.h"
+#include "unit.h"
+#include "unittype.h"
+#include "world_object.h"
 
 /**
    Return a player with the given player_id.

--- a/common/scriptcore/api_game_find.h
+++ b/common/scriptcore/api_game_find.h
@@ -1,18 +1,12 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-/* dependencies/lua */
+// dependencies/lua
 #include "lua.h"
 
-/* common/scriptcore */
+// common
 #include "luascript_types.h"
 
 // Object find module.

--- a/common/scriptcore/api_game_find.h
+++ b/common/scriptcore/api_game_find.h
@@ -3,10 +3,13 @@
 
 #pragma once
 
-// dependencies/lua
+// dependencies
+extern "C" {
 #include "lua.h"
+}
 
 // common
+#include "fc_types.h"
 #include "luascript_types.h"
 
 // Object find module.

--- a/common/scriptcore/api_game_methods.cpp
+++ b/common/scriptcore/api_game_methods.cpp
@@ -1,43 +1,58 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "api_game_methods.h"
+
+// dependencies/lua
+extern "C" {
+#include "lua.h"
+}
 
 // utility
 #include "deprecations.h"
+#include "shared.h"
+#include "support.h"
 
 // common
 #include "achievements.h"
 #include "actions.h"
 #include "calendar.h"
 #include "citizens.h"
+#include "city.h"
 #include "culture.h"
 #include "disaster.h"
 #include "effects.h"
+#include "extras.h"
+#include "fc_types.h"
 #include "featured_text.h"
 #include "game.h"
 #include "government.h"
 #include "improvement.h"
+#include "luascript.h"
+#include "luascript_types.h"
 #include "map.h"
 #include "movement.h"
 #include "nation.h"
+#include "player.h"
 #include "research.h"
 #include "team.h"
 #include "tech.h"
 #include "terrain.h"
 #include "tile.h"
+#include "unit.h"
 #include "unitlist.h"
 #include "unittype.h"
 
-/* common/scriptcore */
-#include "luascript.h"
+// Qt
+#include <QLoggingCategory> // qCDebug, qCWarning, qCCricital
+#include <QString>
+#include <QtGlobal>              // qUtf8Printable
+#include <QtLogging>             // qDebug, qWarning, qCricital
+#include <QtPreprocessorSupport> // Q_UNUSED
 
-#include "api_game_methods.h"
+// self
+#include <cstddef> // NULL
 
 /**
    Return the current turn.

--- a/common/scriptcore/api_game_methods.h
+++ b/common/scriptcore/api_game_methods.h
@@ -1,16 +1,9 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 #pragma once
 
-/* common/scriptcore */
+// common
 #include "luascript_types.h"
 
 struct lua_State;

--- a/common/scriptcore/api_game_methods.h
+++ b/common/scriptcore/api_game_methods.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+// dependencies
+extern "C" {
+#include "lua.h"
+}
+
 // common
 #include "luascript_types.h"
 

--- a/common/scriptcore/api_game_specenum.cpp
+++ b/common/scriptcore/api_game_specenum.cpp
@@ -1,21 +1,13 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cstring>
+// self
+#include "api_game_specenum.h"
 
-/* dependencies/lua */
+// dependencies/lua
 extern "C" {
 #include "lauxlib.h"
 #include "lua.h"
-#include "lualib.h"
 }
 
 // utility
@@ -23,9 +15,10 @@ extern "C" {
 #include "support.h"
 
 // common
-#include "events.h"
+#include "fc_types.h"
 
-#include "api_game_specenum.h"
+// std
+#include <cstring>
 
 #define API_SPECENUM_INDEX_NAME(type) api_specenum_##type##_index
 #define API_SPECENUM_CREATE_TABLE(L, type, name)                            \

--- a/common/scriptcore/api_game_specenum.h
+++ b/common/scriptcore/api_game_specenum.h
@@ -1,13 +1,6 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- __    __          part of Freeciv21. Freeciv21 is free software: you can
-/ \\..// \    redistribute it and/or modify it under the terms of the GNU
-  ( oo )        General Public License  as published by the Free Software
-   \__/         Foundation, either version 3 of the License,  or (at your
-                      option) any later version. You should have received
-    a copy of the GNU General Public License along with Freeciv21. If not,
-                  see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 struct lua_State;

--- a/common/scriptcore/api_signal_base.cpp
+++ b/common/scriptcore/api_signal_base.cpp
@@ -1,17 +1,22 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
-/* common/scriptcore */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
+// self
+#include "api_signal_base.h"
+
+// dependencies/lua
+extern "C" {
+#include "lua.h"
+}
+
+// common
 #include "luascript.h"
 #include "luascript_signal.h"
 
-#include "api_signal_base.h"
+// Qt
+#include <QByteArrayAlgorithms> // qstrdup
+#include <QString>
+#include <QtGlobal> // qUtf8Printable
 
 /**
    Connects a callback function to a certain signal.

--- a/common/scriptcore/api_signal_base.h
+++ b/common/scriptcore/api_signal_base.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-// utility
-#include "support.h"
-
 struct lua_State;
 
 void api_signal_connect(lua_State *L, const char *signal_name,

--- a/common/scriptcore/api_signal_base.h
+++ b/common/scriptcore/api_signal_base.h
@@ -1,12 +1,5 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 #pragma once
 

--- a/common/scriptcore/luascript.cpp
+++ b/common/scriptcore/luascript.cpp
@@ -1,46 +1,52 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cstdarg>
-#include <ctime>
+// self
+#include "luascript.h"
 
-// Qt
-
-/* dependencies/lua */
+// dependencies/lua
 extern "C" {
+#include "lauxlib.h"
 #include "lua.h"
 #include "lualib.h"
 }
 
-/* dependencies/tolua */
+// dependencies/tolua
 #include "tolua.h"
 
-// Sol
+// dependencies/sol2
 #include "sol/sol.hpp"
 
 // utility
 #include "log.h"
 #include "registry.h"
 #include "registry_ini.h"
+#include "support.h"
 
 // common
-#include "map.h"
-
-/* common/scriptcore */
 #include "api_common_intl.h"
 #include "api_common_utilities.h"
+#include "fc_types.h"
 #include "luascript_func.h"
 #include "luascript_signal.h"
+#include "luascript_types.h"
+#include "map.h"
 #include "tolua_common_a_gen.h"
 
-#include "luascript.h"
+// Qt
+#include <QByteArrayAlgorithms> // qstr*
+#include <QFile>
+#include <QString>
+#include <QStringLiteral>
+#include <QtContainerFwd> // QVector<QString>, QStringList = QList<QString>
+#include <QtGlobal>       // qUtf8Printable
+#include <QtLogging>      // qDebug, qWarning, qCricital
+#include <QtPreprocessorSupport> // Q_UNUSED
+#include <QtResource>            // Q_INIT_RESOURCE, Q_CLEANUP_RESOURCE
+
+// std
+#include <cstdarg>
+#include <ctime>
 
 /**
   Configuration for script execution time limits. Checkinterval is the

--- a/common/scriptcore/luascript.h
+++ b/common/scriptcore/luascript.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <QHash>
 #include <QVector>
 #include <QtContainerFwd> // QVector<QString>
-#include <QtLogging>      // qDebug, qWarning, qCricital
+#include <QtLogging>      // qDebug, qWarning, qCritical
 
 // std
 #include <csignal> // signal

--- a/common/scriptcore/luascript.h
+++ b/common/scriptcore/luascript.h
@@ -3,14 +3,17 @@
 
 #pragma once
 
-// dependencies/tolua
-#include "tolua.h"
+// dependencies
+extern "C" {
+#include "lua.h"
+}
 
 // utility
 #include "log.h"
 #include "support.h" // fc__attribute()
 
 // common
+#include "fc_types.h"
 #include "luascript_func.h"
 #include "luascript_signal.h"
 #include "luascript_types.h"
@@ -18,6 +21,12 @@
 // Qt
 #include <QHash>
 #include <QVector>
+#include <QtContainerFwd> // QVector<QString>
+#include <QtLogging>      // qDebug, qWarning, qCricital
+
+// std
+#include <csignal> // signal
+#include <cstdarg> // va_*
 
 struct section_file;
 struct luascript_func_hash;

--- a/common/scriptcore/luascript.h
+++ b/common/scriptcore/luascript.h
@@ -1,27 +1,23 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
-#include <QHash>
-#include <QVector>
-/* dependencies/tolua */
+// dependencies/tolua
 #include "tolua.h"
 
 // utility
 #include "log.h"
 #include "support.h" // fc__attribute()
 
-/* common/scriptcore */
+// common
 #include "luascript_func.h"
 #include "luascript_signal.h"
 #include "luascript_types.h"
+
+// Qt
+#include <QHash>
+#include <QVector>
 
 struct section_file;
 struct luascript_func_hash;

--- a/common/scriptcore/luascript_func.cpp
+++ b/common/scriptcore/luascript_func.cpp
@@ -1,26 +1,29 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
-#include <cstdarg>
+// self
+#include "luascript_func.h"
 
-/* dependencies/lua */
+// dependencies/lua
 extern "C" {
 #include "lua.h"
-#include "lualib.h"
 }
 
-/* common/scriptcore */
+// utility
+#include "log.h"
+#include "support.h"
+
+// common
 #include "luascript.h"
 #include "luascript_types.h"
 
-#include "luascript_func.h"
+// Qt
+#include <QString>
+#include <QtContainerFwd> // QVector<QString>
+
+// std
+#include <cstdarg>
+#include <utility> // std::as_const
 
 static struct luascript_func *func_new(bool required, int nargs,
                                        enum api_types *parg_types,

--- a/common/scriptcore/luascript_func.h
+++ b/common/scriptcore/luascript_func.h
@@ -1,16 +1,13 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 // utility
 #include "support.h"
+
+// Qt
+#include <QVector>
 
 struct fc_lua;
 

--- a/common/scriptcore/luascript_func.h
+++ b/common/scriptcore/luascript_func.h
@@ -8,6 +8,10 @@
 
 // Qt
 #include <QVector>
+#include <QtContainerFwd> // QVector<QString>
+
+// std
+#include <cstdarg> // va_*
 
 struct fc_lua;
 

--- a/common/scriptcore/luascript_signal.cpp
+++ b/common/scriptcore/luascript_signal.cpp
@@ -1,12 +1,5 @@
-/*
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
 
 /**
   Signals implementation.
@@ -33,14 +26,29 @@
 
   If the value is 'true' the current signal emission will be stopped.
  */
+
+// self
+#include "luascript_signal.h"
+
 // utility
 #include "deprecations.h"
+#include "log.h"
+#include "support.h"
 
-/* common/scriptcore */
+// common
 #include "luascript.h"
 #include "luascript_types.h"
 
-#include "luascript_signal.h"
+// Qt
+#include <QHash>
+#include <QList>
+#include <QLoggingCategory> // qCWarning
+
+// std
+#include <csignal> // signal
+#include <cstdarg> // va_*
+#include <cstring> // str*, mem*
+#include <utility> // std::as_const
 
 static struct signal_callback *signal_callback_new(const char *name);
 static void signal_callback_destroy(struct signal_callback *pcallback);

--- a/common/scriptcore/luascript_signal.h
+++ b/common/scriptcore/luascript_signal.h
@@ -1,17 +1,14 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
+
 // utility
 #include "support.h"
 
+// comon
 #include "luascript_types.h"
+
 struct fc_lua;
 
 typedef char *signal_deprecator;

--- a/common/scriptcore/luascript_signal.h
+++ b/common/scriptcore/luascript_signal.h
@@ -9,6 +9,12 @@
 // comon
 #include "luascript_types.h"
 
+// Qt
+#include <QList>
+
+// std
+#include <cstdarg> // va_*
+
 struct fc_lua;
 
 typedef char *signal_deprecator;

--- a/common/scriptcore/luascript_types.h
+++ b/common/scriptcore/luascript_types.h
@@ -1,12 +1,6 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+
 #pragma once
 
 // utility

--- a/common/scriptcore/luascript_types.h
+++ b/common/scriptcore/luascript_types.h
@@ -3,17 +3,17 @@
 
 #pragma once
 
-// utility
-#include "genlist.h"
+// dependencies
+extern "C" {
+#include "lua.h"
+}
 
 // common
 #include "achievements.h"
 #include "actions.h"
 #include "city.h"
 #include "connection.h"
-#include "events.h"
 #include "fc_types.h"
-#include "game.h"
 #include "government.h"
 #include "improvement.h"
 #include "nation.h"
@@ -23,6 +23,7 @@
 #include "terrain.h"
 #include "tile.h"
 #include "unit.h"
+#include "unitlist.h"
 #include "unittype.h"
 
 // Classes.

--- a/common/scriptcore/tolua_common_a.pkg
+++ b/common/scriptcore/tolua_common_a.pkg
@@ -1,12 +1,7 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+ **/
 
 /*****************************************************************************
   ADVERTISEMENT: do not attempt to change the name of the API functions.

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -1,12 +1,7 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+ **/
 
 /*****************************************************************************
   ADVERTISEMENT: do not attempt to change the name of the API functions.
@@ -17,16 +12,15 @@
   old one running.
 *****************************************************************************/
 
+/* generated */
 $#include <fc_config.h>
 
 /* common */
-$#include "disaster.h"
-
-/* common/scriptcore */
 $#include "api_common_utilities.h"
 $#include "api_game_effects.h"
 $#include "api_game_find.h"
 $#include "api_game_methods.h"
+$#include "disaster.h"
 $#include "luascript_types.h"
 
 /* Classes. */

--- a/common/scriptcore/tolua_signal.pkg
+++ b/common/scriptcore/tolua_signal.pkg
@@ -1,12 +1,7 @@
-/**************************************************************************
- Copyright (c) 1996-2020 Freeciv21 and Freeciv contributors. This file is
- part of Freeciv21. Freeciv21 is free software: you can redistribute it
- and/or modify it under the terms of the GNU  General Public License  as
- published by the Free Software Foundation, either version 3 of the
- License,  or (at your option) any later version. You should have received
- a copy of the GNU General Public License along with Freeciv21. If not,
- see https://www.gnu.org/licenses/.
-**************************************************************************/
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: Freeciv21 and Freeciv Contributors
+ **/
 
 /*****************************************************************************
   ADVERTISEMENT: do not attempt to change the name of the API functions.
@@ -17,11 +12,11 @@
   old one running.
 *****************************************************************************/
 
+/* generated */
 $#include <fc_config.h>
 
-/* common/scriptcore */
+/* common */
 $#include "api_signal_base.h"
-$#include "luascript_types.h"
 
 /* Signal module. */
 module signal {

--- a/common/tech.cpp
+++ b/common/tech.cpp
@@ -18,6 +18,10 @@
 #include "name_translation.h"
 #include "requirements.h"
 
+// Qt
+#include <QString>
+#include <QStringLiteral>
+
 // std
 #include <cmath>   // sqrt
 #include <cstring> // str*, mem*

--- a/common/tile.cpp
+++ b/common/tile.cpp
@@ -26,6 +26,7 @@
 
 // Qt
 #include <QBitArray>
+#include <QString>
 #include <QStringLiteral>
 #include <QtLogging> // qDebug, qWarning, qCricital, etc
 

--- a/common/unit.cpp
+++ b/common/unit.cpp
@@ -30,6 +30,7 @@
 #include "unittype.h"
 
 // Qt
+#include <QString>
 #include <QStringLiteral>
 #include <QtLogging> // qDebug, qWarning, qCricital, etc
 

--- a/utility/netfile.cpp
+++ b/utility/netfile.cpp
@@ -14,6 +14,7 @@
 #include <QBuffer>
 #include <QEventLoop>
 #include <QJsonDocument>
+#include <QJsonParseError>
 #include <QLatin1String>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>

--- a/utility/registry_ini.cpp
+++ b/utility/registry_ini.cpp
@@ -169,6 +169,7 @@
 #include <cstdlib> // free
 #include <cstring> // str*
 #include <memory>  // std::make_unique
+#include <tuple>   // std::ignore
 
 #define MAX_LEN_SECPATH 1024
 

--- a/utility/section_file.cpp
+++ b/utility/section_file.cpp
@@ -12,6 +12,7 @@
 
 // Qt
 #include <QMultiHash>
+#include <QString>
 #include <QStringLiteral>
 #include <Qt>
 

--- a/utility/tests/test_paths.cpp
+++ b/utility/tests/test_paths.cpp
@@ -6,9 +6,11 @@
 
 // Qt
 #include <QDir>
-#include <QObject>
-#include <QString>
+#include <QLatin1String> // QLatin1String
+#include <QObject>       // Q_OBJECT
 #include <QTest>
+#include <qtestcase.h>    // QCOMPARE, QVERIFY
+#include <qtmetamacros.h> // Q_OBJECT
 
 /**
  * Tests functions acting on paths


### PR DESCRIPTION
IWYU refactor. Cleanup of `utility`, `common` and `common/networking`. Adds in `common/scriptcore` Outside of the dependencies and generated Lua related code this PR should close out `utility` and `common`

Part of https://github.com/longturn/freeciv21/issues/2464