### PR TITLE
Make Unit_Class Lua methods accept a const punit_class

### DIFF
--- a/common/scriptcore/api_game_methods.cpp
+++ b/common/scriptcore/api_game_methods.cpp
@@ -1324,7 +1324,8 @@ int api_methods_unit_type_veteran_level_max_get(lua_State *L,
 /**
  * Return true if the unit class has the given unit class flag.
  */
-bool api_methods_unit_class_has_flag(lua_State *L, Unit_Class *punit_class,
+bool api_methods_unit_class_has_flag(lua_State *L,
+                                     const Unit_Class *punit_class,
                                      const char *flag)
 {
   LUASCRIPT_CHECK_STATE(L, false);
@@ -1344,7 +1345,7 @@ bool api_methods_unit_class_has_flag(lua_State *L, Unit_Class *punit_class,
  * Return the rule name of the unit class.
  */
 const char *api_methods_unit_class_rule_name(lua_State *L,
-                                             Unit_Class *punit_class)
+                                             const Unit_Class *punit_class)
 {
   LUASCRIPT_CHECK_STATE(L, nullptr);
   LUASCRIPT_CHECK_SELF(L, punit_class, nullptr);
@@ -1354,8 +1355,9 @@ const char *api_methods_unit_class_rule_name(lua_State *L,
 /**
  * Return the translated name of the unit class.
  */
-const char *api_methods_unit_class_name_translation(lua_State *L,
-                                                    Unit_Class *punit_class)
+const char *
+api_methods_unit_class_name_translation(lua_State *L,
+                                        const Unit_Class *punit_class)
 {
   LUASCRIPT_CHECK_STATE(L, nullptr);
   LUASCRIPT_CHECK_SELF(L, punit_class, nullptr);

--- a/common/scriptcore/api_game_methods.h
+++ b/common/scriptcore/api_game_methods.h
@@ -194,12 +194,14 @@ int api_methods_unit_type_veteran_level_max_get(lua_State *L,
                                                 Unit_Type *punit_type);
 
 // Unit Class
-bool api_methods_unit_class_has_flag(lua_State *L, Unit_Class *punit_class,
+bool api_methods_unit_class_has_flag(lua_State *L,
+                                     const Unit_Class *punit_class,
                                      const char *flag);
 const char *api_methods_unit_class_rule_name(lua_State *L,
-                                             Unit_Class *punit_class);
-const char *api_methods_unit_class_name_translation(lua_State *L,
-                                                    Unit_Class *punit_class);
+                                             const Unit_Class *punit_class);
+const char *
+api_methods_unit_class_name_translation(lua_State *L,
+                                        const Unit_Class *punit_class);
 
 // Unit_List_Link Type
 Unit *api_methods_unit_list_link_data(lua_State *L, Unit_List_Link *link);

--- a/common/scriptcore/tolua_game.pkg
+++ b/common/scriptcore/tolua_game.pkg
@@ -508,11 +508,11 @@ $]
 /* Module Unit_Class. */
 module Unit_Class {
   bool api_methods_unit_class_has_flag
-    @ has_flag (lua_State *L, Unit_Class *self, const char *flag);
+    @ has_flag (lua_State *L, const Unit_Class *self, const char *flag);
   const char *api_methods_unit_class_rule_name
-    @ rule_name (lua_State *L, Unit_Class *self);
+    @ rule_name (lua_State *L, const Unit_Class *self);
   const char *api_methods_unit_class_name_translation
-    @ name_translation (lua_State *L, Unit_Class *self);
+    @ name_translation (lua_State *L, const Unit_Class *self);
 }
 
 /* Module Tech_Type. */


### PR DESCRIPTION
They're all read-only, and the most likely way for a Lua script to get a
 uclass (utype.unit_class) gives a const, so this change is needed to be
 able to actually look up unit class flags.