### PR TITLE
Removed find.cities_iterate and find.units_iterate

### DIFF
--- a/common/scriptcore/stubs/game.lua
+++ b/common/scriptcore/stubs/game.lua
@@ -676,35 +676,11 @@ function find.teams_iterate() end
 --- @return City city The city if it exists and belongs to player, or nil
 function find.city(player, city_id) end
 
---- Safe iteration over each :lua:obj:`City` in the game. See 
---- :lua:obj:`Player.cities_iterate` for iterating over a specific player's
---- cities.
----
---- .. note::
----    If there is a chance that a :lua:obj:`City` is destroyed during
----    iteration, it is a good idea to use :lua:obj:`~Nonexistent.exists` to
----    check it is still present before attempting to use it.
----
---- Version added: 3.2
-function find.cities_iterate() end
-
 --- 
 --- @param player Player The player who owns the unit, or nil for any player
 --- @param unit_id int The unique ID for the unit to search for
 --- @return Unit unit The unit if it exists and belongs to player, or nil
 function find.unit(player, unit_id) end
-
---- Safe iteration over each :lua:obj:`Unit` in the game. See
---- :lua:obj:`Player.units_iterate` for iterating over a specific player's
---- units.
----
---- .. note::
----    If there is a chance that a :lua:obj:`Unit` dies during
----    iteration, it is a good idea to use :lua:obj:`~Nonexistent.exists` to
----    check it is still present before attempting to use it.
----
---- Version added: 3.2
-function find.units_iterate() end
 
 --- Looks for an existing unit that can transport unit_type at tile. Intended
 --- to be used with create_unit_full, to spawn it directly into the hold of the

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -827,24 +827,6 @@ do
     return index_iterate(find.team)
   end
 
-  local function find_city(city_id)
-    return find.city(nil, city_id)
-  end
-
-  -- Iterate over all cities in the world regardless of nation
-  function find.cities_iterate()
-    return index_iterate(find_city)
-  end
-
-  local function find_unit(unit_id)
-    return find.unit(nil, unit_id)
-  end
-
-  -- Iterate over all cities in the world regardless of nation
-  function find.units_iterate()
-    return index_iterate(find_unit)
-  end
-
   -- Iterate over all tiles of the game
   function find.tiles_iterate()
     return index_iterate(find.tile)


### PR DESCRIPTION
Closes #2929

Script authors have an easy workaround:
```
for player in find.players_iterate() do
  for unit in player:units_iterate() do
    log.debug("%s", unit)
  end
end
```

And it would be a lot of work just to shorten it to:
```
for player in find.units_iterate() do
  log.debug("%s", unit)
end
```
With less control over how the units are ordered. 

So I just removed them. It's not like they ever worked in the first place to cause a problem in existing scripts.