### PR TITLE
IWYU: clang-tidy 20 common

### DIFF
--- a/common/movement.h
+++ b/common/movement.h
@@ -8,6 +8,9 @@
 #include "map_types.h" // struct civ_map
 #include "tile.h"      // struct tile
 
+// Qt
+#include <QString>
+
 #define SINGLE_MOVE (terrain_control.move_fragments)
 #define MOVE_COST_IGTER (terrain_control.igter_cost)
 // packets.def MOVEFRAGS

--- a/common/networking/dataio.h
+++ b/common/networking/dataio.h
@@ -15,4 +15,4 @@
 /* This dataio.h header exist only as a interface to include.
  * Currently dataio_raw.h has all the functionality, including the
  * #include of the dataio_json.h at correct spot. */
-#include "dataio_raw.h"
+#include "dataio_raw.h" // IWYU pragma: keep

--- a/common/networking/protocol.h
+++ b/common/networking/protocol.h
@@ -11,6 +11,10 @@
 // common
 #include "packets.h"
 
+// Qt
+#include <QBitArray>
+#include <QtPreprocessorSupport> // Q_UNUSED
+
 // std
 #include <optional>
 #include <unordered_map>


### PR DESCRIPTION
As we standardize on clang-tidy v20, need to pass though `common` to ensure its clean.

Part of https://github.com/longturn/freeciv21/issues/2464