### PR TITLE
IWYU: clang-tidy 20 utility

### DIFF
--- a/utility/bitvector.h
+++ b/utility/bitvector.h
@@ -10,6 +10,7 @@
 #include <QBitArray>
 
 // std
+#include <array>   // std::array
 #include <cstddef> // size_t
 
 // Yields TRUE iff the bit bit_no is set in val.


### PR DESCRIPTION
As we standardize on `clang-tidy` v20, need to pass though `utility` to ensure its clean.

Part of https://github.com/longturn/freeciv21/issues/2464