### PR TITLE
IWYU Common: Remove pragma keeps 

### DIFF
--- a/common/aicore/cm.cpp
+++ b/common/aicore/cm.cpp
@@ -17,7 +17,7 @@
 #include "fc_types.h"
 #include "game.h"
 #include "government.h"
-#include "map.h" // IWYU pragma: keep
+#include "map.h" // IWYU pragma: keep -- map.h and tile.h work closely together. Must keep map.h included
 #include "player.h"
 #include "specialist.h"
 #include "tile.h"

--- a/common/aicore/pf_tools.cpp
+++ b/common/aicore/pf_tools.cpp
@@ -6,7 +6,6 @@
 
 // utility
 #include "bitvector.h"
-#include "iterator.h" // IWYU pragma: keep
 #include "log.h"
 #include "shared.h"
 

--- a/common/clientutils.cpp
+++ b/common/clientutils.cpp
@@ -11,7 +11,6 @@
 // common
 #include "extras.h"
 #include "fc_types.h"
-#include "game.h" // IWYU pragma: keep -- needed by extras.h:extra_type_iterate()
 #include "tile.h"
 #include "unit.h"
 #include "unitlist.h"

--- a/common/extras.h
+++ b/common/extras.h
@@ -230,7 +230,8 @@ bool player_knows_extra_exist(const struct player *pplayer,
 #define extra_type_iterate(_p)                                              \
   {                                                                         \
     int _i_##_p;                                                            \
-    for (_i_##_p = 0; _i_##_p < game.control.num_extra_types; _i_##_p++) {  \
+    int extra_count##_p = extra_count();                                    \
+    for (_i_##_p = 0; _i_##_p < extra_count##_p; _i_##_p++) {               \
       struct extra_type *_p = extra_by_number(_i_##_p);
 
 #define extra_type_iterate_end                                              \

--- a/common/game.h
+++ b/common/game.h
@@ -14,11 +14,11 @@
 // common
 #include "city.h" // CITY_MAP_*
 #include "fc_types.h"
-#include "player.h"   // enum plrcolor_mode
-#include "rgbcolor.h" // struct rgbcolor
-#include "traits.h"   // struct trait_limits
-#include "unittype.h" // struct veteran_system
-#include "world_object.h" // IWYU pragma: keep - (FIXME) struct world needed by scriptcore
+#include "player.h"       // enum plrcolor_mode
+#include "rgbcolor.h"     // struct rgbcolor
+#include "traits.h"       // struct trait_limits
+#include "unittype.h"     // struct veteran_system
+#include "world_object.h" // struct world
 
 // Qt
 #include <QMutex>

--- a/common/unit.h
+++ b/common/unit.h
@@ -5,6 +5,7 @@
 
 // utility
 #include "fcintl.h"
+#include "iterator.h"
 #include "log.h"
 #include "support.h"
 


### PR DESCRIPTION
As with Utility (#2945), this is a final clean of `common`. I could not find a solution for `aicore/cm.cpp` so added a note to the pragma: keep there.

Part of https://github.com/longturn/freeciv21/issues/2464