### PR TITLE
Remove explicit link_activated handlers

### DIFF
--- a/client/editor/tool_tile.cpp
+++ b/client/editor/tool_tile.cpp
@@ -49,16 +49,6 @@ editor_tool_tile::editor_tool_tile(QWidget *parent)
 
   connect(ui.tbut_select_tile, &QAbstractButton::clicked, this,
           &editor_tool_tile::select_tile);
-
-  // links to help for tile properties
-  connect(ui.value_terrain, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_owner, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_resource, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_road, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_infra, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_base, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_hut, &QLabel::linkActivated, follow_help_link);
-  connect(ui.value_nuisance, &QLabel::linkActivated, follow_help_link);
 }
 
 /**

--- a/client/editor/tool_tile.ui
+++ b/client/editor/tool_tile.ui
@@ -105,12 +105,18 @@
       <property name="text">
        <string>value_base</string>
       </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="4" column="1">
      <widget class="QLabel" name="value_owner">
       <property name="text">
        <string>value_owner</string>
+      </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
       </property>
      </widget>
     </item>
@@ -231,6 +237,9 @@
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="9" column="1">
@@ -252,6 +261,9 @@
       <property name="text">
        <string>value_hut</string>
       </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="2" column="1">
@@ -266,6 +278,9 @@
       <property name="text">
        <string>value_nuisance</string>
       </property>
+      <property name="openExternalLinks">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
     <item row="12" column="1">
@@ -274,6 +289,9 @@
        <string>value_infra</string>
       </property>
       <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="openExternalLinks">
        <bool>true</bool>
       </property>
      </widget>
@@ -304,6 +322,9 @@
        <enum>Qt::TextFormat::RichText</enum>
       </property>
       <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="openExternalLinks">
        <bool>true</bool>
       </property>
       <property name="textInteractionFlags">
@@ -344,6 +365,9 @@
        <enum>Qt::TextFormat::RichText</enum>
       </property>
       <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="openExternalLinks">
        <bool>true</bool>
       </property>
       <property name="textInteractionFlags">

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -148,7 +148,6 @@ void follow_help_link(const QString &link)
 {
   QStringList sl = link.split(QStringLiteral("/"));
   fc_assert_ret(sl.size() == 2);
-  int n = sl.at(0).toInt();
   enum help_page_type type =
       help_page_type_by_name(qUtf8Printable(sl.at(0)), fc_strcasecmp);
   QString st =

--- a/client/helpdlg.cpp
+++ b/client/helpdlg.cpp
@@ -789,7 +789,7 @@ void help_widget::add_extras_of_act_for_terrain(struct terrain *pterr,
                   .toHtmlEscaped()
             + "\n";
       tb->setText(str.trimmed());
-      connect(tb, &QLabel::linkActivated, &follow_help_link);
+      tb->setOpenExternalLinks(true);
       info_layout->addWidget(tb);
     }
   }
@@ -967,7 +967,7 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
       str = "<b>" + str + "</b> "
             + link_me(advance_name_translation(tech), HELP_TECH);
       tb->setText(str.trimmed());
-      connect(tb, &QLabel::linkActivated, &follow_help_link);
+      tb->setOpenExternalLinks(true);
       info_layout->addWidget(tb);
     } else {
       add_info_label(_("No technology required."));
@@ -986,7 +986,7 @@ void help_widget::set_topic_unit(const help_item *topic, const char *title)
               + link_me(advance_name_translation(tech), HELP_TECH) + ")";
         tb = set_properties(this);
         tb->setText(str.trimmed());
-        connect(tb, &QLabel::linkActivated, &follow_help_link);
+        tb->setOpenExternalLinks(true);
         info_layout->addWidget(tb);
       } else {
         add_info_label(
@@ -1069,7 +1069,7 @@ void help_widget::set_topic_building(const help_item *topic,
       str = "<b>" + str + "</b> " + s1;
       tb = set_properties(this);
       tb->setText(str.trimmed());
-      connect(tb, &QLabel::linkActivated, &follow_help_link);
+      tb->setOpenExternalLinks(true);
       info_layout->addWidget(tb);
     }
 
@@ -1088,7 +1088,7 @@ void help_widget::set_topic_building(const help_item *topic,
     if (!s2.isEmpty()) {
       tb = set_properties(this);
       tb->setText(str.trimmed());
-      connect(tb, &QLabel::linkActivated, &follow_help_link);
+      tb->setOpenExternalLinks(true);
       info_layout->addWidget(tb);
     }
     info_panel_done();
@@ -1127,7 +1127,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
                   + link_me(government_name_translation(&pgov),
                             HELP_GOVERNMENT);
             tb->setText(str.trimmed());
-            connect(tb, &QLabel::linkActivated, &follow_help_link);
+            tb->setOpenExternalLinks(true);
             info_layout->addWidget(tb);
           }
         }
@@ -1147,7 +1147,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
                                                       : HELP_IMPROVEMENT);
             tb = set_properties(this);
             tb->setText(str.trimmed());
-            connect(tb, &QLabel::linkActivated, &follow_help_link);
+            tb->setOpenExternalLinks(true);
             info_layout->addWidget(tb);
           }
         }
@@ -1164,7 +1164,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
                                                       : HELP_IMPROVEMENT);
             tb = set_properties(this);
             tb->setText(str.trimmed());
-            connect(tb, &QLabel::linkActivated, &follow_help_link);
+            tb->setOpenExternalLinks(true);
             info_layout->addWidget(tb);
           }
         }
@@ -1182,7 +1182,7 @@ void help_widget::set_topic_tech(const help_item *topic, const char *title)
               + link_me(utype_name_translation(punittype), HELP_UNIT);
         tb = set_properties(this);
         tb->setText(str.trimmed());
-        connect(tb, &QLabel::linkActivated, &follow_help_link);
+        tb->setOpenExternalLinks(true);
         info_layout->addWidget(tb);
       }
       unit_type_iterate_end;
@@ -1289,7 +1289,7 @@ void help_widget::make_terrain_lab(QString &str)
 {
   QLabel *tb = set_properties(this);
   tb->setText(str.trimmed());
-  connect(tb, &QLabel::linkActivated, &follow_help_link);
+  tb->setOpenExternalLinks(true);
   info_layout->addWidget(tb);
 }
 


### PR DESCRIPTION
Remove all instances of explicit `link_activated` handlers. This fixes the generated links in the help browser and the links in the editor.

Part of #2778 