### PR TITLE
Fix client bugs with the Capture The Flag ruleset

### DIFF
--- a/client/tileset/layer_abstract_activities.cpp
+++ b/client/tileset/layer_abstract_activities.cpp
@@ -44,6 +44,10 @@ void layer_abstract_activities::initialize_extra(const extra_type *extra,
                                                  const QString &tag,
                                                  extrastyle_id style)
 {
+  // This function is not called for extras with style=none
+  if (extra->id > m_extra_activities.size()) {
+    m_extra_activities.resize(extra->id);
+  }
   fc_assert(extra->id == m_extra_activities.size());
 
   if (!fc_strcasecmp(extra->activity_gfx, "none")) {

--- a/common/networking/dataio_raw.cpp
+++ b/common/networking/dataio_raw.cpp
@@ -490,7 +490,9 @@ bool dio_get(QByteArrayView &din, struct requirement &preq)
   preq = req_from_values(type, range, survives, present, quiet, value);
   if (preq.source.kind == universals_n_invalid()) {
     // Keep bad requirements but make sure we never touch them.
-    qWarning() << "The server sent an invalid or unknown requirement.";
+    qWarning() << "The server sent an invalid or unknown requirement with "
+                  "type, range, value:"
+               << type << range << value;
     preq.source.kind = VUT_NONE;
   }
 

--- a/common/requirements.cpp
+++ b/common/requirements.cpp
@@ -567,7 +567,8 @@ struct universal universal_by_number(const enum universals_n kind,
     break;
   case VUT_UCFLAG:
     source.value.unitclassflag = value;
-    if (source.value.unitclassflag) {
+    if (unit_class_flag_id_is_valid(
+            static_cast<unit_class_flag_id>(source.value.unitclassflag))) {
       return source;
     }
     break;


### PR DESCRIPTION
This fixes two bugs that lead to a lot of logging output when connecting:
* A bug with `extra_flag_captured`, which has `style=none`. This likely leads to workers building roads shown as building rails, and rails as maglev (haven't checked though).
* A bug that prevented receiving effects with `"UnitClassFlag", "LimitedCR",` correctly. This seems to be used only for `Combat_Rounds`, which isn't displayed directly in the UI but affects battle win chances.

I also slightly improved the logging.

Back port recommended, at least for the two bugfix commits.