### PR TITLE
Allow unsafe PR checkout for clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          allow-unsafe-pr-checkout: true # We have no permissions to do any harm
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 


### PR DESCRIPTION
Our action explicitly drops all permissions, so it is harmless. See https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

Since this is a change to a `pull_request_target` workflow its effects will only be visible after merging.